### PR TITLE
Adding support for AzureUSGovernment cloud and sovereign clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # kitchen-azurerm Changelog
 
+## [0.9.0] - 2017-04-28
+- Support for AzureUSGovernment, AzureChina and AzureGermanCloud environments
+- Add ```azure_environment``` driver_config parameter (@stuartpreston)
+
 ## [0.8.1] - 2017-02-28
 - Adding provider identifier tag to all created resources (@stuartpreston)
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,42 @@ suites:
     attributes:
 ```
 
+## Support for Government and Sovereign Clouds (China and Germany)
+
+Starting with v0.9.0 this driver has support for Azure Government and Sovereign Clouds via the use of the ```azure_environment``` setting.  Valid Azure environments are ```Azure```, ```AzureUSGovernment```, ```AzureChina``` and ```AzureGermanCloud```
+
+### Example .kitchen.yml for Azure US Government cloud
+
+```yaml
+---
+driver:
+  name: azurerm
+
+driver_config:
+  subscription_id: 'abcdabcd-YOUR-GUID-HERE-abcdabcdabcd'
+  azure_environment: 'AzureUSGovernment'
+  location: 'US Gov Iowa'
+  machine_size: 'Standard_D2_v2_Promo'
+
+provisioner:
+  name: chef_zero
+
+verifier:
+  name: inspec
+
+platforms:
+- name: ubuntu1604
+  driver_config:
+    image_urn: Canonical:UbuntuServer:16.04-LTS:latest
+  transport:
+    ssh_key: ~/.ssh/id_kitchen-azurerm
+
+suites:
+  - name: default
+    run_list:
+      - recipe[vmtesting::default]
+```
+
 ### How to retrieve the image_urn
 You can use the azure (azure-cli) command line tools to interrogate for the Urn. All 4 parts of the Urn must be specified, though the last part can be changed to "latest" to indicate you always wish to provision the latest operating system and patches.
 

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -4,12 +4,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'kitchen-azurerm'
-  spec.version       = '0.8.1'
+  spec.version       = '0.9.0'
   spec.authors       = ['Stuart Preston']
-  spec.email         = ['stuart@pendrica.com']
+  spec.email         = ['stuart@chef.io']
   spec.summary       = 'Test Kitchen driver for Azure Resource Manager.'
   spec.description   = 'Test Kitchen driver for the Microsoft Azure Resource Manager (ARM) API'
-  spec.homepage      = 'https://github.com/pendrica/kitchen-azurerm'
+  spec.homepage      = 'https://github.com/test-kitchen/kitchen-azurerm'
   spec.license       = 'Apache-2.0'
 
   spec.files         = Dir['LICENSE', 'README.md', 'CHANGELOG.md', 'lib/**/*', 'templates/**/*']

--- a/lib/kitchen/driver/credentials.rb
+++ b/lib/kitchen/driver/credentials.rb
@@ -26,12 +26,31 @@ module Kitchen
       #
       # @return [MsRest::TokenCredentials] TokenCredentials object to be passed in with each subsequent request.
       #
-      def azure_credentials_for_subscription(subscription_id)
+      def azure_credentials_for_subscription(subscription_id, azure_environment)
         tenant_id = ENV['AZURE_TENANT_ID'] || @credentials[subscription_id]['tenant_id']
         client_id = ENV['AZURE_CLIENT_ID'] || @credentials[subscription_id]['client_id']
         client_secret = ENV['AZURE_CLIENT_SECRET'] || @credentials[subscription_id]['client_secret']
-        token_provider = ::MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret)
+        token_provider = ::MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, settings_for_azure_environment(azure_environment))
         ::MsRest::TokenCredentials.new(token_provider)
+      end
+
+      #
+      # Retrieves a [MsRestAzure::ActiveDirectoryServiceSettings] object representing the settings for the given cloud.
+      # @param azure_environment [String] The Azure environment to retrieve settings for.
+      #
+      # @return [MsRestAzure::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
+      #
+      def settings_for_azure_environment(azure_environment)
+        case azure_environment.downcase
+        when 'azureusgovernment'
+          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_us_government_settings
+        when 'azurechina'
+          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_china_settings
+        when 'azuregermancloud'
+          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_germany_settings
+        when 'azure'
+          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_settings
+        end
       end
 
       def self.singleton

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -196,7 +196,7 @@
                     "osDisk": {
                         "name": "osdisk",
                         "vhd": {
-                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                            "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/',variables('OSDiskName'),'.vhd')]"
                         },
                         "caching": "ReadWrite",
                         "createOption": "FromImage"
@@ -212,7 +212,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": "[parameters('bootDiagnosticsEnabled')]",
-                        "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
+                        "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob]"
                     }
                 }
             },

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -215,7 +215,7 @@
                     "osDisk": {
                         "name": "osdisk",
                         "vhd": {
-                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                            "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/',variables('OSDiskName'),'.vhd')]"
                         },
                         "caching": "ReadWrite",
                         "createOption": "FromImage"
@@ -231,7 +231,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": "[parameters('bootDiagnosticsEnabled')]",
-                        "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
+                        "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob]"
                     }
                 }
             },


### PR DESCRIPTION
This PR adds support for the AzureUSGovernment, AzureChina and AzureGermanCloud environments to kitchen-azurerm.  To authenticate to the correct cloud environment, an endpoint needs to be selected according to the cloud. 

The changes are broadly centered on adding a single ```azure_environment``` parameter (defaulting to the current value: ```Azure```), and looking up the Management URL values for each cloud environment at runtime.

Signed-off-by: Stuart Preston <spreston@chef.io>