### PR TITLE
Amended readme.md example 2 to use a valid name in platforms sections…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: windows2012-r2
+  - name: win2012-r2
     driver_config:
       image_urn: MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:latest
     transport:


### PR DESCRIPTION
…. Currently it fails as 'windows' is copyrighted so resourcegroup will not be created