### PR TITLE
Fix Constant Names for ARM Configuration

### DIFF
--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'inifile', '~> 3.0', '>= 3.0.0'
-  spec.add_dependency 'azure_mgmt_resources', '~> 0.5', '>= 0.5.0'
-  spec.add_dependency 'azure_mgmt_network', '~> 0.5', '>= 0.5.0'
+  spec.add_dependency 'azure_mgmt_resources', '~> 0.5', '>= 0.11.0'
+  spec.add_dependency 'azure_mgmt_network', '~> 0.5', '>= 0.11.0'
   spec.add_dependency 'sshkey', '~> 1', '>= 1.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -458,11 +458,11 @@ logoff
         when 'azureusgovernment'
           MsRestAzure::AzureEnvironments::AzureUSGovernment.resource_manager_endpoint_url
         when 'azurechina'
-          MsRestAzure::AzureEnvironments::AzureChina.resource_manager_endpoint_url
+          MsRestAzure::AzureEnvironments::AzureChinaCloud.resource_manager_endpoint_url
         when 'azuregermancloud'
           MsRestAzure::AzureEnvironments::AzureGermanCloud.resource_manager_endpoint_url
         when 'azure'
-          MsRestAzure::AzureEnvironments::Azure.resource_manager_endpoint_url
+          MsRestAzure::AzureEnvironments::AzureCloud.resource_manager_endpoint_url
         end
       end
 


### PR DESCRIPTION
For the ARM API, there are different constant names - AzureCloud (ARM) vs Azure (ASM).

https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest_azure/lib/ms_rest_azure/azure_environment.rb#L87

Signed-off-by: Steven Murawski <steven.murawski@gmail.com>