### PR TITLE
Raise when subscription_id is not available

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -148,6 +148,10 @@ module Kitchen
           vmName: state[:vm_name]
         }
 
+        if config[:subscription_id].to_s == ''
+          raise 'A subscription_id config value was not detected and kitchen-azurerm cannot continue. Please check your .kitchen.yml configuration. Exiting.'
+        end
+
         if config[:custom_data].to_s != ''
           deployment_parameters['customData'] = prepared_custom_data
         end


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

This will cause kitchen-azurerm to fail the current session with a user-friendly message if an Azure subscription_id cannot be detected.

Fixes #47 