### PR TITLE
Add destroy_resource_group_contents configuration option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,3 @@ Naming/HeredocDelimiterNaming:
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
-
-Layout/ClosingHeredocIndentation:
-  Enabled: false

--- a/README.md
+++ b/README.md
@@ -474,6 +474,14 @@ info:    vm image list command OK
 - The ```os_disk_size_gb``` parameter can be used to specify a custom os disk size.
 - The ```azure_resource_group_prefix``` and ```azure_resource_group_suffix``` can be used to further disambiguate Azure resource group names created by the driver.
 - The ```explicit_resource_group_name``` and ```destroy_explicit_resource_group``` (default: "true") parameters can be used in scenarios where you are provided a pre-created Resource Group.  Example usage: ```explicit_resource_group_name: kitchen-<%= ENV["USERNAME"] %>```
+- The ```destroy_resource_group_contents``` (default: "false") parameter can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase.
+```
+---
+driver:
+  explicit_resource_group_name: stuart-rg-demo-001
+  destroy_explicit_resource_group: false
+  destroy_resource_group_contents: true
+```
 
 ## Contributing
 

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 11.0'
-  spec.add_development_dependency 'rubocop', '~> 0.57.2'
+  spec.add_development_dependency 'rubocop', '~> 0.58', '>= 0.58.1'
 end

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -464,7 +464,8 @@ module Kitchen
       end
 
       def enable_winrm_powershell_script
-        config[:winrm_powershell_script] || <<-PS1
+        config[:winrm_powershell_script] ||
+          <<-PS1
   $cert = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME -CertStoreLocation Cert:\\LocalMachine\\My
   $config = '@{CertificateThumbprint="' + $cert.Thumbprint + '"}'
   winrm create winrm/config/listener?Address=*+Transport=HTTPS $config
@@ -472,13 +473,14 @@ module Kitchen
   New-NetFirewallRule -DisplayName "Windows Remote Management (HTTPS-In)" -Name "Windows Remote Management (HTTPS-In)" -Profile Any -LocalPort 5986 -Protocol TCP
   winrm set winrm/config/service '@{AllowUnencrypted="true"}'
   New-NetFirewallRule -DisplayName "Windows Remote Management (HTTP-In)" -Name "Windows Remote Management (HTTP-In)" -Profile Any -LocalPort 5985 -Protocol TCP
-        PS1
+          PS1
       end
 
       def format_data_disks_powershell_script
         return unless config[:format_data_disks]
         info 'Data disks will be initialized and formatted NTFS automatically.' unless config[:data_disks].nil?
-        config[:format_data_disks_powershell_script] || <<-PS1
+        config[:format_data_disks_powershell_script] ||
+          <<-PS1
   Write-Host "Initializing and formatting raw disks"
   $disks = Get-Disk | where partitionstyle -eq 'raw'
   $letters = New-Object System.Collections.ArrayList
@@ -501,7 +503,7 @@ module Kitchen
     Start-Sleep 1
     Format-Volume -FileSystem NTFS -NewFileSystemLabel "datadisk" -DriveLetter $driveLetter -Confirm:$false
   }
-        PS1
+          PS1
       end
 
       def custom_data_script_windows

--- a/templates/empty.erb
+++ b/templates/empty.erb
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "variables": {},
+    "resources": []
+}


### PR DESCRIPTION
This adds the `destroy_resource_group_contents` configuration option which allows a user to remove the resources created in a specific resource within the `kitchen destroy` phase.

Fixes #90 