### PR TITLE
Feature/post deployment template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # kitchen-azurerm Changelog
 
+## [0.14.4] - 2018-08-10
+- Adding capability to execute ARM template after VM deployment, ```post_deployment_template``` and ```post_deployment_parameters``` added (@sebastiankasprzak)
+
 ## [0.14.3] - 2018-07-16
 - Add `destroy_resource_group_contents` (default: false) property to allow contents of Azure Resource Group to be deleted rather than entire Resource Group, fixes [#90](https://github.com/test-kitchen/kitchen-azurerm/issues/85)
 

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -2,7 +2,7 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name          = 'kitchen-azurerm'
-  spec.version       = '0.14.3'
+  spec.version       = '0.14.4'
   spec.authors       = ['Stuart Preston']
   spec.email         = ['stuart@chef.io']
   spec.summary       = 'Test Kitchen driver for Azure Resource Manager.'


### PR DESCRIPTION
Implements #93 

This change adds `post_deployment_template` option to the driver. This is useful when additional actions need to be taken post the deployment of the test system. An example use case is to enable MSU authentication on the VM, as this eliminates the need to hardcode SPN credentials in configuration files, but needs to happen post VM creation.

Example Usage:
```yaml
---
driver:
  name: azurerm
  vm_name: chef-cookbook-test
  subscription_id: '4801fa9d-YOUR-GUID-HERE-b265ff49ce21'
  location: 'West Europe'
  machine_size: 'Standard_D1'
  post_deployment_template: postdeploy.json
  post_deployment_parameters: 
    vmName: 'chef-cookbook-test'
    location: 'northeurope'
    msiExtensionName: 'ManagedIdentityExtensionForLinux'

transport:
  ssh_key: ~/.ssh/id_kitchen-azurerm

provisioner:
  name: chef_zero

platforms:
  - name: ubuntu-1404
    driver:
      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest

suites:
  - name: default
    run_list:
      - recipe[kitchen-azurerm-demo::default]
    attributes:
```

Example postdeploy.json to enable MSI extention on VM:

```json
{
    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
    "contentVersion": "1.0.0.0",
    "parameters": {
        "vmName": {
            "type": "String"
        },
        "location": {
            "type": "String"
        },
        "msiExtensionName": {
            "type": "String"
        }
    },
    "resources": [
        {
            "type": "Microsoft.Compute/virtualMachines",
            "name": "[parameters('vmName')]",
            "apiVersion": "2017-12-01",
            "location": "[parameters('location')]",
            "identity": {
                "type": "systemAssigned"
            }
        },
        {
            "type": "Microsoft.Compute/virtualMachines/extensions",
            "name": "[concat( parameters('vmName'), '/' , parameters('msiExtensionName') )]",
            "apiVersion": "2017-12-01",
            "location": "[parameters('location')]",
            "properties": {
                "publisher": "Microsoft.ManagedIdentity",
                "type": "[parameters('msiExtensionName')]",
                "typeHandlerVersion": "1.0",
                "autoUpgradeMinorVersion": true,
                "settings": {
                    "port": 50342
                }
            },
            "dependsOn": [
                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
            ]
        }
    ]
}
```

Console output:

```
$ kitchen converge msi-auth-ubuntu-1804
-----> Starting Kitchen (v1.19.2)
-----> Creating <msi-auth-ubuntu-1804>...
       Creating Resource Group: kitchen-msi-auth-ubuntu-1804-20180810T135751
       Creating deployment: deploy-f75922063635dc10
       Using custom vnet: /subscriptions/4801fa9d-YOUR-GUID-HERE-b265ff49ce21/resourceGroups/seb_test/providers/Microsoft.Network/virtualNetworks/seb_shared
       Adding public key from ~/.ssh/id_kitchen-azurerm.pub to the deployment.
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Template deployment reached end state of 'Succeeded'.
       Creating deployment: post-deploy-f75922063635dc10
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines 'chef-cookbook-test' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines/extensions 'chef-cookbook-test/ManagedIdentityExtensionForLinux' provisioning status is Running
       Resource Microsoft.Compute/virtualMachines/extensions 'chef-cookbook-test/ManagedIdentityExtensionForLinux' provisioning status is Running
       Resource Template deployment reached end state of 'Succeeded'.
       IP Address is: 40.xxx.xxx.xxx [kitchen-f759xxxxxxxxdc10.northeurope.cloudapp.azure.com]
       Finished creating <msi-auth-ubuntu-1804> (3m53.57s).
-----> Converging <msi-auth-ubuntu-1804>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 6.3.1...
[...]
```