### PR TITLE
Update virtualMachines API version

### DIFF
--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -245,7 +245,7 @@
             }
         },
         {
-            "apiVersion": "2017-03-30",
+            "apiVersion": "2018-04-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('vmName')]",
             "location": "[variables('location')]",

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -263,7 +263,7 @@
             }
         },
         {
-            "apiVersion": "2017-03-30",
+            "apiVersion": "2018-04-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('vmName')]",
             "location": "[variables('location')]",


### PR DESCRIPTION
This change simply updates the `apiVersion` parameter for the `virtualMachines` resource in both ARM templates. This will allow users to specify an `imageId` which references an image from a Shared Image Gallery in  Azure, a feature which is currently in private preview and which makes creating and distributing images much simpler.