### PR TITLE
MSI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,42 @@ Example postdeploy.json to enable MSI extention on VM:
 }
 ```
 
+### .kitchen.yml example 10 - Enabling Managed Service Identities
+
+This example demonstrates how to enable a System Assigned Identity and User Assigned Identities on a Kitchen VM.
+Any combination of System and User assigned identities may be enabled, and multiple User Assigned Identities can be supplied.
+
+See the [Managed identities for Azure resources](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) documentation for more information on using Managed Service Identities.
+
+```yaml
+---
+driver:
+  name: azurerm
+  subscription_id: '4801fa9d-YOUR-GUID-HERE-b265ff49ce21'
+  location: 'West Europe'
+  machine_size: 'Standard_D1'
+
+transport:
+  ssh_key: ~/.ssh/id_kitchen-azurerm
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-1404
+    driver:
+      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      system_assigned_identity: true
+      user_assigned_identities:
+        - /subscriptions/4801fa9d-YOUR-GUID-HERE-b265ff49ce21/resourcegroups/test-kitchen-user/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-kitchen-user
+
+suites:
+  - name: default
+    run_list:
+      - recipe[kitchentesting::default]
+    attributes:
+```
+
 
 ## Support for Government and Sovereign Clouds (China and Germany)
 

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -146,6 +146,14 @@ module Kitchen
         false
       end
 
+      default_config(:system_assigned_identity) do |_config|
+        false
+      end
+
+      default_config(:user_assigned_identities) do |_config|
+        []
+      end
+
       default_config(:destroy_explicit_resource_group) do |_config|
         true
       end
@@ -166,6 +174,8 @@ module Kitchen
           adminPassword: state[:password] || "P2ssw0rd",
           dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
           vmName: state[:vm_name],
+          systemAssignedIdentity: config[:system_assigned_identity],
+          userAssignedIdentities: config[:user_assigned_identities],
         }
 
         if config[:subscription_id].to_s == ""

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -143,6 +143,20 @@
                 "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
             }
         },
+        "systemAssignedIdentity": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Whether to enable system assigned identity for the vm."
+            }
+        },
+        "userAssignedIdentities": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "A list of resource IDs for user identities to associate with the Virtual Machine, or empty to disable user assigned identities."
+            }
+        },
         "bootDiagnosticsEnabled": {
             "type": "string",
             "defaultValue": "true",
@@ -164,6 +178,7 @@
         "vmStorageAccountContainerName": "vhds",
         "vmName": "[parameters('vmName')]",
         "vmSize": "[parameters('vmSize')]",
+        "vmIdentityType": "[if(parameters('systemAssignedIdentity'), if(empty(parameters('userAssignedIdentities')), 'SystemAssigned', 'SystemAssigned, UserAssigned'), if(empty(parameters('userAssignedIdentities')), 'None', 'UserAssigned'))]",
         "virtualNetworkName": "vnet",
         "vnetID": "<%= vnet_id %>",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"     
@@ -341,6 +356,10 @@
                     }
                     <%- end -%>
                 }
+            },
+            "identity": {
+                "type": "[variables('vmIdentityType')]",
+                "identityIds": "[if(empty(parameters('userAssignedIdentities')), json('null'), parameters('userAssignedIdentities'))]"
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -143,6 +143,20 @@
                 "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
             }
         },
+        "systemAssignedIdentity": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Whether to enable system assigned identity for the vm."
+            }
+        },
+        "userAssignedIdentities": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "A list of resource IDs for user identities to associate with the Virtual Machine, or empty to disable user assigned identities."
+            }
+        },
         "bootDiagnosticsEnabled": {
             "type": "string",
             "defaultValue": "true",
@@ -164,6 +178,7 @@
         "vmStorageAccountContainerName": "vhds",
         "vmName": "[parameters('vmName')]",
         "vmSize": "[parameters('vmSize')]",
+        "vmIdentityType": "[if(parameters('systemAssignedIdentity'), if(empty(parameters('userAssignedIdentities')), 'SystemAssigned', 'SystemAssigned, UserAssigned'), if(empty(parameters('userAssignedIdentities')), 'None', 'UserAssigned'))]",
         "virtualNetworkName": "vnet",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
@@ -359,6 +374,10 @@
                     }
                     <%- end -%>
                 }
+            },
+            "identity": {
+                "type": "[variables('vmIdentityType')]",
+                "identityIds": "[if(empty(parameters('userAssignedIdentities')), json('null'), parameters('userAssignedIdentities'))]"
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>


### PR DESCRIPTION
This pull request adds `system_assigned_identity` and `user_assigned_identities` config parameters, to make it easy to enable Managed Service Identities on Test Kitchen VMs in Azure.