### PR TITLE
Unpin the bundler dev dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: ruby
-sudo: false
-rvm:
- - 2.4.5
- - 2.5.3
+cache: bundler
+dist: xenial
+
+branches:
+  only:
+  - master
+
+matrix:
+  include:
+    - rvm: 2.4.5
+    - rvm: 2.5.3
+    - rvm: 2.6.0
+  allow_failures:
+  - rvm: ruby-head

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "inifile", "~> 3.0", ">= 3.0.0"
   spec.add_dependency "sshkey", "~> 1", ">= 1.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 11.0"
   spec.add_development_dependency "chefstyle"
 end


### PR DESCRIPTION
This allows installing this gem in placeas that only have bundler 2.x

Signed-off-by: Tim Smith <tsmith@chef.io>