### PR TITLE
Add ssh_public_key for separate public key location.

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -357,7 +357,11 @@ module Kitchen
 
           output = k.ssh_public_key
         else
-          output = File.read("#{private_key_filename}.pub")
+          output = if instance.transport[:ssh_public_key].nil?
+                     File.read("#{private_key_filename}.pub")
+                   else
+                     File.read(instance.transport[:ssh_public_key])
+                   end
         end
         output.strip
       end


### PR DESCRIPTION
- The default assumption of the public key being in the same location
  might not work for situations where the Jenkins or other CI's are
  concerned.
- Unlike AWS in the case of Azure the public key is not stored
  in the Cloud Provider and needs to be given upon instance creation.

Signed-off-by: Harold Dost <h.dost@criteo.com>