### PR TITLE
Allow nic name to be passed in as a parameter

### DIFF
--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -2,7 +2,7 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name          = "kitchen-azurerm"
-  spec.version       = "0.14.8"
+  spec.version       = "0.14.9"
   spec.authors       = ["Stuart Preston"]
   spec.email         = ["stuart@chef.io"]
   spec.summary       = "Test Kitchen driver for Azure Resource Manager."

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -74,6 +74,10 @@ module Kitchen
         "vm"
       end
 
+      default_config(:nic_name) do |_config|
+        ""
+      end
+
       default_config(:vnet_id) do |_config|
         ""
       end
@@ -182,6 +186,13 @@ module Kitchen
           raise "A subscription_id config value was not detected and kitchen-azurerm cannot continue. Please check your .kitchen.yml configuration. Exiting."
         end
 
+        if config[:nic_name].to_s == ''
+          vmnic = "nic-#{config[:vm_name]}"
+        else
+          vmnic = config[:nic_name]
+        end
+        deployment_parameters['nicName'] = vmnic.to_s
+
         if config[:custom_data].to_s != ""
           deployment_parameters["customData"] = prepared_custom_data
         end
@@ -274,7 +285,7 @@ module Kitchen
         else
           # Retrieve the internal IP from the resource group:
           network_interfaces = ::Azure::Network::Profiles::Latest::Mgmt::NetworkInterfaces.new(network_management_client)
-          result = network_interfaces.get(state[:azure_resource_group_name], "nic")
+          result = network_interfaces.get(state[:azure_resource_group_name], vmnic.to_s)
           info "IP Address is: #{result.ip_configurations[0].private_ipaddress}"
           state[:hostname] = result.ip_configurations[0].private_ipaddress
         end

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -186,12 +186,12 @@ module Kitchen
           raise "A subscription_id config value was not detected and kitchen-azurerm cannot continue. Please check your .kitchen.yml configuration. Exiting."
         end
 
-        if config[:nic_name].to_s == ''
+        if config[:nic_name].to_s == ""
           vmnic = "nic-#{config[:vm_name]}"
         else
           vmnic = config[:nic_name]
         end
-        deployment_parameters['nicName'] = vmnic.to_s
+        deployment_parameters["nicName"] = vmnic.to_s
 
         if config[:custom_data].to_s != ""
           deployment_parameters["customData"] = prepared_custom_data
@@ -309,11 +309,13 @@ module Kitchen
       def azure_resource_group_name
         formatted_time = Time.now.utc.strftime "%Y%m%dT%H%M%S"
         return "#{config[:azure_resource_group_prefix]}#{config[:azure_resource_group_name]}-#{formatted_time}#{config[:azure_resource_group_suffix]}" unless config[:explicit_resource_group_name]
+
         config[:explicit_resource_group_name]
       end
 
       def data_disks_for_vm_json
         return nil if config[:data_disks].nil?
+
         disks = []
 
         if config[:use_managed_disks]
@@ -484,6 +486,7 @@ module Kitchen
 
       def destroy(state)
         return if state[:server_id].nil?
+
         options = Kitchen::Driver::Credentials.new.azure_options_for_subscription(state[:subscription_id], state[:azure_environment])
         @resource_management_client = ::Azure::Resources::Profiles::Latest::Mgmt::Client.new(options)
         if config[:destroy_resource_group_contents] == true
@@ -533,6 +536,7 @@ module Kitchen
 
       def format_data_disks_powershell_script
         return unless config[:format_data_disks]
+
         info "Data disks will be initialized and formatted NTFS automatically." unless config[:data_disks].nil?
         config[:format_data_disks_powershell_script] ||
           <<-PS1
@@ -599,7 +603,7 @@ module Kitchen
               componentName: "Microsoft-Windows-Shell-Setup",
               settingName: "AutoLogon",
               content: "[concat('<AutoLogon><Password><Value>', parameters('adminPassword'), '</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount><Username>', parameters('adminUserName'), '</Username></AutoLogon>')]",
-            }
+            },
           ],
         }
       end
@@ -635,6 +639,7 @@ module Kitchen
       def prepared_custom_data
         # If user_data is a file reference, lets read it as such
         return nil if config[:custom_data].nil?
+
         @custom_data ||= begin
           if File.file?(config[:custom_data])
             Base64.strict_encode64(File.read(config[:custom_data]))

--- a/lib/kitchen/driver/credentials.rb
+++ b/lib/kitchen/driver/credentials.rb
@@ -6,7 +6,7 @@ module Kitchen
     # Credentials
     #
     class Credentials
-      CONFIG_PATH = "#{ENV[\"HOME\"]}/.azure/credentials".freeze
+      CONFIG_PATH = "#{ENV['HOME']}/.azure/credentials".freeze
 
       #
       # Creates and initializes a new instance of the Credentials class.

--- a/lib/kitchen/driver/credentials.rb
+++ b/lib/kitchen/driver/credentials.rb
@@ -6,7 +6,7 @@ module Kitchen
     # Credentials
     #
     class Credentials
-      CONFIG_PATH = "#{ENV['HOME']}/.azure/credentials".freeze
+      CONFIG_PATH = "#{ENV["HOME"]}/.azure/credentials".freeze
 
       #
       # Creates and initializes a new instance of the Credentials class.

--- a/lib/kitchen/driver/credentials.rb
+++ b/lib/kitchen/driver/credentials.rb
@@ -6,7 +6,7 @@ module Kitchen
     # Credentials
     #
     class Credentials
-      CONFIG_PATH = "#{ENV['HOME']}/.azure/credentials".freeze
+      CONFIG_PATH = "#{ENV[\"HOME\"]}/.azure/credentials".freeze
 
       #
       # Creates and initializes a new instance of the Credentials class.

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -136,6 +136,13 @@
                 "description": "The vm name created inside of the resource group."
             }
         },
+        "nicName": {
+            "type": "string",
+            "defaultValue": "nic",
+            "metadata": {
+                "description": "The nic name created inside of the resource group."
+            }
+        },
         "storageAccountType": {
             "type": "string",
             "defaultValue": "Standard_LRS",
@@ -168,7 +175,7 @@
     "variables": {
         "location": "[parameters('location')]",
         "OSDiskName": "osdisk",
-        "nicName": "nic",
+        "nicName": "[parameters('nicName')]",
         "addressPrefix": "10.0.0.0/16",
         "subnetName": "<%= subnet_id %>",
         "subnetPrefix": "10.0.0.0/24",
@@ -181,12 +188,12 @@
         "vmIdentityType": "[if(parameters('systemAssignedIdentity'), if(empty(parameters('userAssignedIdentities')), 'SystemAssigned', 'SystemAssigned, UserAssigned'), if(empty(parameters('userAssignedIdentities')), 'None', 'UserAssigned'))]",
         "virtualNetworkName": "vnet",
         "vnetID": "<%= vnet_id %>",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"     
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
     },
     "resources": [
         {
             "apiVersion": "2017-05-10",
-            "name": "pid-18d63047-6cdf-4f34-beed-62f01fc73fc2", 
+            "name": "pid-18d63047-6cdf-4f34-beed-62f01fc73fc2",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -267,7 +274,7 @@
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('vmName')]",
             "location": "[variables('location')]",
-            "dependsOn": [ 
+            "dependsOn": [
                 <%- unless use_managed_disks -%>
                 <%- if existing_storage_account_blob_url.empty? -%>
                 "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
@@ -302,7 +309,7 @@
                     <%- end -%>
                     <%- if use_managed_disks -%>
                     "osDisk": {
-                        "name": "osdisk",
+                        "name": "[concat('disk-', parameters('vmName'))]",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
                         "diskSizeGB": "[parameters('osDiskSizeGB')]",
                         <%- end -%>
@@ -310,7 +317,7 @@
                     }
                     <%- else -%>
                     "osDisk": {
-                        "name": "osdisk",
+                        "name": "[concat('disk-', parameters('vmName'))]",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
                         "diskSizeGB": "[parameters('osDiskSizeGB')]",
                         <%- end -%>
@@ -336,7 +343,7 @@
                     }
                     <%- end -%>
                     <%- unless data_disks_for_vm_json.nil? -%>
-                      ,"dataDisks": 
+                      ,"dataDisks":
                           <%= data_disks_for_vm_json %>
                     <%- end -%>
                 },


### PR DESCRIPTION
- Updated azurerm.rb to include passing in a parameter for the name of the nic
and also using that name or generating a nic name based on the vm name
- Updated internal.erb to include nic name updates and also disk names that
are unique based on vm name

### Description

In our environment we have to use a predefined resource group with a specific subscription, and are not able to create a new resource group for each VM provisioned. As a result we can only create on VM at a time since the name "nic" is hardcoded and in use once a VM is provisioned. 
This pull request is to allow for the nic name to be passed in as a parameter, or at least be unique based on the name of the VM if it is passed in. Testing in our site has dramatically improved our ability to have multiple nodes running at the same time.
I haven't cracked the nut of a destroy only destroying what it creates, but this is a big improvement


### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
