### PR TITLE
Enable WinRM HTTP listener by default

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -554,6 +554,7 @@ module Kitchen
   $cert = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME -CertStoreLocation Cert:\\LocalMachine\\My
   $config = '@{CertificateThumbprint="' + $cert.Thumbprint + '"}'
   winrm create winrm/config/listener?Address=*+Transport=HTTPS $config
+  winrm create winrm/config/Listener?Address=*+Transport=HTTP
   winrm set winrm/config/service/auth '@{Basic="true";Kerberos="false";Negotiate="true";Certificate="false";CredSSP="true"}'
   New-NetFirewallRule -DisplayName "Windows Remote Management (HTTPS-In)" -Name "Windows Remote Management (HTTPS-In)" -Profile Any -LocalPort 5986 -Protocol TCP
   winrm set winrm/config/service '@{AllowUnencrypted="true"}'


### PR DESCRIPTION
### Description

Enables HTTP listener in the default WinRM configuration script. This allows the default Test Kitchen WinRM configuration, which uses negotiate over HTTP, to connect successfully without having to manually override the script.

This is a very simple implementation that always enables HTTP. I've never worked with Test Kitchen drivers before so if additional customization is desired, I may need guidance on how to check the Test Kitchen WinRM settings and conditionally update this script.

### Issues Resolved

#119

### Check List

- [ ] New functionality includes tests (I don't see any existing tests setup)
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
