### PR TITLE
Default password is now generated rather than hard-coded (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ info:    vm image list command OK
 
 ### Additional parameters that can be specified
 
-* Note that the ```driver``` section also takes a ```username``` and ```password``` parameter, the defaults if these are not specified are "azure" and "P2ssw0rd" respectively.
+* Note that the ```driver``` section can also takes a ```username``` and ```password```. The default username is "azure" and the password is a randomly generated 12 character password that can be found in your local kitchen state file (typically .kitchen/<instance-name>.yml) if you require it for any reason.
 
 * The ```storage_account_type``` parameter defaults to 'Standard_LRS' and allows you to switch to premium storage (e.g. 'Premium_LRS')
 

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -71,7 +71,7 @@ module Kitchen
       end
 
       default_config(:password) do |_config|
-        "P2ssw0rd"
+        SecureRandom.base64(12)
       end
 
       default_config(:vm_name) do |_config|
@@ -199,7 +199,7 @@ module Kitchen
           bootDiagnosticsEnabled: config[:boot_diagnostics_enabled],
           newStorageAccountName: "storage#{state[:uuid]}",
           adminUsername: state[:username],
-          adminPassword: state[:password] || "P2ssw0rd",
+          adminPassword: state[:password],
           dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
           vmName: state[:vm_name],
           systemAssignedIdentity: config[:system_assigned_identity],


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This change switches out the default behavior of the driver such that the password is not well-known. Users are still able to override the password with one of their own using the `password` driver setting.

The password may contain A-Z, a-z, 0-9, "+", "/" and "=" which should meet the criteria for an Azure VM specified in https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq 

### Issues Resolved

Fixes #122 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
