### PR TITLE
Only add password to deployment template if ssh_key is not set

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -205,7 +205,6 @@ module Kitchen
           bootDiagnosticsEnabled: config[:boot_diagnostics_enabled],
           newStorageAccountName: "storage#{state[:uuid]}",
           adminUsername: state[:username],
-          adminPassword: state[:password],
           dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
           vmName: state[:vm_name],
           systemAssignedIdentity: config[:system_assigned_identity],
@@ -214,6 +213,10 @@ module Kitchen
           vaultName: config[:vault_name],
           vaultResourceGroup: config[:vault_resource_group],
         }
+
+        if instance.transport[:ssh_key].nil?
+          deployment_parameters["adminPassword"] = state[:password]
+        end
 
         if config[:subscription_id].to_s == ""
           raise "A subscription_id config value was not detected and kitchen-azurerm cannot continue. Please check your .kitchen.yml configuration. Exiting."
@@ -638,10 +641,10 @@ module Kitchen
 
       def virtual_machine_deployment_template
         if config[:vnet_id] == ""
-          virtual_machine_deployment_template_file("public.erb", vm_tags: vm_tag_string(config[:vm_tags]), use_managed_disks: config[:use_managed_disks], image_url: config[:image_url], existing_storage_account_blob_url: config[:existing_storage_account_blob_url], image_id: config[:image_id], existing_storage_account_container: config[:existing_storage_account_container], custom_data: config[:custom_data], os_disk_size_gb: config[:os_disk_size_gb], data_disks_for_vm_json: data_disks_for_vm_json, use_ephemeral_osdisk: config[:use_ephemeral_osdisk])
+          virtual_machine_deployment_template_file("public.erb", vm_tags: vm_tag_string(config[:vm_tags]), use_managed_disks: config[:use_managed_disks], image_url: config[:image_url], existing_storage_account_blob_url: config[:existing_storage_account_blob_url], image_id: config[:image_id], existing_storage_account_container: config[:existing_storage_account_container], custom_data: config[:custom_data], os_disk_size_gb: config[:os_disk_size_gb], data_disks_for_vm_json: data_disks_for_vm_json, use_ephemeral_osdisk: config[:use_ephemeral_osdisk], ssh_key: instance.transport[:ssh_key])
         else
           info "Using custom vnet: #{config[:vnet_id]}"
-          virtual_machine_deployment_template_file("internal.erb", vnet_id: config[:vnet_id], subnet_id: config[:subnet_id], public_ip: config[:public_ip], vm_tags: vm_tag_string(config[:vm_tags]), use_managed_disks: config[:use_managed_disks], image_url: config[:image_url], existing_storage_account_blob_url: config[:existing_storage_account_blob_url], image_id: config[:image_id], existing_storage_account_container: config[:existing_storage_account_container], custom_data: config[:custom_data], os_disk_size_gb: config[:os_disk_size_gb], data_disks_for_vm_json: data_disks_for_vm_json, use_ephemeral_osdisk: config[:use_ephemeral_osdisk])
+          virtual_machine_deployment_template_file("internal.erb", vnet_id: config[:vnet_id], subnet_id: config[:subnet_id], public_ip: config[:public_ip], vm_tags: vm_tag_string(config[:vm_tags]), use_managed_disks: config[:use_managed_disks], image_url: config[:image_url], existing_storage_account_blob_url: config[:existing_storage_account_blob_url], image_id: config[:image_id], existing_storage_account_container: config[:existing_storage_account_container], custom_data: config[:custom_data], os_disk_size_gb: config[:os_disk_size_gb], data_disks_for_vm_json: data_disks_for_vm_json, use_ephemeral_osdisk: config[:use_ephemeral_osdisk], ssh_key: instance.transport[:ssh_key])
         end
       end
 

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -26,12 +26,14 @@
                 "description": "User name for the Virtual Machine."
             }
         },
+        <%- if ssh_key.nil? -%>
         "adminPassword": {
             "type": "securestring",
             "metadata": {
                 "description": "Password for the Virtual Machine."
             }
         },
+        <%- end -%>
         "dnsNameForPublicIP": {
             "type": "string",
             "metadata": {
@@ -322,8 +324,10 @@
                         ]
                     ],
                     <%- end -%>
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
+                    <%- if ssh_key.nil? -%>
+                    "adminPassword": "[parameters('adminPassword')]",
+                    <%- end -%>
+                    "adminUsername": "[parameters('adminUsername')]"
                 },
                 "storageProfile": {
                     <%- if image_url.empty? and image_id.empty? -%>

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -26,12 +26,14 @@
                 "description": "User name for the Virtual Machine."
             }
         },
+        <%- if ssh_key.nil? -%>
         "adminPassword": {
             "type": "securestring",
             "metadata": {
                 "description": "Password for the Virtual Machine."
             }
         },
+        <%- end -%>
         "dnsNameForPublicIP": {
             "type": "string",
             "metadata": {
@@ -341,8 +343,10 @@
                         ]
                     ],
                     <%- end -%>
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
+                    <%- if ssh_key.nil? -%>
+                    "adminPassword": "[parameters('adminPassword')]",
+                    <%- end -%>
+                    "adminUsername": "[parameters('adminUsername')]"
                 },
                 "storageProfile": {
                     <%- if image_url.empty? and image_id.empty? -%>


### PR DESCRIPTION
### Description

When `instance.transport[:ssh_key]` is set, do not add an empty `adminPassword` field to the deployment template to avoid Azure complaining about a null value.

I initially thought about using a dummy password (just to be sure that the `adminPassword` is not empty), but finally decided it would be cleaner to simply remove the field from the deployment template if it does not need to exist.

Tested on the [datadog-agent](https://github.com/DataDog/datadog-agent) kitchen tests, and worked for both Windows (w/o `ssh_key` set) and Linux (Debian, Ubuntu, CentOS and SLES w/ `ssh_key` set).

### Issues Resolved

Fixes regression introduced by #124 (details on this comment: https://github.com/test-kitchen/kitchen-azurerm/pull/124#issuecomment-576471233).

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
