### PR TITLE
Refactor Kitchen::Driver::Credentials class

### DIFF
--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -49,10 +49,6 @@ module Kitchen
         options
       end
 
-      def self.singleton
-        @credentials ||= Credentials.new
-      end
-
       private
 
       def tenant_id

--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -3,9 +3,9 @@ require "inifile"
 module Kitchen
   module Driver
     #
-    # Credentials
+    # AzureCredentials
     #
-    class Credentials
+    class AzureCredentials
       CONFIG_PATH = "#{ENV["HOME"]}/.azure/credentials".freeze
 
       #
@@ -16,14 +16,14 @@ module Kitchen
       #
       # @return [String]
       #
-      attr_reader :azure_environment
+      attr_reader :environment
 
       #
       # Creates and initializes a new instance of the Credentials class.
       #
-      def initialize(subscription_id:, azure_environment: "Azure")
+      def initialize(subscription_id:, environment: "Azure")
         @subscription_id = subscription_id
-        @azure_environment = azure_environment
+        @environment = environment
         config_file = ENV["AZURE_CONFIG_FILE"] || File.expand_path(CONFIG_PATH)
         if File.file?(config_file)
           @credentials = IniFile.load(File.expand_path(config_file))
@@ -77,7 +77,7 @@ module Kitchen
       # @return [MsRestAzure::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
       #
       def ad_settings
-        case azure_environment.downcase
+        case environment.downcase
         when "azureusgovernment"
           ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_us_government_settings
         when "azurechina"
@@ -95,7 +95,7 @@ module Kitchen
       # @return [MsRestAzure::AzureEnvironment] Settings to be used for subsequent requests
       #
       def endpoint_settings
-        case azure_environment.downcase
+        case environment.downcase
         when "azureusgovernment"
           ::MsRestAzure::AzureEnvironments::AzureUSGovernment
         when "azurechina"

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -264,7 +264,8 @@ module Kitchen
           deployment_parameters["imageVersion"] = image_version
         end
 
-        options = Kitchen::Driver::Credentials.new.azure_options_for_subscription(config[:subscription_id], config[:azure_environment])
+        options = Kitchen::Driver::Credentials.new(subscription_id: config[:subscription_id],
+                                                   azure_environment: config[:azure_environment]).azure_options
 
         debug "Azure environment: #{config[:azure_environment]}"
         @resource_management_client = ::Azure::Resources::Profiles::Latest::Mgmt::Client.new(options)
@@ -517,7 +518,8 @@ module Kitchen
       def destroy(state)
         return if state[:server_id].nil?
 
-        options = Kitchen::Driver::Credentials.new.azure_options_for_subscription(state[:subscription_id], state[:azure_environment])
+        options = Kitchen::Driver::Credentials.new(subscription_id: state[:subscription_id],
+                                                   azure_environment: state[:azure_environment]).azure_options
         @resource_management_client = ::Azure::Resources::Profiles::Latest::Mgmt::Client.new(options)
         if config[:destroy_resource_group_contents] == true
           info "Destroying individual resources within the Resource Group."

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -264,8 +264,8 @@ module Kitchen
           deployment_parameters["imageVersion"] = image_version
         end
 
-        options = Kitchen::Driver::Credentials.new(subscription_id: config[:subscription_id],
-                                                   azure_environment: config[:azure_environment]).azure_options
+        options = Kitchen::Driver::AzureCredentials.new(subscription_id: config[:subscription_id],
+                                                        environment: config[:azure_environment]).azure_options
 
         debug "Azure environment: #{config[:azure_environment]}"
         @resource_management_client = ::Azure::Resources::Profiles::Latest::Mgmt::Client.new(options)
@@ -518,8 +518,8 @@ module Kitchen
       def destroy(state)
         return if state[:server_id].nil?
 
-        options = Kitchen::Driver::Credentials.new(subscription_id: state[:subscription_id],
-                                                   azure_environment: state[:azure_environment]).azure_options
+        options = Kitchen::Driver::AzureCredentials.new(subscription_id: state[:subscription_id],
+                                                        environment: state[:azure_environment]).azure_options
         @resource_management_client = ::Azure::Resources::Profiles::Latest::Mgmt::Client.new(options)
         if config[:destroy_resource_group_contents] == true
           info "Destroying individual resources within the Resource Group."

--- a/lib/kitchen/driver/credentials.rb
+++ b/lib/kitchen/driver/credentials.rb
@@ -9,9 +9,21 @@ module Kitchen
       CONFIG_PATH = "#{ENV["HOME"]}/.azure/credentials".freeze
 
       #
+      # @return [String]
+      #
+      attr_reader :subscription_id
+
+      #
+      # @return [String]
+      #
+      attr_reader :azure_environment
+
+      #
       # Creates and initializes a new instance of the Credentials class.
       #
-      def initialize
+      def initialize(subscription_id:, azure_environment: "Azure")
+        @subscription_id = subscription_id
+        @azure_environment = azure_environment
         config_file = ENV["AZURE_CONFIG_FILE"] || File.expand_path(CONFIG_PATH)
         if File.file?(config_file)
           @credentials = IniFile.load(File.expand_path(config_file))
@@ -21,36 +33,50 @@ module Kitchen
       end
 
       #
-      # Retrieves an object containing options and credentials for the given
-      # subscription_id and azure_environment.
-      #
-      # @param subscription_id [String] The subscription_id to retrieve a token for
-      # @param azure_environment [String] The azure_environment to use
+      # Retrieves an object containing options and credentials
       #
       # @return [Object] Object that can be supplied along with all Azure client requests.
       #
-      def azure_options_for_subscription(subscription_id, azure_environment = "Azure")
-        tenant_id = ENV["AZURE_TENANT_ID"] || @credentials[subscription_id]["tenant_id"]
-        client_id = ENV["AZURE_CLIENT_ID"] || @credentials[subscription_id]["client_id"]
-        client_secret = ENV["AZURE_CLIENT_SECRET"] || @credentials[subscription_id]["client_secret"]
-        token_provider = ::MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings_for_azure_environment(azure_environment))
+      def azure_options
         options = { tenant_id: tenant_id,
                     client_id: client_id,
                     client_secret: client_secret,
                     subscription_id: subscription_id,
                     credentials: ::MsRest::TokenCredentials.new(token_provider),
-                    active_directory_settings: ad_settings_for_azure_environment(azure_environment),
-                    base_url: endpoint_settings_for_azure_environment(azure_environment).resource_manager_endpoint_url }
+                    active_directory_settings: ad_settings,
+                    base_url: endpoint_settings.resource_manager_endpoint_url }
+
         options
+      end
+
+      def self.singleton
+        @credentials ||= Credentials.new
+      end
+
+      private
+
+      def tenant_id
+        ENV["AZURE_TENANT_ID"] || @credentials[subscription_id]["tenant_id"]
+      end
+
+      def client_id
+        ENV["AZURE_CLIENT_ID"] || @credentials[subscription_id]["client_id"]
+      end
+
+      def client_secret
+        ENV["AZURE_CLIENT_SECRET"] || @credentials[subscription_id]["client_secret"]
+      end
+
+      def token_provider
+        ::MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings)
       end
 
       #
       # Retrieves a [MsRestAzure::ActiveDirectoryServiceSettings] object representing the AD settings for the given cloud.
-      # @param azure_environment [String] The Azure environment to retrieve settings for.
       #
       # @return [MsRestAzure::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
       #
-      def ad_settings_for_azure_environment(azure_environment)
+      def ad_settings
         case azure_environment.downcase
         when "azureusgovernment"
           ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_us_government_settings
@@ -65,11 +91,10 @@ module Kitchen
 
       #
       # Retrieves a [MsRestAzure::AzureEnvironment] object representing endpoint settings for the given cloud.
-      # @param azure_environment [String] The Azure environment to retrieve settings for.
       #
       # @return [MsRestAzure::AzureEnvironment] Settings to be used for subsequent requests
       #
-      def endpoint_settings_for_azure_environment(azure_environment)
+      def endpoint_settings
         case azure_environment.downcase
         when "azureusgovernment"
           ::MsRestAzure::AzureEnvironments::AzureUSGovernment
@@ -80,10 +105,6 @@ module Kitchen
         when "azure"
           ::MsRestAzure::AzureEnvironments::AzureCloud
         end
-      end
-
-      def self.singleton
-        @credentials ||= Credentials.new
       end
     end
   end


### PR DESCRIPTION
### Description

Refactor of `Kitchen::Driver::AzureCredentials` (was `Kitchen::Driver::Credentials`) class to make things overall simpler and easier to add features later.

### Changes

- Renamed `Kitchen::Driver::Credentials` to `Kitchen::Driver::AzureCredentials`
- Removed unused `::singleton` method from `Kitchen::Driver::AzureCredentials`
- Refactored entire `Kitchen::Driver::AzureCredentials`

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
