### PR TITLE
Fix require_relative for azure_credentials

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -1,5 +1,5 @@
 require "kitchen"
-require_relative "credentials"
+require_relative "azure_credentials"
 require "securerandom"
 require "azure_mgmt_resources"
 require "azure_mgmt_network"


### PR DESCRIPTION
### Description

Fixes bad `require_relative`.

This bug was introduced in #128.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
