### PR TITLE
Remove the bundler dev dep

### DIFF
--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sshkey", ">= 1.0.0", "< 3"
   spec.add_dependency "test-kitchen", ">= 1.20", "< 3.0"
 
-  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", ">= 11.0"
   spec.add_development_dependency "chefstyle"
   spec.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
Bundler is part of ruby now and adding bundler to the gemspec is a
little chicken and egg ish.

Signed-off-by: Tim Smith <tsmith@chef.io>