### PR TITLE
Fix issue #117

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -214,7 +214,7 @@ module Kitchen
           dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
           vmName: state[:vm_name],
           systemAssignedIdentity: config[:system_assigned_identity],
-          userAssignedIdentities: config[:user_assigned_identities],
+          userAssignedIdentities: config[:user_assigned_identities].map { |identity| [identity, {}] }.to_h,
           secretUrl: config[:secret_url],
           vaultName: config[:vault_name],
           vaultResourceGroup: config[:vault_resource_group],

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -178,10 +178,10 @@
             }
         },
         "userAssignedIdentities": {
-            "type": "array",
-            "defaultValue": [],
+            "type": "object",
+            "defaultValue": {},
             "metadata": {
-                "description": "A list of resource IDs for user identities to associate with the Virtual Machine, or empty to disable user assigned identities."
+                "description": "An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned identities."
             }
         },
         "bootDiagnosticsEnabled": {
@@ -415,7 +415,7 @@
             <%- end -%>
             "identity": {
                 "type": "[variables('vmIdentityType')]",
-                "identityIds": "[if(empty(parameters('userAssignedIdentities')), json('null'), parameters('userAssignedIdentities'))]"
+                "userAssignedIdentities": "[if(empty(parameters('userAssignedIdentities')), json('null'), parameters('userAssignedIdentities'))]"
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -178,10 +178,10 @@
             }
         },
         "userAssignedIdentities": {
-            "type": "array",
-            "defaultValue": [],
+            "type": "object",
+            "defaultValue": {},
             "metadata": {
-                "description": "A list of resource IDs for user identities to associate with the Virtual Machine, or empty to disable user assigned identities."
+                "description": "An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned identities."
             }
         },
         "bootDiagnosticsEnabled": {
@@ -434,7 +434,7 @@
             <%- end -%>
             "identity": {
                 "type": "[variables('vmIdentityType')]",
-                "identityIds": "[if(empty(parameters('userAssignedIdentities')), json('null'), parameters('userAssignedIdentities'))]"
+                "userAssignedIdentities": "[if(empty(parameters('userAssignedIdentities')), json('null'), parameters('userAssignedIdentities'))]"
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>


### PR DESCRIPTION
### Description

This PR allows [Azure user assigned identities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-template-windows-vm#assign-a-user-assigned-managed-identity-to-an-azure-vm) to be added to the Kitchen instance again, fixing issue #117 

### Issues Resolved

#117 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
