### PR TITLE
Make 'az login' the default authentication mechanism

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -15,7 +15,9 @@ module Kitchen
   module Driver
     #
     # Azurerm
+    # Create a new resource group object and set the location and tags attributes then return it.
     #
+    # @return [::Azure::Resources::Profiles::Latest::Mgmt::Models::ResourceGroup] A new resource group object.
     class Azurerm < Kitchen::Driver::Base
       attr_accessor :resource_management_client
       attr_accessor :network_management_client

--- a/spec/unit/kitchen/driver/azure_credentials_spec.rb
+++ b/spec/unit/kitchen/driver/azure_credentials_spec.rb
@@ -94,7 +94,7 @@ describe Kitchen::Driver::AzureCredentials do
       end
 
       it "logs a warning" do
-        expect(Kitchen.logger).to receive(:warn).with("#{default_config_path} was not found or not accessible. Will attempt to use Managed Identity.")
+        expect(Kitchen.logger).to receive(:warn).with("#{default_config_path} was not found or not accessible.")
         azure_options
       end
     end
@@ -152,7 +152,7 @@ describe Kitchen::Driver::AzureCredentials do
 
       context "active_directory_settings" do
         it "sets the authentication_endpoint correctly" do
-          expect(active_directory_settings.authentication_endpoint).to eq("https://login-us.microsoftonline.com/")
+          expect(active_directory_settings.authentication_endpoint).to eq("https://login.microsoftonline.us/")
         end
 
         it "sets the token_audience correctly" do


### PR DESCRIPTION
…r options are explicitly set. Update the code documentation. Update the tests. Remove failure when no tenant_id or AZURE_TENANT_ID is set and rely on 'az login' error message from Azure Ruby SDK. Fixes Issue #147

Signed-off-by: Adam M Dutko <adutko@chef.io>

### Description

Make the 'az login' the default authentication mechanism when no other options are explicitly set. Update the code documentation. Update the tests. Remove failure when no tenant_id or AZURE_TENANT_ID is set and rely on 'az login' error message from Azure Ruby SDK. Fixes Issue #147

### Issues Resolved

Issue #147

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] PR title is a worthy inclusion in the CHANGELOG
