### PR TITLE
Adding FQDN communication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,8 @@ driver:
 
 * The ```secret_url```, ```vault_name```, and ```vault_resource_group``` parameters can be used to deploy VM with specified key vault certificate.
 
+* The ```use_fqdn_hostname``` (default: "false") parameter can be used to determine how kitchen communicates with the Virtual Machine. When true, Kitchen will use the FQDN that is assigned to the Virtual Machine. When false, kitchen will use the public IP address of the machine. This may overcome issues with Corporate firewalls or VPNs blocking Public IP addresses.
+
 ## Enabling alternative WinRM configurations
 
 * By default on Windows machines, a PowerShell script runs that enables WinRM over the SSL transport, for Basic, Negotiate and CredSSP connections. To supply your own PowerShell script (e.g. to enable HTTP), use the `winrm_powershell_script` parameter. Windows 2008 R2 example:

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -214,6 +214,10 @@ module Kitchen
         5
       end
 
+      default_config(:use_fqdn_hostname) do |_config|
+        false
+      end
+
       def create(state)
         state = validate_state(state)
         deployment_parameters = {
@@ -337,6 +341,10 @@ module Kitchen
           result = get_public_ip(state[:azure_resource_group_name], "publicip")
           info "IP Address is: #{result.ip_address} [#{result.dns_settings.fqdn}]"
           state[:hostname] = result.ip_address
+          if config[:use_fqdn_hostname]
+            info "Using FQDN to communicate instead of IP"
+            state[:hostname] = result.dns_settings.fqdn
+          end
         else
           # Retrieve the internal IP from the resource group:
           result = get_network_interface(state[:azure_resource_group_name], vmnic.to_s)

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -78,6 +78,17 @@ describe Kitchen::Driver::Azurerm do
     end
   end
 
+  describe "#default_config" do
+    let(:default_config) { driver.instance_variable_get(:@config) }
+
+    it "Should have the use_fqdn_hostname option available" do
+      expect(default_config).to have_key(:use_fqdn_hostname)
+    end
+    it "Should use the IP to communicate with VM by default" do
+      expect(default_config[:use_fqdn_hostname]).to eq(false)
+    end
+  end
+
   describe "#create" do
     let(:tenant_id) { "2d38055e-66a1-435c-be53-TENANT_ID" }
     let(:client_id) { "2e201a46-44a8-4508-84aa-CLIENT_ID" }
@@ -96,7 +107,6 @@ describe Kitchen::Driver::Azurerm do
       allow(ENV).to receive(:[]).with("GEM_SKIP").and_return("")
       allow(ENV).to receive(:[]).with("http_proxy").and_return("")
       allow(ENV).to receive(:[]).with("GEM_REQUIREMENT_AZURE_MGMT_RESOURCES").and_return("azure_mgmt_resources")
-
     end
 
     it "has credentials available" do


### PR DESCRIPTION
### Description

Adds the ```use_fqdn_hostname``` that will have the state use the VMs FQDN rather than IP to communicate.

### Issues Resolved

I had an issue where my corporate firewall blocks WinRM with IP addresses (e.g. http://xxx.xxx.xxx.xxx/wsman) but, after some local experimentation, allows the FQDN (e.g. http://kitchen-efb274779b8780eb.uksouth.cloudapp.azure.com/wsman)

Currently, the only way the driver communicates is using the IP address and there is no option to use the FQDN that could help get around this issue. Looking into the code, I added an attribute:

Before:
```yaml
# Kitchen state file
---
<--Cut For Brevity-->
hostname: xxx.xxx.xxx.xxx
<--Cut For Brevity-->
```
Usage:
```yaml
# kitchen.yml
---
driver:
  use_fqdn_hostname: true
```

Result:
```yaml
# Kitchen state file
---
<--Cut For Brevity-->
hostname: kitchen-efb274779b8780eb.uksouth.cloudapp.azure.com
<--Cut For Brevity-->
```

It is optional and defaults to false so that current functionality is kept.

I am not precious about this and understand if you see something I missed but glad to put forward the contribution 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
