### PR TITLE
public_ip_sku fixes for default/existing behavior

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -209,7 +209,7 @@ module Kitchen
       end
 
       default_config(:public_ip_sku) do |_config|
-        "Basic"
+        ""
       end
 
       default_config(:azure_api_retries) do |_config|

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -242,7 +242,9 @@ module Kitchen
           deployment_parameters[:adminPassword] = config[:password]
         end
 
-        deployment_parameters[:publicIPSKU] = config[:public_ip_sku]
+        unless config[:public_ip_sku] == ""
+          deployment_parameters[:publicIPSKU] = config[:public_ip_sku]
+        end
 
         if config[:public_ip_sku] == "Standard"
           deployment_parameters[:publicIPAddressType] = "Static"

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -100,10 +100,6 @@ describe Kitchen::Driver::Azurerm do
     it "Should use the IP to communicate with VM by default" do
       expect(default_config[:use_fqdn_hostname]).to eq(false)
     end
-
-    it "Should use basic public IP resources" do
-      expect(default_config[:public_ip_sku]).to eq("Basic")
-    end
   end
 
   describe "#create" do


### PR DESCRIPTION
### Description

Recent changes for `public_ip_sku` cause breaks for default and existing configurations using the driver.  This updates to restore default/existing functionality while still supporting new `public_ip_sku` specification:

- Updates to not populate a default value for `public_ip_sku`
- Updates to only include deployment_parameters[:publicIPSKU] if a `public_ip_sku` is specified in kitchen configuration


### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X] PR title is a worthy inclusion in the CHANGELOG
