### PR TITLE
public_ip_sku fixes for default/existing behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kitchen-azurerm
 
-[![Gem Version](https://badge.fury.io/rb/kitchen-azurerm.svg)](https://badge.fury.io/rb/kitchen-azurerm) 
+[![Gem Version](https://badge.fury.io/rb/kitchen-azurerm.svg)](https://badge.fury.io/rb/kitchen-azurerm)
 ![CI](https://github.com/test-kitchen/kitchen-azurerm/workflows/CI/badge.svg?branch=master)
 
 **kitchen-azurerm** is a driver for the popular test harness [Test Kitchen](http://kitchen.ci) that allows Microsoft Azure resources to be provisioned before testing. This driver uses the new Microsoft Azure Resource Management REST API via the [azure-sdk-for-ruby](https://github.com/azure/azure-sdk-for-ruby).
@@ -76,6 +76,62 @@ Instance            Driver   Provisioner  Verifier  Transport  Last Action    La
 wsus-windows-2019   Azurerm  ChefZero     Inspec    Winrm      <Not Created>  <None>
 wsus-windows-2016   Azurerm  ChefZero     Inspec    Winrm      <Not Created>  <None>
 ```
+
+### Driver Properties
+
+The following properties are able to be specified in the `driver` section of the Test Kitchen configuration:
+
+| Name | Required | Default Value | Description |
+| --- | --- | --- | --- |
+| subscription_id | `true` | `ENV["AZURE_SUBSCRIPTION_ID"]` | Reads string from `ENV["AZURE_SUBSCRIPTION_ID"]` or must be specified if not present in `ENV`.
+| azure_environment | `false` | `"Azure"` | Optional name of Azure environment to use. |
+| machine_size | `true` | `nil` | Machine size to use for instances created. |
+| location | `true` | `nil` | Azure location to use, example `"Central US"` |
+| azure_resource_group_prefix | `false` | `"kitchen-"` | Prefix to use for the resource group configuration which will be created. |
+| azure_resource_group_suffix | `false` | `""` | Optional suffix to append to resource group name. |
+| azure_resource_group_name | `false` | kitchen suite instance name | Optional override for base name of the Azure Resource group which is created, uses prefix and suffix. |
+| explicit_resource_group_name | `false` | `nil` | Optional explicit resource group name, does not use `azure_resource_group_prefix`/`azure_resource_group_suffix` |
+| resource_group_tags | `false` | `{}` | Optional hash of tags to pass to resource group |
+| image_urn | `false` | `"Canonical:UbuntuServer:14.04.3-LTS:latest"` | Image URN to use for vm creation. List can be found using `az` cli - [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#list-popular-images] |
+| image_url | `false` | `""` | Optional explicit URL to use for fetching image. |
+| image_id | `false` | `""` | Optional explicit id to use for image. |
+| use_ephemeral_osdisk | `false` | `false` | Optional flag to use ephermeal disk for instances. |
+| os_disk_size_gb | `false` | `""` | Optional override of os disk size for instances. |
+| os_type | `false` | `"linux"` | Should be specified when os type is not `linux`. |
+| custom_data | `false` | `""` | Optional custom data which may be specified for instances [https://docs.microsoft.com/en-us/azure/virtual-machines/custom-data] |
+| username | `false` | `"azure"` | Username to use for connecting to instances. |
+| password | `false` | `SecureRandom.base64(25)` | Optional password to use for connecting to instances.  Defaults to creating random 25-digit password. |
+| vm_name | `false` | `"vm"` | Optional name for vm instances to create. |
+| nic_name | `false` | `""` | Optional name to provide for nic, if not specified then nic name will be `"nic-#{config[:vm_name]}"`. |
+| vnet_id | `false` | `""` | Optional `vnet` to provide.  If no `vnet` is chosen then public IP will be assigned using default values. |
+| subnet_id | `false` | `""` | Optional subnet to provide, should be used with `vnet_id`. |
+| public_ip | `false` | `false` | Option to specify if a public IP should be assigned.  In default configuration if all other options are left at default then a public IP _will_ be assigned, due to `vnet_id` having no value. |
+| public_ip_sku | `false` | `"Basic"` | Optional string to change the SKU of allocated public IP address.  Defaults to `Basic`. |
+| storage_account_type | `false` | `"Standard_LRS"` | Optional storage account type. |
+| existing_storage_account_blob_url | `false` | `""` | Used with private image specification, the URL of the existing storage account (blob) (without container) |
+| existing_storage_account_container | `false` | Used with private image specification, the Container Name for OS Images (blob) |
+| boot_diagnostics_enabled | `false` | `true` | Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage). |
+| winrm_powershell_script | `false` | `false` | Optional block to specify custom winrm enable contents or else use defaults in driver. |
+| pre_deployment_template | `false` | `""` | Optional path to name of pre-deployment template to use. |
+| pre_deployment_parameters | `false` | `{}` | Optional parameters to pass to pre-deployment template. |
+| post_deployment_template | `false` | `""` | Optional path to name of post-deployment template to use. |
+| post_deployment_parameters | `false` | `{}` | Optional parameters to pass to post-deployment template. |
+| plan | `false` | `{}` | Optional JSON object to use for plan data. |
+| vm_tags | `false` | `{}` | Optional hash of vm tags to populate. |
+| use_managed_disks | `false` | `true` | Must be set to `true` to use `data_disks` property. |
+| data_disks | `false` | `nil` | Additional disks to configure for instances. |
+| format_data_disks | `false` | `false` | Run format operations on attached data disks|
+| format_data_disks_powershell_script | `false` | `false` | Customize the content of format operations for attached `data_disks` |
+| system_assigned_identity | `false` | `false` | Whether to enable system assigned identity for the vm. |
+| user_assigned_identities | `false` | `[]` | An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned identities. |
+| destroy_explicit_resource_group | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
+| destroy_explicit_resource_group_tags | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
+| deployment_sleep | `false` | `10` | Time in seconds to sleep at the end of deployment before fetching details. |
+| secret_url | `false` | `""` | used with connecting to Azure Key Vault |
+| vault_name | `false` | `""` | used with connecting to Azure Key Vault |
+| vault_resource_group | `false` | `""` | used with connecting to Azure Key Vault |
+| azure_api_retries | `false` | `5` | Number of times to retry connections to Azure API. |
+| use_fqdn_hostname | `false` | `false` | Use FQDN to communicate with instances instead of IP. |
 
 ### .kitchen.yml example 1 - Linux/Ubuntu
 
@@ -711,7 +767,7 @@ info:    vm image list command OK
 
 * The ```explicit_resource_group_name``` and ```destroy_explicit_resource_group``` (default: "true") parameters can be used in scenarios where you are provided a pre-created Resource Group. Example usage: ```explicit_resource_group_name: kitchen-<%= ENV["USERNAME"] %>```. The ```destroy_explicit_resource_group``` option can now be used after using the ```destroy_resource_group_contents``` option creates an empty resource group to destroy the resource group previously created.
 
-* The ```destroy_resource_group_contents``` (default: "false") parameter can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase. If you wish to destroy the empty resource group created after you empty the resource group with this flag you can now set the ```destroy_explicit_resource_group``` to "true" to destroy the empty resource group. 
+* The ```destroy_resource_group_contents``` (default: "false") parameter can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase. If you wish to destroy the empty resource group created after you empty the resource group with this flag you can now set the ```destroy_explicit_resource_group``` to "true" to destroy the empty resource group.
 
 * The ```destroy_explicit_resource_group_tags``` (default: "true") parameter can be used when you want to remove tags associated with an explicit resource group. The default setting is set to "true" to remain consistent with previous behavior. This should be used in combination with an ```explicit_resource_group_name``` and will be honored during the ```kitchen destroy``` phase.
 

--- a/README.md
+++ b/README.md
@@ -81,58 +81,58 @@ wsus-windows-2016   Azurerm  ChefZero     Inspec    Winrm      <Not Created>  <N
 
 The following properties are able to be specified in the `driver` section of the Test Kitchen configuration:
 
-| Name | Required | Default Value | Description |
-| --- | --- | --- | --- |
-| subscription_id | `true` | `ENV["AZURE_SUBSCRIPTION_ID"]` | Reads string from `ENV["AZURE_SUBSCRIPTION_ID"]` or must be specified if not present in `ENV`.
-| azure_environment | `false` | `"Azure"` | Optional name of Azure environment to use. |
-| machine_size | `true` | `nil` | Machine size to use for instances created. |
-| location | `true` | `nil` | Azure location to use, example `"Central US"` |
-| azure_resource_group_prefix | `false` | `"kitchen-"` | Prefix to use for the resource group configuration which will be created. |
-| azure_resource_group_suffix | `false` | `""` | Optional suffix to append to resource group name. |
-| azure_resource_group_name | `false` | kitchen suite instance name | Optional override for base name of the Azure Resource group which is created, uses prefix and suffix. |
-| explicit_resource_group_name | `false` | `nil` | Optional explicit resource group name, does not use `azure_resource_group_prefix`/`azure_resource_group_suffix` |
-| destroy_explicit_resource_group | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
-| destroy_explicit_resource_group_tags | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
-| destroy_resource_group_contents | `false` | `false` | can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase. If you wish to destroy the empty resource group created after you empty the resource group with this flag you can now set the ```destroy_explicit_resource_group``` to "true" to destroy the empty resource group. |
-| resource_group_tags | `false` | `{}` | Optional hash of tags to pass to resource group |
-| image_urn | `false` | `"Canonical:UbuntuServer:14.04.3-LTS:latest"` | Image URN to use for vm creation. List can be found using `az` cli - [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#list-popular-images] |
-| image_url | `false` | `""` | (unmanaged disks only) can be used to specify a custom vhd (This VHD must be in the same storage account as the disks of the VM, therefore ```existing_storage_account_blob_url``` must also be set and ```use_managed_disks``` must be set to false) |
-| image_id | `false` | `""` | (managed disks only) can be used to specify an image by id (managed disk). This works only with managed disks. |
-| use_ephemeral_osdisk | `false` | `false` | Optional flag to use ephermeal disk for instances. |
-| os_disk_size_gb | `false` | `""` | Optional override of os disk size for instances. |
-| os_type | `false` | `"linux"` | Should be specified when os type is not `linux`. |
-| custom_data | `false` | `""` | Optional custom data which may be specified for instances [https://docs.microsoft.com/en-us/azure/virtual-machines/custom-data].  This can be a file or the data itself. This module handles base64 encoding for you.|
-| username | `false` | `"azure"` | Username to use for connecting to instances. |
-| password | `false` | `SecureRandom.base64(25)` | Optional password to use for connecting to instances.  Defaults to creating random 24-digit password. |
-| vm_name | `false` | `"vm"` | Optional name for vm instances to create. |
-| nic_name | `false` | `""` | Optional name to provide for nic, if not specified then nic name will be `"nic-#{config[:vm_name]}"`. |
-| vnet_id | `false` | `""` | Optional `vnet` to provide.  If no `vnet` is chosen then public IP will be assigned using default values. |
-| subnet_id | `false` | `""` | Optional subnet to provide, should be used with `vnet_id`. |
-| public_ip | `false` | `false` | Option to specify if a public IP should be assigned.  In default configuration if all other options are left at default then a public IP _will_ be assigned, due to `vnet_id` having no value. |
-| public_ip_sku | `false` | `"Basic"` | Optional string to change the SKU of allocated public IP address.  Defaults to `Basic`. |
-| storage_account_type | `false` | `"Standard_LRS"` | Optional storage account type. |
-| existing_storage_account_blob_url | `false` | `""` | Used with private image specification, the URL of the existing storage account (blob) (without container) |
-| existing_storage_account_container | `false` | Used with private image specification, the Container Name for OS Images (blob) |
-| boot_diagnostics_enabled | `false` | `true` | Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage). |
-| winrm_powershell_script | `false` | `false` | Optional block to specify custom winrm enable contents or else use defaults in driver. |
-| pre_deployment_template | `false` | `""` | Optional path to name of pre-deployment template to use. |
-| pre_deployment_parameters | `false` | `{}` | Optional parameters to pass to pre-deployment template. |
-| post_deployment_template | `false` | `""` | Optional path to name of post-deployment template to use. |
-| post_deployment_parameters | `false` | `{}` | Optional parameters to pass to post-deployment template. |
-| plan | `false` | `{}` | Optional JSON object which allows you to define plan information when creating VMs from Marketplace images. Please refer to [Deploy an image with Marketplace terms](https://aka.ms/azuremarketplaceapideployment) for more details. Not all Marketplace images support programmatic deployment, and support is controlled by the image publisher.|
-| vm_tags | `false` | `{}` | Optional hash of vm tags to populate. |
-| use_managed_disks | `false` | `true` | Must be set to `true` to use `data_disks` property. |
-| data_disks | `false` | `nil` | Additional disks to configure for instances. |
-| format_data_disks | `false` | `false` | Run format operations on attached data disks|
-| format_data_disks_powershell_script | `false` | `false` | Customize the content of format operations for attached `data_disks` |
-| system_assigned_identity | `false` | `false` | Whether to enable system assigned identity for the vm. |
-| user_assigned_identities | `false` | `[]` | An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned identities. |
-| deployment_sleep | `false` | `10` | Time in seconds to sleep at the end of deployment before fetching details. |
-| secret_url | `false` | `""` | used with connecting to Azure Key Vault |
-| vault_name | `false` | `""` | used with connecting to Azure Key Vault |
-| vault_resource_group | `false` | `""` | used with connecting to Azure Key Vault |
-| azure_api_retries | `false` | `5` | Number of times to retry connections to Azure API. |
-| use_fqdn_hostname | `false` | `false` | When true, Kitchen will use the FQDN that is assigned to the Virtual Machine. When false, kitchen will use the public IP address of the machine. This may overcome issues with Corporate firewalls or VPNs blocking Public IP addresses. |
+| Name                                  | Required  | Default Value     | Description   |
+| ---                                   | ---       | ---               | ---           |
+| subscription_id                       | `true` | `ENV["AZURE_SUBSCRIPTION_ID"]` | Reads string from `ENV["AZURE_SUBSCRIPTION_ID"]` or must be specified if not present in `ENV`.
+| azure_environment                     | `false` | `"Azure"` | Optional name of Azure environment to use. |
+| machine_size                          | `true` | `nil` | Machine size to use for instances created. |
+| location                              | `true` | `nil` | Azure location to use, example `"Central US"` |
+| azure_resource_group_prefix           | `false` | `"kitchen-"` | Prefix to use for the resource group configuration which will be created. |
+| azure_resource_group_suffix           | `false` | `""` | Optional suffix to append to resource group name. |
+| azure_resource_group_name             | `false` | kitchen suite instance name | Optional override for base name of the Azure Resource group which is created, uses prefix and suffix. |
+| explicit_resource_group_name          | `false` | `nil` | Optional explicit resource group name, does not use `azure_resource_group_prefix`/`azure_resource_group_suffix` |
+| destroy_explicit_resource_group       | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
+| destroy_explicit_resource_group_tags  | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
+| destroy_resource_group_contents       | `false` | `false` | can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase. If you wish to destroy the empty resource group created after you empty the resource group with this flag you can now set the ```destroy_explicit_resource_group``` to "true" to destroy the empty resource group. |
+| resource_group_tags                   | `false` | `{}` | Optional hash of tags to pass to resource group |
+| image_urn                             | `false` | `"Canonical:UbuntuServer:14.04.3-LTS:latest"` | Image URN to use for vm creation. List can be found using `az` cli - [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#list-popular-images] |
+| image_url                             | `false` | `""` | (unmanaged disks only) can be used to specify a custom vhd (This VHD must be in the same storage account as the disks of the VM, therefore ```existing_storage_account_blob_url``` must also be set and ```use_managed_disks``` must be set to false) |
+| image_id                              | `false` | `""` | (managed disks only) can be used to specify an image by id (managed disk). This works only with managed disks. |
+| use_ephemeral_osdisk                  | `false` | `false` | Optional flag to use ephermeal disk for instances. |
+| os_disk_size_gb                       | `false` | `""` | Optional override of os disk size for instances. |
+| os_type                               | `false` | `"linux"` | Should be specified when os type is not `linux`. |
+| custom_data                           | `false` | `""` | Optional custom data which may be specified for instances [https://docs.microsoft.com/en-us/azure/virtual-machines/custom-data].  This can be a file or the data itself. This module handles base64 encoding for you.|
+| username                              | `false` | `"azure"` | Username to use for connecting to instances. |
+| password                              | `false` | `SecureRandom.base64(25)` | Optional password to use for connecting to instances.  Defaults to creating random 24-digit password. |
+| vm_name                               | `false` | `"vm"` | Optional name for vm instances to create. |
+| nic_name                              | `false` | `""` | Optional name to provide for nic, if not specified then nic name will be `"nic-#{config[:vm_name]}"`. |
+| vnet_id                               | `false` | `""` | Optional `vnet` to provide.  If no `vnet` is chosen then public IP will be assigned using default values. |
+| subnet_id                             | `false` | `""` | Optional subnet to provide, should be used with `vnet_id`. |
+| public_ip                             | `false` | `false` | Option to specify if a public IP should be assigned.  In default configuration if all other options are left at default then a public IP _will_ be assigned, due to `vnet_id` having no value. |
+| public_ip_sku                         | `false` | `"Basic"` | Optional string to change the SKU of allocated public IP address.  Defaults to `Basic`. |
+| storage_account_type                  | `false` | `"Standard_LRS"` | Optional storage account type. |
+| existing_storage_account_blob_url     | `false` | `""` | Used with private image specification, the URL of the existing storage account (blob) (without container) |
+| existing_storage_account_container    | `false` | Used with private image specification, the Container Name for OS Images (blob) |
+| boot_diagnostics_enabled              | `false` | `true` | Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage). |
+| winrm_powershell_script               | `false` | `false` | Optional block to specify custom winrm enable contents or else use defaults in driver. |
+| pre_deployment_template               | `false` | `""` | Optional path to name of pre-deployment template to use. |
+| pre_deployment_parameters             | `false` | `{}` | Optional parameters to pass to pre-deployment template. |
+| post_deployment_template              | `false` | `""` | Optional path to name of post-deployment template to use. |
+| post_deployment_parameters            | `false` | `{}` | Optional parameters to pass to post-deployment template. |
+| plan                                  | `false` | `{}` | Optional JSON object which allows you to define plan information when creating VMs from Marketplace images. Please refer to [Deploy an image with Marketplace terms](https://aka.ms/azuremarketplaceapideployment) for more details. Not all Marketplace images support programmatic deployment, and support is controlled by the image publisher.|
+| vm_tags                               | `false` | `{}` | Optional hash of vm tags to populate. |
+| use_managed_disks                     | `false` | `true` | Must be set to `true` to use `data_disks` property. |
+| data_disks                            | `false` | `nil` | Additional disks to configure for instances. |
+| format_data_disks                     | `false` | `false` | Run format operations on attached data disks|
+| format_data_disks_powershell_script   | `false` | `false` | Customize the content of format operations for attached `data_disks` |
+| system_assigned_identity              | `false` | `false` | Whether to enable system assigned identity for the vm. |
+| user_assigned_identities              | `false` | `[]` | An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned identities. |
+| deployment_sleep                      | `false` | `10` | Time in seconds to sleep at the end of deployment before fetching details. |
+| secret_url                            | `false` | `""` | used with connecting to Azure Key Vault |
+| vault_name                            | `false` | `""` | used with connecting to Azure Key Vault |
+| vault_resource_group                  | `false` | `""` | used with connecting to Azure Key Vault |
+| azure_api_retries                     | `false` | `5` | Number of times to retry connections to Azure API. |
+| use_fqdn_hostname                     | `false` | `false` | When true, Kitchen will use the FQDN that is assigned to the Virtual Machine. When false, kitchen will use the public IP address of the machine. This may overcome issues with Corporate firewalls or VPNs blocking Public IP addresses. |
 
 #### Driver Properties - Enabling alternative WinRM configurations
 
@@ -155,7 +155,7 @@ platforms:
 
 ### kitchen.yml example 1 - Linux/Ubuntu
 
-Here's an example ```.kitchen.yml``` file that provisions an Ubuntu Server, using Chef Zero as the provisioner and SSH as the transport. Note that if the key does not exist at the specified location, it will be created. Also note that if ```ssh_key``` is supplied, Test Kitchen will use this in preference to any default/configured passwords that are supplied.
+Here's an example ```kitchen.yml``` file that provisions an Ubuntu Server, using Chef Zero as the provisioner and SSH as the transport. Note that if the key does not exist at the specified location, it will be created. Also note that if ```ssh_key``` is supplied, Test Kitchen will use this in preference to any default/configured passwords that are supplied.
 
 ```yaml
 ---
@@ -192,7 +192,7 @@ Where n is the number of threads to create. Note that any failure (e.g. an Azure
 
 ### kitchen.yml example 2 - Windows
 
-Here's a further example ```.kitchen.yml``` file that will provision a Windows Server 2019 [smalldisk] instance, using WinRM as the transport. An [ephemeral os disk](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks) is used. The resource created in Azure will enable itself for remote access at deployment time (it does this by customizing the machine at provisioning time) and tags the Azure Resource Group with metadata using the ```resource_group_tags``` property. Notice that the ```vm_tags``` and ```resource_group_tags``` properties use a simple ```key : value``` structure per line:
+Here's a further example ```kitchen.yml``` file that will provision a Windows Server 2019 [smalldisk] instance, using WinRM as the transport. An [ephemeral os disk](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks) is used. The resource created in Azure will enable itself for remote access at deployment time (it does this by customizing the machine at provisioning time) and tags the Azure Resource Group with metadata using the ```resource_group_tags``` property. Notice that the ```vm_tags``` and ```resource_group_tags``` properties use a simple ```key : value``` structure per line:
 
 ```yaml
 ---
@@ -751,7 +751,7 @@ Stuart Preston
 
 ## License and Copyright
 
-Copyright 2015-2020, Chef Software, Inc.
+Copyright 2015-2021, Chef Software, Inc.
 
 ```
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -81,77 +81,268 @@ wsus-windows-2016   Azurerm  ChefZero     Inspec    Winrm      <Not Created>  <N
 
 The following properties are able to be specified in the `driver` section of the Test Kitchen configuration:
 
-| Name                                  | Required  | Default Value     | Description   |
-| ---                                   | ---       | ---               | ---           |
-| subscription_id                       | `true` | `ENV["AZURE_SUBSCRIPTION_ID"]` | Reads string from `ENV["AZURE_SUBSCRIPTION_ID"]` or must be specified if not present in `ENV`.
-| azure_environment                     | `false` | `"Azure"` | Optional name of Azure environment to use. |
-| machine_size                          | `true` | `nil` | Machine size to use for instances created. |
-| location                              | `true` | `nil` | Azure location to use, example `"Central US"` |
-| azure_resource_group_prefix           | `false` | `"kitchen-"` | Prefix to use for the resource group configuration which will be created. |
-| azure_resource_group_suffix           | `false` | `""` | Optional suffix to append to resource group name. |
-| azure_resource_group_name             | `false` | kitchen suite instance name | Optional override for base name of the Azure Resource group which is created, uses prefix and suffix. |
-| explicit_resource_group_name          | `false` | `nil` | Optional explicit resource group name, does not use `azure_resource_group_prefix`/`azure_resource_group_suffix` |
-| destroy_explicit_resource_group       | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
-| destroy_explicit_resource_group_tags  | `false` | `true` | Used for cleanup with `explicit_resource_group_name` |
-| destroy_resource_group_contents       | `false` | `false` | can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase. If you wish to destroy the empty resource group created after you empty the resource group with this flag you can now set the ```destroy_explicit_resource_group``` to "true" to destroy the empty resource group. |
-| resource_group_tags                   | `false` | `{}` | Optional hash of tags to pass to resource group |
-| image_urn                             | `false` | `"Canonical:UbuntuServer:14.04.3-LTS:latest"` | Image URN to use for vm creation. List can be found using `az` cli - [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#list-popular-images] |
-| image_url                             | `false` | `""` | (unmanaged disks only) can be used to specify a custom vhd (This VHD must be in the same storage account as the disks of the VM, therefore ```existing_storage_account_blob_url``` must also be set and ```use_managed_disks``` must be set to false) |
-| image_id                              | `false` | `""` | (managed disks only) can be used to specify an image by id (managed disk). This works only with managed disks. |
-| use_ephemeral_osdisk                  | `false` | `false` | Optional flag to use ephermeal disk for instances. |
-| os_disk_size_gb                       | `false` | `""` | Optional override of os disk size for instances. |
-| os_type                               | `false` | `"linux"` | Should be specified when os type is not `linux`. |
-| custom_data                           | `false` | `""` | Optional custom data which may be specified for instances [https://docs.microsoft.com/en-us/azure/virtual-machines/custom-data].  This can be a file or the data itself. This module handles base64 encoding for you.|
-| username                              | `false` | `"azure"` | Username to use for connecting to instances. |
-| password                              | `false` | `SecureRandom.base64(25)` | Optional password to use for connecting to instances.  Defaults to creating random 24-digit password. |
-| vm_name                               | `false` | `"vm"` | Optional name for vm instances to create. |
-| nic_name                              | `false` | `""` | Optional name to provide for nic, if not specified then nic name will be `"nic-#{config[:vm_name]}"`. |
-| vnet_id                               | `false` | `""` | Optional `vnet` to provide.  If no `vnet` is chosen then public IP will be assigned using default values. |
-| subnet_id                             | `false` | `""` | Optional subnet to provide, should be used with `vnet_id`. |
-| public_ip                             | `false` | `false` | Option to specify if a public IP should be assigned.  In default configuration if all other options are left at default then a public IP _will_ be assigned, due to `vnet_id` having no value. |
-| public_ip_sku                         | `false` | `"Basic"` | Optional string to change the SKU of allocated public IP address.  Defaults to `Basic`. |
-| storage_account_type                  | `false` | `"Standard_LRS"` | Optional storage account type. |
-| existing_storage_account_blob_url     | `false` | `""` | Used with private image specification, the URL of the existing storage account (blob) (without container) |
-| existing_storage_account_container    | `false` | Used with private image specification, the Container Name for OS Images (blob) |
-| boot_diagnostics_enabled              | `false` | `true` | Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage). |
-| winrm_powershell_script               | `false` | `false` | Optional block to specify custom winrm enable contents or else use defaults in driver. |
-| pre_deployment_template               | `false` | `""` | Optional path to name of pre-deployment template to use. |
-| pre_deployment_parameters             | `false` | `{}` | Optional parameters to pass to pre-deployment template. |
-| post_deployment_template              | `false` | `""` | Optional path to name of post-deployment template to use. |
-| post_deployment_parameters            | `false` | `{}` | Optional parameters to pass to post-deployment template. |
-| plan                                  | `false` | `{}` | Optional JSON object which allows you to define plan information when creating VMs from Marketplace images. Please refer to [Deploy an image with Marketplace terms](https://aka.ms/azuremarketplaceapideployment) for more details. Not all Marketplace images support programmatic deployment, and support is controlled by the image publisher.|
-| vm_tags                               | `false` | `{}` | Optional hash of vm tags to populate. |
-| use_managed_disks                     | `false` | `true` | Must be set to `true` to use `data_disks` property. |
-| data_disks                            | `false` | `nil` | Additional disks to configure for instances. |
-| format_data_disks                     | `false` | `false` | Run format operations on attached data disks|
-| format_data_disks_powershell_script   | `false` | `false` | Customize the content of format operations for attached `data_disks` |
-| system_assigned_identity              | `false` | `false` | Whether to enable system assigned identity for the vm. |
-| user_assigned_identities              | `false` | `[]` | An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned identities. |
-| deployment_sleep                      | `false` | `10` | Time in seconds to sleep at the end of deployment before fetching details. |
-| secret_url                            | `false` | `""` | used with connecting to Azure Key Vault |
-| vault_name                            | `false` | `""` | used with connecting to Azure Key Vault |
-| vault_resource_group                  | `false` | `""` | used with connecting to Azure Key Vault |
-| azure_api_retries                     | `false` | `5` | Number of times to retry connections to Azure API. |
-| use_fqdn_hostname                     | `false` | `false` | When true, Kitchen will use the FQDN that is assigned to the Virtual Machine. When false, kitchen will use the public IP address of the machine. This may overcome issues with Corporate firewalls or VPNs blocking Public IP addresses. |
+#### subscription_id (required)
 
-#### Driver Properties - Enabling alternative WinRM configurations
+* _string_ : Reads string from `ENV["AZURE_SUBSCRIPTION_ID"]` or must be specified if not present in `ENV`.
+  * Default Value: `ENV["AZURE_SUBSCRIPTION_ID"]`
 
-* By default on Windows machines, a PowerShell script runs that enables WinRM over the SSL transport, for Basic, Negotiate and CredSSP connections. To supply your own PowerShell script (e.g. to enable HTTP), use the `winrm_powershell_script` parameter. Windows 2008 R2 example:
+#### azure_environment
 
-```yaml
-platforms:
-  - name: windows2008-r2
-    driver_config:
-      image_urn: MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:latest
-      winrm_powershell_script: |-
-        winrm quickconfig -q
-        winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
-        winrm set winrm/config '@{MaxTimeoutms="1800000"}'
-        winrm set winrm/config/service '@{AllowUnencrypted="true"}'
-        winrm set winrm/config/service/auth '@{Basic="true"}'
+* _string_ : Name of Azure environment to use.
 
-```
+#### machine_size (required)
 
+* _string_ : Machine size to use for instances created.
+
+#### location (required)
+
+* _string_ : Azure location to use, example `"Central US"`
+
+#### azure_resource_group_prefix
+
+* _string_ : Prefix to use for the resource group configuration which will be created.
+  * Default Value: `"kitchen-"`
+
+#### azure_resource_group_suffix
+
+* _string_ : Optional suffix to append to resource group name.
+  * Default Value: `""`
+
+#### azure_resource_group_name
+
+* _string_ : Optional override for base name of the Azure Resource group which is created, uses prefix and suffix.
+  * Default Value: `""`
+
+#### explicit_resource_group_name
+
+* _string_ : Optional explicit resource group name, does not use `azure_resource_group_prefix`/`azure_resource_group_suffix`
+  * Default Value: `""`
+
+#### destroy_explicit_resource_group
+
+* _boolean_ : Used for cleanup with `explicit_resource_group_name`
+  * Default Value: `true`
+
+#### destroy_explicit_resource_group_tags
+
+* _boolean_ : Used for cleanup with `explicit_resource_group_name`
+  * Default Value: `true`
+
+#### destroy_resource_group_contents
+
+* _boolean_ : Can be used when you want to destroy the resources within a resource group without destroying the resource group itself. For example, the following configuration options used in combination would use an existing resource group (or create one if it doesn't exist) and will destroy the contents of the resource group in the ```kitchen destroy``` phase. If you wish to destroy the empty resource group created after you empty the resource group with this flag you can now set the ```destroy_explicit_resource_group``` to "true" to destroy the empty resource group.
+  * Default Value: `false`
+
+#### resource_group_tags
+
+* _hash_ : Optional hash of tags to pass to resource group
+
+  ```yaml
+  driver:
+    name: azurerm
+    resource_group_tags:
+      tag1: tag1value
+  ```
+
+#### image_urn
+
+* _string_ : Image URN to use for vm creation. List can be found using `az` cli - [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#list-popular-images]
+  * Default Value: `"Canonical:UbuntuServer:14.04.3-LTS:latest"`
+
+#### image_url
+
+* _string_ : (unmanaged disks only) can be used to specify a custom vhd
+  * This VHD must be in the same storage account as the disks of the VM, therefore ```existing_storage_account_blob_url``` must also be set and ```use_managed_disks``` must be set to false.
+
+#### image_id
+
+* _string_ : (managed disks only) can be used to specify an image by id (managed disk). This works only with managed disks.
+
+#### use_ephemeral_osdisk
+
+* _boolean_ : Optional flag to use ephermeal disk for instances.
+  * Default Value: `false`
+
+#### os_disk_size_gb
+
+* _string_ : Optional override of os disk size for instances.
+
+#### os_type
+
+* _string_ : Should be specified when os type is not `linux`
+  * Default Value: `"linux"`
+
+#### custom_data
+
+* _string_ : Optional custom data which may be specified for instances [https://docs.microsoft.com/en-us/azure/virtual-machines/custom-data].
+  * Value can be a file or the data itself, this module handles base64 encoding for you.
+
+#### username
+
+* _string_ : Username to use for connecting to instances.
+  * Default Value: `"azure"`
+
+#### password
+
+* _string_ : Optional password to use for connecting to instances.
+  * Default Value: `SecureRandom.base64(25)` (Randomly generated 24 digit password)
+
+#### vm_name
+
+* _string_ : Optional name for vm instances to create.
+  * Default Value: `"vm"`
+
+#### nic_name
+
+* _string_ : Optional name to provide for nic, if not specified then nic name will be `"nic-#{config[:vm_name]}"`.
+
+#### vnet_id
+
+* _string_ : Optional `vnet` to provide.  If no `vnet` is chosen then public IP will be assigned using default values.
+
+#### subnet_id
+
+* _string_ : Optional subnet to provide, should be used with `vnet_id`.
+
+#### public_ip
+
+* _boolean_ : Option to specify if a public IP should be assigned.  In default configuration if all other options are left at default then a public IP _will_ be assigned, due to `vnet_id` having no value.
+  * Default Value: `false`
+
+#### public_ip_sku
+
+* _string_ : Optional string to change the SKU of allocated public IP address.  Defaults to `Basic`.
+  * Default Value: `"Basic"`
+
+#### storage_account_type
+
+* _string_ : Optional storage account type.
+  * Default Value: `"Standard_LRS"`
+
+#### existing_storage_account_blob_url
+
+* _string_ : Used with private image specification, the URL of the existing storage account (blob) (without container)
+
+#### existing_storage_account_container
+
+* _string_ : Used with private image specification, the Container Name for OS Images (blob)
+
+#### boot_diagnostics_enabled
+
+* _boolean_ : Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage).
+  * Default Value: `true`
+
+#### winrm_powershell_script
+
+* _string_ : By default on Windows machines, a PowerShell script runs that enables WinRM over the SSL transport, for Basic, Negotiate and CredSSP connections. To supply your own PowerShell script (e.g. to enable HTTP), use the `winrm_powershell_script` parameter. Windows 2008 R2 example:
+
+    ```yaml
+    platforms:
+    - name: windows2008-r2
+        driver_config:
+        image_urn: MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:latest
+        winrm_powershell_script: |-
+            winrm quickconfig -q
+            winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+            winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+            winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+            winrm set winrm/config/service/auth '@{Basic="true"}'
+
+    ```
+
+#### pre_deployment_template
+
+* _string_ : Optional path to name of pre-deployment template to use.
+
+#### pre_deployment_parameters
+
+* _hash_ : Optional parameters to pass to pre-deployment template.
+
+#### post_deployment_template
+
+* _string_ : Optional path to name of post-deployment template to use.
+
+#### post_deployment_parameters
+
+* _hash_ : Optional parameters to pass to post-deployment template.
+
+#### plan
+
+* _hash_ : Optional JSON object which allows you to define plan information when creating VMs from Marketplace images. Please refer to [Deploy an image with Marketplace terms](https://aka.ms/azuremarketplaceapideployment) for more details. Not all Marketplace images support programmatic deployment, and support is controlled by the image publisher.
+
+#### vm_tags
+
+* _hash_ : Optional hash of vm tags to populate.
+
+#### use_managed_disks
+
+* _boolean_ : Must be set to `true` to use `data_disks` property.
+  * Default Value: `true`
+
+#### data_disks
+
+* _array_ : Additional disks to configure for instances.
+
+    ```yaml
+    platforms:
+    - name: windows2016-noformat
+    driver:
+        image_urn: MicrosoftWindowsServer:WindowsServer:2016-Datacenter:latest
+        data_disks:
+        - lun: 0
+            disk_size_gb: 128
+        - lun: 1
+            disk_size_gb: 128
+        - lun: 2
+            disk_size_gb: 128
+    ```
+
+#### format_data_disks
+
+* _boolean_ : Run format operations on attached data disks
+  * Default Value: `false`
+
+#### format_data_disks_powershell_script
+
+* _boolean_ : Customize the content of format operations for attached `data_disks`
+  * Default Value: `false`
+
+#### system_assigned_identity
+
+* _boolean_ : Whether to enable system assigned identity for the vm.
+  * Default Value: `false`
+
+#### user_assigned_identities
+
+* _hash_ : An object whose keys are resource IDs for user identities to associate with the Virtual Machine and whose values are empty objects, or empty to disable user assigned
+identities.
+
+#### deployment_sleep
+
+* _string_ : Time in seconds to sleep at the end of deployment before fetching details.
+  * Default Value: `10`
+
+#### secret_url
+
+* _string_ : used with connecting to Azure Key Vault
+
+#### vault_name
+
+* _string_ : used with connecting to Azure Key Vault
+
+#### vault_resource_group
+
+* _string_ : used with connecting to Azure Key Vault
+
+#### azure_api_retries
+
+* _string_ : Number of times to retry connections to Azure API.
+  * Default Value: `5`
+
+#### use_fqdn_hostname
+
+* _boolean_ : When true, Kitchen will use the FQDN that is assigned to the Virtual Machine. When false, kitchen will use the public IP address of the machine. This may overcome issues with Corporate firewalls or VPNs blocking Public IP addresses.
+  * Default Value: `false`
 
 ### kitchen.yml example 1 - Linux/Ubuntu
 

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -40,10 +40,9 @@
                 "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
             }
         },
-        <%- if public_ip_sku %>
         "publicIPSKU": {
             "type": "string",
-            "defaultValue": "Standard",
+            "defaultValue": "Basic",
             "metadata": {
                 "description": "SKU name for the Public IP used to access the Virtual Machine."
             }
@@ -55,7 +54,6 @@
                 "description": "SKU name for the Public IP used to access the Virtual Machine."
             }
         },
-        <%- end %>
         <%- unless os_disk_size_gb.to_s.empty?  -%>
         "osDiskSizeGb": {
             "type": "int",
@@ -261,9 +259,9 @@
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[variables('publicIPAddressName')]",
             "location": "[variables('location')]",
-	    "sku": {
-	    	"name": "[parameters('publicIPSKU')]"
-	    },
+            "sku": {
+              "name": "[parameters('publicIPSKU')]"
+            },
             "properties": {
                 "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
                 "dnsSettings": {

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -163,6 +163,20 @@
                 "description": "The nic name created inside of the resource group."
             }
         },
+        "publicIPSKU": {
+            "type": "string",
+            "defaultValue": "Basic",
+            "metadata": {
+                "description": "SKU name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "publicIPAddressType": {
+            "type": "string",
+            "defaultValue": "Dynamic",
+            "metadata": {
+                "description": "SKU name for the Public IP used to access the Virtual Machine."
+            }
+        },
         "storageAccountType": {
             "type": "string",
             "defaultValue": "<%= storage_account_type %>",
@@ -201,7 +215,6 @@
         "subnetPrefix": "10.0.0.0/24",
         "storageAccountType": "[parameters('storageAccountType')]",
         "publicIPAddressName": "publicip",
-        "publicIPAddressType": "Dynamic",
         "vmStorageAccountContainerName": "vhds",
         "vmName": "[parameters('vmName')]",
         "vmSize": "[parameters('vmSize')]",
@@ -213,7 +226,7 @@
     "resources": [
         {
             "apiVersion": "2017-05-10",
-            "name": "pid-18d63047-6cdf-4f34-beed-62f01fc73fc2", 
+            "name": "pid-18d63047-6cdf-4f34-beed-62f01fc73fc2",
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
@@ -241,15 +254,18 @@
         <%- end -%>
         <%- end -%>
         {
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2017-08-01",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[variables('publicIPAddressName')]",
             "location": "[variables('location')]",
             "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
                 }
+            },
+            "sku": {
+              "name": "[parameters('publicIPSKU')]"
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>
@@ -362,12 +378,12 @@
                     },
                     <%- end -%>
                     <%- if use_ephemeral_osdisk -%>
-                    "osDisk": { 
-                        "diffDiskSettings": { 
-                             "option": "Local" 
-                        }, 
-                        "caching": "ReadOnly", 
-                        "createOption": "FromImage" 
+                    "osDisk": {
+                        "diffDiskSettings": {
+                             "option": "Local"
+                        },
+                        "caching": "ReadOnly",
+                        "createOption": "FromImage"
                     }
                     <%- elsif use_managed_disks -%>
                     "osDisk": {
@@ -408,7 +424,7 @@
                     }
                     <%- end -%>
                     <%- unless data_disks_for_vm_json.nil? -%>
-                      ,"dataDisks": 
+                      ,"dataDisks":
                           <%= data_disks_for_vm_json %>
                     <%- end -%>
                 },


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

### Description

Recent changes for `public_ip_sku` causes break for default and existing configurations using the driver for interacting with the `public` template.  This updates to restore default/existing functionality while still supporting new `public_ip_sku` specification:

- Updates `public` template file to include parameter updates for `public_ip_sku`, defaulting to `Basic` SKU allocation of public IP.
- Updates `README` to document all available driver property options.
- Updates `README` to remove `.kitchen.yml` and `run-list` references from kitchen YAML examples.

### Issues Resolved

#193 - Covers all of the scenarios that would have been existing with a default or existing configuration for the `public_ip_sku` setting.

Validated that this is working as intended using multiple suite parameters to test different data-population scenarios:

```yaml
driver:
  name: azurerm
  subscription_id: 'id'
  location: 'Central US'
  machine_size: 'Standard_B1s'

transport:
  ssh_key: ~/.ssh/id_kitchen-azurerm

provisioner:
  name: chef_zero

verifier:
  name: inspec

platforms:
  - name: ubuntu-18.04
    driver:
      image_urn: Canonical:UbuntuServer:18.04-LTS:latest

suites:
  - name: default
    attributes:
  - name: public-ip
    driver:
      public_ip: true
  - name: ip-sku
    driver:
      public_ip_sku: Standard
  - name: public-ip-sku
    driver:
      public_ip: true
      public_ip_sku: Standard
```

### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X] PR title is a worthy inclusion in the CHANGELOG

