### PR TITLE
Added support to provide availability zone

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -219,7 +219,7 @@ module Kitchen
       end
 
       default_config(:zone) do |_config|
-        '1'
+        "1"
       end
 
       def create(state)

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -218,10 +218,15 @@ module Kitchen
         false
       end
 
+      default_config(:zone) do |_config|
+        '1'
+      end
+
       def create(state)
         state = validate_state(state)
         deployment_parameters = {
           location: config[:location],
+          zone: config[:zone],
           vmSize: config[:machine_size],
           storageAccountType: config[:storage_account_type],
           bootDiagnosticsEnabled: config[:boot_diagnostics_enabled],

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -106,6 +106,10 @@ describe Kitchen::Driver::Azurerm do
     it "Should use basic public IP resources" do
       expect(default_config[:public_ip_sku]).to eq("Basic")
     end
+
+    it "Should use 1 availability zone" do
+      expect(default_config[:zone]).to eq("1")
+    end
   end
 
   describe "#validate_state" do

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -8,6 +8,18 @@
                 "description": "The location where the resources will be created."
             }
         },
+        "zone": {
+            "type": "string",
+            "defaultValue": "1",
+            "allowedValues": [
+                "1",
+                "2",
+                "3"
+            ],
+            "metadata": {
+                "description": "Zone number for the virtual machine"
+            }
+        },
         "vmSize": {
             "type": "string",
             "metadata": {
@@ -208,6 +220,7 @@
     },
     "variables": {
         "location": "[parameters('location')]",
+        "zone": "[parameters('zone')]",
         "OSDiskName": "osdisk",
         "nicName": "[parameters('nicName')]",
         "addressPrefix": "10.0.0.0/16",
@@ -259,6 +272,9 @@
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[variables('publicIPAddressName')]",
             "location": "[variables('location')]",
+            "zones": [
+                "[variables('zone')]"
+            ],
             "sku": {
               "name": "[parameters('publicIPSKU')]"
             },
@@ -310,6 +326,9 @@
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('vmName')]",
             "location": "[variables('location')]",
+            "zones": [
+                "[variables('zone')]"
+            ],
             "dependsOn": [
                 <%- unless use_managed_disks -%>
                 <%- if existing_storage_account_blob_url.empty? -%>


### PR DESCRIPTION
### Description

- This allows to specify the Availability zone for VM creation.
- Default zone used is - 1
- Zone will be used for below resources -
  - virtualMachines
  - publicIPAddresses 
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]
- NA
### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] PR title is a worthy inclusion in the CHANGELOG
