### PR TITLE
move warning about missing credentials into debug

### DIFF
--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -60,7 +60,7 @@ module Kitchen
         @credentials ||= if File.file?(config_path)
                            IniFile.load(config_path)
                          else
-                           warn "#{config_path} was not found or not accessible."
+                           debug "#{config_path} was not found or not accessible."
                            {}
                          end
       end

--- a/spec/unit/kitchen/driver/azure_credentials_spec.rb
+++ b/spec/unit/kitchen/driver/azure_credentials_spec.rb
@@ -95,7 +95,7 @@ describe Kitchen::Driver::AzureCredentials do
       end
 
       it "logs a warning" do
-        expect(Kitchen.logger).to receive(:warn).with("#{default_config_path} was not found or not accessible.")
+        expect(Kitchen.logger).to receive(:debug).with("#{default_config_path} was not found or not accessible.")
         azure_options
       end
     end


### PR DESCRIPTION
### Description

Moves warning to a debug message. It was confusing to end users when it was warned and there were failures.

Many people use Managed Identities and this warning is just adds to the confusion.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [ ] PR title is a worthy inclusion in the CHANGELOG
