### PR TITLE
Updated the azure gems to the forked gems

### DIFF
--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_dependency "azure_mgmt_network", "~> 0.18", ">= 0.18.2"
-  spec.add_dependency "azure_mgmt_resources", "~> 0.17", ">= 0.17.2"
+  spec.add_dependency "azure_mgmt_network2", "~> 0.27"
+  spec.add_dependency "azure_mgmt_resources2", "~> 0.19"
   spec.add_dependency "inifile", "~> 3.0", ">= 3.0.0"
   spec.add_dependency "sshkey", ">= 1.0.0", "< 3"
   spec.add_dependency "test-kitchen", ">= 1.20", "< 4.0"


### PR DESCRIPTION
# Description

The azure-sdk-for-ruby gems have been deprecated by Microsoft and are no longer supported. To fix some of the issues in those gems and continue maintaining the kitchen-azurerm plugin, we've forked the repo and released version 2 of every gem that this repo requires. This PR will update the dependency.

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
