### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 This CHANGELOG is maintained by the [release-please-action](google-github-actions/release-please-action)
 
+### [1.11.0](http3://g11hub.com/test-kitchen/kitchen-azurerm/compare/v1.10.6...v1.11.0) (2023-04-11)
+
+### Features
+
+* Replaced the deprecated azure SDK gems with separately maintained version twos. ([#238](https://github.com/test-kitchen/kitchen-azurerm/issues/238)) ([c6da371](https://github.com/test-kitchen/kitchen-azurerm/commit/c6da371443912b9d689e445f3f714d5cae6dd3a0))
+
+
 ### [1.10.7](https://github.com/test-kitchen/kitchen-azurerm/compare/v1.10.6...v1.10.7) (2022-04-20)
 
 

--- a/lib/kitchen/driver/azurerm_version.rb
+++ b/lib/kitchen/driver/azurerm_version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Driver
-    AZURERM_VERSION = "1.10.7".freeze
+    AZURERM_VERSION = "1.11.0".freeze
   end
 end


### PR DESCRIPTION
# Description

Release 1.11.0 

* Replaced the deprecated azure SDK gems with separately maintained version twos. ([#238](https://github.com/test-kitchen/kitchen-azurerm/issues/238)) ([c6da371](https://github.com/test-kitchen/kitchen-azurerm/commit/c6da371443912b9d689e445f3f714d5cae6dd3a0))

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant
https://github.com/test-kitchen/kitchen-azurerm/issues/218

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
