### PR TITLE
Feat: Azure sdk namespace updates

### DIFF
--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_dependency "azure_mgmt_network2", "~> 1.0"
-  spec.add_dependency "azure_mgmt_resources2", "~> 1.0"
+  spec.add_dependency "azure_mgmt_network2", "~> 1.0.1", ">= 1.0.1"
+  spec.add_dependency "azure_mgmt_resources2", "~> 1.0.1", ">= 1.0.1"
   spec.add_dependency "inifile", "~> 3.0", ">= 3.0.0"
   spec.add_dependency "sshkey", ">= 1.0.0", "< 3"
   spec.add_dependency "test-kitchen", ">= 1.20", "< 4.0"

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_dependency "azure_mgmt_network2", "~> 0.27"
-  spec.add_dependency "azure_mgmt_resources2", "~> 0.19"
+  spec.add_dependency "azure_mgmt_network2", "~> 1.0"
+  spec.add_dependency "azure_mgmt_resources2", "~> 1.0"
   spec.add_dependency "inifile", "~> 3.0", ">= 3.0.0"
   spec.add_dependency "sshkey", ">= 1.0.0", "< 3"
   spec.add_dependency "test-kitchen", ">= 1.20", "< 4.0"

--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -1,6 +1,5 @@
 require "inifile"
 
-
 require "kitchen/logging"
 autoload :MsRest2, "ms_rest2"
 autoload :MsRestAzure2, "ms_rest_azure2"

--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -1,6 +1,9 @@
 require "inifile"
+
+
 require "kitchen/logging"
-autoload :MsRest, "ms_rest"
+autoload :MsRest2, "ms_rest2"
+autoload :MsRestAzure2, "ms_rest_azure2"
 
 module Kitchen
   module Driver
@@ -38,7 +41,7 @@ module Kitchen
       def azure_options
         options = { tenant_id: tenant_id!,
                     subscription_id: subscription_id,
-                    credentials: ::MsRest::TokenCredentials.new(token_provider),
+                    credentials: ::MsRest2::TokenCredentials.new(token_provider),
                     active_directory_settings: ad_settings,
                     base_url: endpoint_settings.resource_manager_endpoint_url }
         options[:client_id] = client_id if client_id
@@ -87,7 +90,7 @@ module Kitchen
 
       # Retrieve a token based upon the preferred authentication method.
       #
-      # @return [::MsRest::TokenProvider] A new token provider object.
+      # @return [::MsRest2::TokenProvider] A new token provider object.
       def token_provider
         # Login with a credentials file or setting the environment variables
         #
@@ -95,63 +98,63 @@ module Kitchen
         #
         # SPN with client_id, client_secret and tenant_id
         if client_id && client_secret && tenant_id
-          ::MsRestAzure::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings)
+          ::MsRestAzure2::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings)
         # Login with a Managed Service Identity.
         #
         # Typically used with a Managed Service Identity when you have a particular object registered in a tenant.
         #
         # MSI with client_id and tenant_id (aka User Assigned Identity).
         elsif client_id && tenant_id
-          ::MsRestAzure::MSITokenProvider.new(50342, ad_settings, { client_id: client_id })
+          ::MsRestAzure2::MSITokenProvider.new(50342, ad_settings, { client_id: client_id })
         # Default approach to inheriting existing object permissions (application or device this code is running on).
         #
         # Typically used when you want to inherit the permissions of the system you're running on that are in a tenant.
         #
         # MSI with just tenant_id (aka System Assigned Identity).
         elsif tenant_id
-          ::MsRestAzure::MSITokenProvider.new(50342, ad_settings)
+          ::MsRestAzure2::MSITokenProvider.new(50342, ad_settings)
         # Login using the Azure CLI
         #
         # Typically used when you want to rely upon `az login` as your preferred authentication method.
         else
           warn("Using tenant id set through `az login`.")
-          ::MsRestAzure::AzureCliTokenProvider.new(ad_settings)
+          ::MsRestAzure2::AzureCliTokenProvider.new(ad_settings)
         end
       end
 
       #
-      # Retrieves a [MsRestAzure::ActiveDirectoryServiceSettings] object representing the AD settings for the given cloud.
+      # Retrieves a [MsRestAzure2::ActiveDirectoryServiceSettings] object representing the AD settings for the given cloud.
       #
-      # @return [MsRestAzure::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
+      # @return [MsRestAzure2::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
       #
       def ad_settings
         case environment.downcase
         when "azureusgovernment"
-          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_us_government_settings
+          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_us_government_settings
         when "azurechina"
-          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_china_settings
+          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_china_settings
         when "azuregermancloud"
-          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_german_settings
+          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_german_settings
         when "azure"
-          ::MsRestAzure::ActiveDirectoryServiceSettings.get_azure_settings
+          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_settings
         end
       end
 
       #
-      # Retrieves a [MsRestAzure::AzureEnvironment] object representing endpoint settings for the given cloud.
+      # Retrieves a [MsRestAzure2::AzureEnvironment] object representing endpoint settings for the given cloud.
       #
-      # @return [MsRestAzure::AzureEnvironment] Settings to be used for subsequent requests
+      # @return [MsRestAzure2::AzureEnvironment] Settings to be used for subsequent requests
       #
       def endpoint_settings
         case environment.downcase
         when "azureusgovernment"
-          ::MsRestAzure::AzureEnvironments::AzureUSGovernment
+          ::MsRestAzure2::AzureEnvironments::AzureUSGovernment
         when "azurechina"
-          ::MsRestAzure::AzureEnvironments::AzureChinaCloud
+          ::MsRestAzure2::AzureEnvironments::AzureChinaCloud
         when "azuregermancloud"
-          ::MsRestAzure::AzureEnvironments::AzureGermanCloud
+          ::MsRestAzure2::AzureEnvironments::AzureGermanCloud
         when "azure"
-          ::MsRestAzure::AzureEnvironments::AzureCloud
+          ::MsRestAzure2::AzureEnvironments::AzureCloud
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 require "rspec/its"
-require "ms_rest"
-require "ms_rest_azure"
-require "azure_mgmt_resources"
+require "ms_rest2"
+require "ms_rest_azure2"
+require "azure_mgmt_resources2"
 require_relative "../lib/kitchen/driver/azurerm"

--- a/spec/unit/kitchen/driver/azure_credentials_spec.rb
+++ b/spec/unit/kitchen/driver/azure_credentials_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require "ms_rest_azure"
+require "ms_rest_azure2"
 
 describe Kitchen::Driver::AzureCredentials do
   CLIENT_ID_AND_SECRET_SUB = 0
@@ -198,7 +198,7 @@ describe Kitchen::Driver::AzureCredentials do
       it { is_expected.to be_instance_of(Hash) }
       its([:tenant_id]) { is_expected.to eq(tenant_id) }
       its([:subscription_id]) { is_expected.to eq(subscription_id) }
-      its([:credentials]) { is_expected.to be_instance_of(MsRest::TokenCredentials) }
+      its([:credentials]) { is_expected.to be_instance_of(MsRest2::TokenCredentials) }
       its([:client_id]) { is_expected.to eq(client_id) }
       its([:client_secret]) { is_expected.to eq(client_secret) }
       its([:base_url]) { is_expected.to eq("https://management.azure.com/") }
@@ -209,8 +209,8 @@ describe Kitchen::Driver::AzureCredentials do
 
       include_examples "common option specs"
 
-      it "uses token provider: MsRestAzure::ApplicationTokenProvider" do
-        expect(token_provider).to be_instance_of(MsRestAzure::ApplicationTokenProvider)
+      it "uses token provider: MsRestAzure2::ApplicationTokenProvider" do
+        expect(token_provider).to be_instance_of(MsRestAzure2::ApplicationTokenProvider)
       end
 
       it "sets the client_id" do
@@ -229,8 +229,8 @@ describe Kitchen::Driver::AzureCredentials do
 
       include_examples "common option specs"
 
-      it "uses token provider: MsRestAzure::MSITokenProvider" do
-        expect(token_provider).to be_instance_of(MsRestAzure::MSITokenProvider)
+      it "uses token provider: MsRestAzure2::MSITokenProvider" do
+        expect(token_provider).to be_instance_of(MsRestAzure2::MSITokenProvider)
       end
 
       it "sets the client_id" do
@@ -248,8 +248,8 @@ describe Kitchen::Driver::AzureCredentials do
 
       include_examples "common option specs"
 
-      it "uses token provider: MsRestAzure::MSITokenProvider" do
-        expect(token_provider).to be_instance_of(MsRestAzure::MSITokenProvider)
+      it "uses token provider: MsRestAzure2::MSITokenProvider" do
+        expect(token_provider).to be_instance_of(MsRestAzure2::MSITokenProvider)
       end
 
       it "does not set the client_id" do

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -46,7 +46,7 @@ describe Kitchen::Driver::Azurerm do
   end
 
   let(:client) do
-    Azure::Resources::Profiles::Latest::Mgmt::Client.new(options)
+    Azure::Resources2::Profiles::Latest::Mgmt::Client.new(options)
   end
 
   let(:instance) do
@@ -59,7 +59,7 @@ describe Kitchen::Driver::Azurerm do
   end
 
   let(:resource_group) do
-    Azure::Resources::Profiles::Latest::Mgmt::Models::ResourceGroup.new
+    Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup.new
   end
 
   let(:resource_groups) do
@@ -204,8 +204,8 @@ describe Kitchen::Driver::Azurerm do
       rg.location = location
       rg.tags = vm_tags
 
-      # https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest_azure/spec/azure_operation_error_spec.rb
-      expect { resource_groups.create_or_update(rgn, rg) }.to raise_error( an_instance_of(MsRestAzure::AzureOperationError) )
+      # https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest_azure2/spec/azure_operation_error_spec.rb
+      expect { resource_groups.create_or_update(rgn, rg) }.to raise_error( an_instance_of(MsRestAzure2::AzureOperationError) )
     end
 
     it "saves deployment credentials to state, when store_deployment_credentials_in_state is true" do


### PR DESCRIPTION
# Description

The azure-sdk-for-ruby has been deprecated by Microsoft and we have forked it and maintained it separately. Since the old version of the SDK and the new forked sdk co-exists in the chef environment, having the same namespace conflicts. The gem namespace for the new version has been updated and this PR will update the code in this repo accordingly. 


## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
