### PR TITLE
add configurable vm prefix

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -84,6 +84,11 @@ module Kitchen
         SecureRandom.base64(25)
       end
 
+      # This prefix MUST be no longer than 3 characters
+      default_config(:vm_prefix) do |_config|
+        "tk-"
+      end
+
       default_config :vm_name, nil
 
       default_config :store_deployment_credentials_in_state, true
@@ -379,7 +384,7 @@ module Kitchen
       # @return [Hash] Updated Hash of state values.
       def validate_state(state = {})
         state[:uuid] = SecureRandom.hex(8) unless existing_state_value?(state, :uuid)
-        state[:vm_name] = config[:vm_name] || "tk-#{state[:uuid][0..11]}" unless existing_state_value?(state, :vm_name)
+        state[:vm_name] = config[:vm_name] || "#{config[:vm_prefix]}#{state[:uuid][0..11]}" unless existing_state_value?(state, :vm_name)
         state[:server_id] = "vm#{state[:uuid]}" unless existing_state_value?(state, :server_id)
         state[:azure_resource_group_name] = azure_resource_group_name unless existing_state_value?(state, :azure_resource_group_name)
         %i{subscription_id azure_environment use_managed_disks}.each do |config_element|

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -110,6 +110,10 @@ describe Kitchen::Driver::Azurerm do
     it "should set store_deployment_credentials_in_state to true" do
       expect(default_config[:store_deployment_credentials_in_state]).to eq(true)
     end
+
+    it "Should use tk- vm prefix" do
+      expect(default_config[:vm_prefix]).to eq("tk-")
+    end
   end
 
   describe "#validate_state" do
@@ -150,6 +154,7 @@ describe Kitchen::Driver::Azurerm do
         expect(state[:vm_name].length).to eq(15)
         expect(state[:vm_name]).to be_an_instance_of(String)
         expect(state[:vm_name]).not_to eq(vm_name)
+        expect(state[:vm_name]).to start_with("tk-")
       end
 
       it "does not generate vm_name, when one exists in state" do
@@ -157,6 +162,20 @@ describe Kitchen::Driver::Azurerm do
         state[:vm_name] = vm_name_in_state
         driver.validate_state(state)
         expect(state[:vm_name]).to eq(vm_name_in_state)
+      end
+
+      context "when vm_prefix is set in config" do
+        before do
+          config[:vm_prefix] = "ab-"
+        end
+
+        it "generates vm_name with prefix, when one does not exist in state" do
+          driver.validate_state(state)
+          expect(state[:vm_name].length).to eq(15)
+          expect(state[:vm_name]).to be_an_instance_of(String)
+          expect(state[:vm_name]).not_to eq(vm_name)
+          expect(state[:vm_name]).to start_with("ab-")
+        end
       end
     end
   end


### PR DESCRIPTION
# Description

This allows you to customize the default vm prefix (i.e. `tk-`) so that you can alter it to whatever you please.

## Issues Resolved

N/A

## Type of Change

`_feat_`: which represents a new feature, and correlates to a SemVer minor.

## Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
