### PR TITLE
feat: Require Ruby 3.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,5 +7,3 @@ name: "Lint, Unit & Integration Tests"
 jobs:
   lint-unit:
     uses: test-kitchen/.github/.github/workflows/lint-unit.yml@main
-    with:
-      bundle_only: "linting"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,4 @@ require:
   - cookstyle/chefstyle
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ group :debug do
   gem "pry"
 end
 
-group :linting do
-  gem "cookstyle", "8.4.0"
+group :cookstyle do
+  gem "cookstyle", "~> 8.4"
 end

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["LICENSE", "lib/**/*", "templates/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.add_dependency "azure_mgmt_network2", "~> 1.0.1", ">= 1.0.1"
   spec.add_dependency "azure_mgmt_resources2", "~> 1.0.1", ">= 1.0.1"


### PR DESCRIPTION
# Description

Ruby 3.1 is EOL. Require 3.2 now

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
