### PR TITLE
Require Ruby 3.1+ and modernize CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  Include:
-    - "**/*.rb"
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,9 @@ require:
   - cookstyle/chefstyle
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.1
+  Include:
+    - "**/*.rb"
+  Exclude:
+    - "vendor/**/*"
+    - "spec/**/*"

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 256
+    level: warning

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-gemspec
-
+gemspec development_group: :test
 group :test do
   gem "rake", ">= 11.0"
   gem "rspec", "~> 3.5"


### PR DESCRIPTION
Standardizes the Ruby requirement and CI across the test-kitchen org.

### Changes
- **Ruby requirement**: `required_ruby_version = ">= 3.1"` in the gemspec.
- **`.rubocop.yml`**: standardized on `cookstyle/chefstyle` with `TargetRubyVersion: 3.1`, matching test-kitchen. Many repos still required the standalone `chefstyle` gem, which no longer loads — cookstyle could not run at all before this.
- **CI**: unit tests on **3.1, 3.2, 3.3, 3.4, 4.0**; `cookstyle --chefstyle` on **3.1**.
- **Bundler**: added the `cookstyle` group where missing, so `bundle exec cookstyle` resolves in CI.
- **Cookstyle**: applied `cookstyle --chefstyle -a` autocorrections; `cookstyle --chefstyle` is now clean.
- **Dead linters removed** where present (`cane`, `tailor`, `finstyle`, standalone `chefstyle`). These are unmaintained and fail on modern Ruby (`cane` calls `File.exists?`, removed in Ruby 4.0; `tailor` needs `ostruct`, no longer a default gem). Cookstyle supersedes them.

Comment/config changes plus mechanical style autocorrections; no intentional behavior changes.
