### PR TITLE
Rewrite unit test suite and fix the bugs it uncovered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ coverage
 *.log
 *kitchen.local.yml
 .kitchen/
+
+.rspec_status
+doc/
+.yardoc/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,4 +6,3 @@ AllCops:
   TargetRubyVersion: 3.1
   Exclude:
     - "vendor/**/*"
-    - "spec/**/*"

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--markup markdown
+--output-dir doc
+--readme README.md
+--no-private
+--protected
+lib/**/*.rb
+-
+CHANGELOG.md
+LICENSE

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,16 @@
 source "https://rubygems.org"
 
 gemspec development_group: :test
+
 group :test do
   gem "rake", ">= 11.0"
-  gem "rspec", "~> 3.5"
-  gem "rspec-its", "~> 2.0.0"
+  gem "rspec", "~> 3.13"
+  gem "simplecov", "~> 0.22"
+  gem "webmock", "~> 3.19"
+end
+
+group :docs do
+  gem "yard", "~> 0.9"
 end
 
 group :debug do

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ provisioner:
 platforms:
   - name: ubuntu-14.04
     driver:
-      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
       vm_name: trusty-vm
 
 suites:
@@ -181,7 +181,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
 
 suites:
   - name: default
@@ -251,7 +251,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
       vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
       subnet_id: subnet-10.1.0
 
@@ -284,7 +284,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
       vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
       subnet_id: subnet-10.1.0
       public_ip: true
@@ -475,7 +475,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
 
 suites:
   - name: default
@@ -555,7 +555,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_urn: Canonical:UbuntuServer:14.04.4-LTS:latest
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
       system_assigned_identity: true
       user_assigned_identities:
         - /subscriptions/4801fa9d-YOUR-GUID-HERE-b265ff49ce21/resourcegroups/test-kitchen-user/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-kitchen-user
@@ -621,7 +621,7 @@ verifier:
 platforms:
 - name: ubuntu1604
   driver:
-    image_urn: Canonical:UbuntuServer:16.04-LTS:latest
+    image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
   transport:
     ssh_key: ~/.ssh/id_kitchen-azurerm
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
+
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:test)
+task spec: :test
 
 begin
   require "cookstyle/chefstyle"
@@ -12,4 +14,28 @@ rescue LoadError
   puts "cookstyle/chefstyle is not available. (sudo) gem install cookstyle to do style checking."
 end
 
+begin
+  require "yard"
+
+  YARD::Rake::YardocTask.new(:yard) do |task|
+    task.stats_options = ["--list-undoc"]
+  end
+  desc "Generate YARD documentation into doc/"
+  task doc: :yard
+
+  desc "Report YARD documentation coverage without failing"
+  task :"yard:stats" do
+    sh "yard stats --list-undoc"
+  end
+
+  desc "Serve YARD documentation at http://localhost:8808"
+  task :"yard:server" do
+    sh "yard server --reload"
+  end
+rescue LoadError
+  puts "yard is not available. (sudo) gem install yard to generate documentation."
+end
+
+# Documentation is deliberately not part of the default task: missing YARD tags
+# should never fail a build.
 task default: %i{test style}

--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -1,42 +1,96 @@
 require "inifile"
 
+require "kitchen/errors"
 require "kitchen/logging"
 autoload :MsRest2, "ms_rest2"
 autoload :MsRestAzure2, "ms_rest_azure2"
 
 module Kitchen
   module Driver
+    # Resolves Azure Resource Manager credentials and endpoint settings for a
+    # single subscription.
     #
-    # AzureCredentials
+    # Credentials are sourced, in order of precedence, from environment
+    # variables (+AZURE_TENANT_ID+, +AZURE_CLIENT_ID+, +AZURE_CLIENT_SECRET+)
+    # and then from the Azure CLI credentials INI file (by default
+    # +~/.azure/credentials+, overridable with +AZURE_CONFIG_FILE+).
     #
+    # The combination of values that resolve determines which token provider is
+    # used - see {#azure_options}.
+    #
+    # @example Service principal supplied by environment
+    #   ENV["AZURE_TENANT_ID"]     = "..."
+    #   ENV["AZURE_CLIENT_ID"]     = "..."
+    #   ENV["AZURE_CLIENT_SECRET"] = "..."
+    #   options = Kitchen::Driver::AzureCredentials.new(subscription_id: "...").azure_options
     class AzureCredentials
       include Kitchen::Logging
 
-      CONFIG_PATH = "#{ENV["HOME"]}/.azure/credentials".freeze
-
+      # Path fragment, relative to the user's home directory, of the Azure CLI
+      # credentials file.
       #
       # @return [String]
+      CONFIG_FILE = File.join(".azure", "credentials").freeze
+
+      # Azure cloud names understood by {#azure_options}, mapped to the
+      # +MsRestAzure2+ constants that describe them. Keys are downcased so
+      # lookups are case-insensitive.
       #
+      # @return [Hash{String => Symbol}]
+      ENVIRONMENTS = {
+        "azure" => :Azure,
+        "azurechina" => :AzureChina,
+        "azuregermancloud" => :AzureGermanCloud,
+        "azureusgovernment" => :AzureUSGovernment,
+      }.freeze
+
+      # Port the Azure Instance Metadata Service listens on for MSI token requests.
+      #
+      # @return [Integer]
+      MSI_PORT = 50342
+
+      # The Azure subscription these credentials authenticate against.
+      #
+      # @return [String]
       attr_reader :subscription_id
 
+      # The Azure cloud name, e.g. +"Azure"+ or +"AzureUSGovernment"+.
       #
       # @return [String]
-      #
       attr_reader :environment
 
+      # Default path of the Azure CLI credentials file.
       #
-      # Creates and initializes a new instance of the Credentials class.
+      # Resolved lazily (rather than at load time) so that a test - or a caller
+      # that manipulates +HOME+ - sees the current home directory rather than
+      # whichever one happened to be set when this file was first required.
       #
-      def initialize(subscription_id:, environment: "Azure")
-        @subscription_id = subscription_id
-        @environment = environment
+      # @return [String] absolute path to +~/.azure/credentials+
+      def self.default_config_path
+        File.join(Dir.home, CONFIG_FILE)
       end
 
+      # @param subscription_id [String] the Azure subscription to authenticate against.
+      # @param environment [String] the Azure cloud name. Case-insensitive.
+      # @raise [Kitchen::UserError] if +environment+ is not a known Azure cloud.
+      def initialize(subscription_id:, environment: "Azure")
+        @subscription_id = subscription_id
+        @environment = environment || "Azure"
+
+        unless ENVIRONMENTS.key?(@environment.to_s.downcase)
+          raise Kitchen::UserError,
+            "Unknown azure_environment '#{@environment}'. Valid values are: #{ENVIRONMENTS.keys.join(", ")} (case-insensitive)."
+        end
+      end
+
+      # Builds the options hash accepted by every +azure_mgmt_*2+ client.
       #
-      # Retrieves an object containing options and credentials
+      # The +:credentials+ entry wraps whichever token provider matches the
+      # resolved credentials - see {#token_provider}. +:client_id+ and
+      # +:client_secret+ are only included when they resolve to a value.
       #
-      # @return [Object] Object that can be supplied along with all Azure client requests.
-      #
+      # @return [Hash] options suitable for
+      #   +Azure::Resources2::Profiles::Latest::Mgmt::Client.new+ and friends.
       def azure_options
         options = { tenant_id: tenant_id!,
                     subscription_id:,
@@ -48,16 +102,76 @@ module Kitchen
         options
       end
 
+      # Selects a token provider based on which credentials resolved.
+      #
+      # * +client_id+ + +client_secret+ + +tenant_id+ - service principal.
+      # * +client_id+ + +tenant_id+ - user-assigned managed identity.
+      # * +tenant_id+ only - system-assigned managed identity.
+      # * none of the above - falls back to the +az login+ token cache.
+      #
+      # @return [MsRestAzure2::ApplicationTokenProvider,
+      #   MsRestAzure2::MSITokenProvider, MsRestAzure2::AzureCliTokenProvider]
+      def token_provider
+        if client_id && client_secret && tenant_id
+          ::MsRestAzure2::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings)
+        elsif client_id && tenant_id
+          ::MsRestAzure2::MSITokenProvider.new(MSI_PORT, ad_settings, { client_id: })
+        elsif tenant_id
+          ::MsRestAzure2::MSITokenProvider.new(MSI_PORT, ad_settings)
+        else
+          warn("Using tenant id set through `az login`.")
+          ::MsRestAzure2::AzureCliTokenProvider.new(ad_settings)
+        end
+      end
+
+      # Active Directory settings for the configured cloud.
+      #
+      # @return [MsRestAzure2::ActiveDirectoryServiceSettings]
+      def ad_settings
+        case environment_key
+        when :AzureUSGovernment then ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_us_government_settings
+        when :AzureChina        then ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_china_settings
+        when :AzureGermanCloud  then ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_german_settings
+        else ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_settings
+        end
+      end
+
+      # Endpoint settings (resource manager URL, storage suffixes, ...) for the
+      # configured cloud.
+      #
+      # @return [MsRestAzure2::AzureEnvironment]
+      def endpoint_settings
+        case environment_key
+        when :AzureUSGovernment then ::MsRestAzure2::AzureEnvironments::AzureUSGovernment
+        when :AzureChina        then ::MsRestAzure2::AzureEnvironments::AzureChinaCloud
+        when :AzureGermanCloud  then ::MsRestAzure2::AzureEnvironments::AzureGermanCloud
+        else ::MsRestAzure2::AzureEnvironments::AzureCloud
+        end
+      end
+
+      # Path of the credentials file actually in use.
+      #
+      # @return [String] +AZURE_CONFIG_FILE+ if set, otherwise
+      #   {.default_config_path}. Always expanded.
+      def config_path
+        @config_path ||= File.expand_path(ENV["AZURE_CONFIG_FILE"] || self.class.default_config_path)
+      end
+
       private
 
+      # @return [Symbol] the {ENVIRONMENTS} key for the configured cloud.
+      def environment_key
+        ENVIRONMENTS.fetch(environment.to_s.downcase)
+      end
+
+      # @return [Kitchen::Logger] the shared Test Kitchen logger.
       def logger
         Kitchen.logger
       end
 
-      def config_path
-        @config_path ||= File.expand_path(ENV["AZURE_CONFIG_FILE"] || CONFIG_PATH)
-      end
-
+      # Parsed credentials file, or an empty Hash when no readable file exists.
+      #
+      # @return [IniFile, Hash]
       def credentials
         @credentials ||= if File.file?(config_path)
                            IniFile.load(config_path)
@@ -67,94 +181,51 @@ module Kitchen
                          end
       end
 
+      # Reads a property from the section of the credentials file matching
+      # {#subscription_id}.
+      #
+      # @param property [String] the INI key to read.
+      # @return [String, nil]
       def credentials_property(property)
-        credentials[subscription_id]&.[](property)
+        value = credentials[subscription_id]&.[](property)
+        value unless value.to_s.empty?
       end
 
+      # Tenant ID, warning the user when one cannot be resolved.
+      #
+      # @return [String, nil]
       def tenant_id!
         tenant_id || warn("(#{config_path}) does not contain tenant_id neither is the AZURE_TENANT_ID environment variable set.")
       end
 
+      # @return [String, nil] tenant ID from the environment or credentials file.
       def tenant_id
-        ENV["AZURE_TENANT_ID"] || credentials_property("tenant_id")
+        env_or_credentials("AZURE_TENANT_ID", "tenant_id")
       end
 
+      # @return [String, nil] client ID from the environment or credentials file.
       def client_id
-        ENV["AZURE_CLIENT_ID"] || credentials_property("client_id")
+        env_or_credentials("AZURE_CLIENT_ID", "client_id")
       end
 
+      # @return [String, nil] client secret from the environment or credentials file.
       def client_secret
-        ENV["AZURE_CLIENT_SECRET"] || credentials_property("client_secret")
+        env_or_credentials("AZURE_CLIENT_SECRET", "client_secret")
       end
 
-      # Retrieve a token based upon the preferred authentication method.
+      # Reads a value from the environment, falling back to the credentials file.
       #
-      # @return [::MsRest2::TokenProvider] A new token provider object.
-      def token_provider
-        # Login with a credentials file or setting the environment variables
-        #
-        # Typically used with a service principal.
-        #
-        # SPN with client_id, client_secret and tenant_id
-        if client_id && client_secret && tenant_id
-          ::MsRestAzure2::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings)
-        # Login with a Managed Service Identity.
-        #
-        # Typically used with a Managed Service Identity when you have a particular object registered in a tenant.
-        #
-        # MSI with client_id and tenant_id (aka User Assigned Identity).
-        elsif client_id && tenant_id
-          ::MsRestAzure2::MSITokenProvider.new(50342, ad_settings, { client_id: })
-        # Default approach to inheriting existing object permissions (application or device this code is running on).
-        #
-        # Typically used when you want to inherit the permissions of the system you're running on that are in a tenant.
-        #
-        # MSI with just tenant_id (aka System Assigned Identity).
-        elsif tenant_id
-          ::MsRestAzure2::MSITokenProvider.new(50342, ad_settings)
-        # Login using the Azure CLI
-        #
-        # Typically used when you want to rely upon `az login` as your preferred authentication method.
-        else
-          warn("Using tenant id set through `az login`.")
-          ::MsRestAzure2::AzureCliTokenProvider.new(ad_settings)
-        end
-      end
+      # Empty environment variables are treated as unset - an exported-but-blank
+      # +AZURE_CLIENT_SECRET+ should not shadow a real value in the file.
+      #
+      # @param env_var [String] environment variable name.
+      # @param property [String] INI property name.
+      # @return [String, nil]
+      def env_or_credentials(env_var, property)
+        value = ENV[env_var]
+        return value unless value.to_s.empty?
 
-      #
-      # Retrieves a [MsRestAzure2::ActiveDirectoryServiceSettings] object representing the AD settings for the given cloud.
-      #
-      # @return [MsRestAzure2::ActiveDirectoryServiceSettings] Settings to be used for subsequent requests
-      #
-      def ad_settings
-        case environment.downcase
-        when "azureusgovernment"
-          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_us_government_settings
-        when "azurechina"
-          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_china_settings
-        when "azuregermancloud"
-          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_german_settings
-        when "azure"
-          ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_settings
-        end
-      end
-
-      #
-      # Retrieves a [MsRestAzure2::AzureEnvironment] object representing endpoint settings for the given cloud.
-      #
-      # @return [MsRestAzure2::AzureEnvironment] Settings to be used for subsequent requests
-      #
-      def endpoint_settings
-        case environment.downcase
-        when "azureusgovernment"
-          ::MsRestAzure2::AzureEnvironments::AzureUSGovernment
-        when "azurechina"
-          ::MsRestAzure2::AzureEnvironments::AzureChinaCloud
-        when "azuregermancloud"
-          ::MsRestAzure2::AzureEnvironments::AzureGermanCloud
-        when "azure"
-          ::MsRestAzure2::AzureEnvironments::AzureCloud
-        end
+        credentials_property(property)
       end
     end
   end

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -3,6 +3,8 @@ require "kitchen"
 autoload :MsRestAzure2, "ms_rest_azure2"
 require_relative "azure_credentials"
 require "securerandom" unless defined?(SecureRandom)
+# Azure SDK namespaces, autoloaded so that requiring this driver does not pull
+# in the (large) management clients until a deployment actually needs them.
 module Azure
   autoload :Resources2, "azure_mgmt_resources2"
   autoload :Network2, "azure_mgmt_network2"
@@ -15,15 +17,29 @@ require "ostruct" unless defined?(OpenStruct)
 require "json" unless defined?(JSON)
 autoload :Faraday, "faraday"
 
+# Test Kitchen's top-level namespace.
 module Kitchen
+  # Namespace for Test Kitchen driver plugins.
   module Driver
+    # Test Kitchen driver for the Microsoft Azure Resource Manager API.
     #
-    # Azurerm
-    # Create a new resource group object and set the location and tags attributes then return it.
+    # Provisions each Test Kitchen instance as an ARM deployment inside its own
+    # resource group, then tears the whole group down again on destroy. The
+    # deployment template is rendered from the ERB files in +templates/+ - see
+    # {#virtual_machine_deployment_template}.
     #
-    # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup] A new resource group object.
+    # @see https://github.com/test-kitchen/kitchen-azurerm
     class Azurerm < Kitchen::Driver::Base
+      # Client for the Azure Resource Manager API, built during {#create} or
+      # {#destroy} once credentials have been resolved.
+      #
+      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Client, nil]
       attr_accessor :resource_management_client
+
+      # Client for the Azure Network API, built during {#create} once the
+      # deployment has completed.
+      #
+      # @return [::Azure::Network2::Profiles::Latest::Mgmt::Client, nil]
       attr_accessor :network_management_client
 
       kitchen_driver_api_version 2
@@ -48,8 +64,10 @@ module Kitchen
         {}
       end
 
+      # Ubuntu 22.04 LTS, generation 2. Canonical renamed their offers after
+      # 18.04, so the old "UbuntuServer" offer no longer resolves at all.
       default_config(:image_urn) do |_config|
-        "Canonical:UbuntuServer:14.04.3-LTS:latest"
+        "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
       end
 
       default_config(:image_url) do |_config|
@@ -225,78 +243,24 @@ module Kitchen
         false
       end
 
+      # Provisions the Azure resource group and ARM deployment backing this
+      # Test Kitchen instance.
+      #
+      # Runs, in order: the optional pre-deployment template, the virtual
+      # machine deployment, and the optional post-deployment template. On
+      # success +state+ gains a +:hostname+ that the transport can connect to.
+      #
+      # @param state [Hash] the instance state, mutated in place.
+      # @return [void]
+      # @raise [RuntimeError] if no +subscription_id+ can be resolved.
+      # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails
+      #   for any reason other than an already-running deployment.
       def create(state)
         state = validate_state(state)
-        deployment_parameters = {
-          location: config[:location],
-          vmSize: config[:machine_size],
-          storageAccountType: config[:storage_account_type],
-          bootDiagnosticsEnabled: config[:boot_diagnostics_enabled],
-          newStorageAccountName: "storage#{state[:uuid]}",
-          adminUsername: config[:username],
-          dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
-          vmName: state[:vm_name],
-          systemAssignedIdentity: config[:system_assigned_identity],
-          userAssignedIdentities: config[:user_assigned_identities].map { |identity| [identity, {}] }.to_h,
-          secretUrl: config[:secret_url],
-          vaultName: config[:vault_name],
-          vaultResourceGroup: config[:vault_resource_group],
-        }
-
-        if instance.transport[:ssh_key].nil?
-          deployment_parameters[:adminPassword] = config[:password]
-        end
-
-        deployment_parameters[:publicIPSKU] = config[:public_ip_sku]
-
-        if config[:public_ip_sku] == "Standard"
-          deployment_parameters[:publicIPAddressType] = "Static"
-        end
+        deployment_parameters = build_deployment_parameters(state)
 
         if config[:subscription_id].to_s == ""
           raise "A subscription_id config value was not detected and kitchen-azurerm cannot continue. Please check your kitchen.yml configuration. Exiting."
-        end
-
-        if config[:nic_name].to_s == ""
-          vmnic = "nic-#{state[:vm_name]}"
-        else
-          vmnic = config[:nic_name]
-        end
-        deployment_parameters["nicName"] = vmnic.to_s
-
-        if config[:custom_data].to_s != ""
-          deployment_parameters["customData"] = prepared_custom_data
-        end
-        # When deploying in a shared storage account, we needs to add
-        # a unique suffix to support multiple kitchen instances
-        if config[:existing_storage_account_blob_url].to_s != ""
-          deployment_parameters["osDiskNameSuffix"] = "-#{state[:azure_resource_group_name]}"
-        end
-        if config[:existing_storage_account_blob_url].to_s != ""
-          deployment_parameters["existingStorageAccountBlobURL"] = config[:existing_storage_account_blob_url]
-        end
-        if config[:existing_storage_account_container].to_s != ""
-          deployment_parameters["existingStorageAccountBlobContainer"] = config[:existing_storage_account_container]
-        end
-        if config[:os_disk_size_gb].to_s != ""
-          deployment_parameters["osDiskSizeGb"] = config[:os_disk_size_gb]
-        end
-
-        # The three deployment modes
-        #  a) Private Image: Managed VM Image (by id)
-        #  b) Private Image: Using a VHD URL (note: we must use existing_storage_account_blob_url due to azure limitations)
-        #  c) Public Image: Using a marketplace image (urn)
-        if config[:image_id].to_s != ""
-          deployment_parameters["imageId"] = config[:image_id]
-        elsif config[:image_url].to_s != ""
-          deployment_parameters["imageUrl"] = config[:image_url]
-          deployment_parameters["osType"] = config[:os_type]
-        else
-          image_publisher, image_offer, image_sku, image_version = config[:image_urn].split(":", 4)
-          deployment_parameters["imagePublisher"] = image_publisher
-          deployment_parameters["imageOffer"] = image_offer
-          deployment_parameters["imageSku"] = image_sku
-          deployment_parameters["imageVersion"] = image_version
         end
 
         options = Kitchen::Driver::AzureCredentials.new(subscription_id: config[:subscription_id],
@@ -305,7 +269,6 @@ module Kitchen
         debug "Azure environment: #{config[:azure_environment]}"
         @resource_management_client = ::Azure::Resources2::Profiles::Latest::Mgmt::Client.new(options)
 
-        # Create Resource Group
         begin
           info "Creating Resource Group: #{state[:azure_resource_group_name]}"
           create_resource_group(state[:azure_resource_group_name], get_resource_group)
@@ -314,34 +277,16 @@ module Kitchen
           raise operation_error
         end
 
-        # Execute deployment steps
         begin
-          if File.file?(config[:pre_deployment_template])
-            pre_deployment_name = "pre-deploy-#{state[:uuid]}"
-            info "Creating deployment: #{pre_deployment_name}"
-            create_deployment_async(state[:azure_resource_group_name], pre_deployment_name, pre_deployment(config[:pre_deployment_template], config[:pre_deployment_parameters])).value!
-            follow_deployment_until_end_state(state[:azure_resource_group_name], pre_deployment_name)
-          end
-          deployment_name = "deploy-#{state[:uuid]}"
-          info "Creating deployment: #{deployment_name}"
-          create_deployment_async(state[:azure_resource_group_name], deployment_name, deployment(deployment_parameters)).value!
-          follow_deployment_until_end_state(state[:azure_resource_group_name], deployment_name)
+          run_deployment(state, "pre-deploy", pre_deployment(config[:pre_deployment_template], config[:pre_deployment_parameters])) if File.file?(config[:pre_deployment_template])
 
-          if config[:store_deployment_credentials_in_state] == true
-            state[:username] = deployment_parameters[:adminUsername] unless existing_state_value?(state, :username)
-            state[:password] = deployment_parameters[:adminPassword] unless existing_state_value?(state, :password) && instance.transport[:ssh_key].nil?
-          end
+          run_deployment(state, "deploy", deployment(deployment_parameters))
+          store_deployment_credentials(state, deployment_parameters)
 
-          if File.file?(config[:post_deployment_template])
-            post_deployment_name = "post-deploy-#{state[:uuid]}"
-            info "Creating deployment: #{post_deployment_name}"
-            create_deployment_async(state[:azure_resource_group_name], post_deployment_name, post_deployment(config[:post_deployment_template], config[:post_deployment_parameters])).value!
-            follow_deployment_until_end_state(state[:azure_resource_group_name], post_deployment_name)
-          end
+          run_deployment(state, "post-deploy", post_deployment(config[:post_deployment_template], config[:post_deployment_parameters])) if File.file?(config[:post_deployment_template])
         rescue ::MsRestAzure2::AzureOperationError => operation_error
           rest_error = operation_error.body["error"]
-          deployment_active = rest_error["code"] == "DeploymentActive"
-          if deployment_active
+          if rest_error["code"] == "DeploymentActive"
             info "Deployment for resource group #{state[:azure_resource_group_name]} is ongoing."
             info "If you need to change the deployment template you'll need to rerun `kitchen create` for this instance."
           else
@@ -351,40 +296,152 @@ module Kitchen
         end
 
         @network_management_client = ::Azure::Network2::Profiles::Latest::Mgmt::Client.new(options)
+        state[:hostname] = resolve_hostname(state, deployment_parameters["nicName"])
+      end
 
-        if config[:vnet_id] == "" || config[:public_ip]
-          # Retrieve the public IP from the resource group:
-          result = get_public_ip(state[:azure_resource_group_name], "publicip")
-          info "IP Address is: #{result.ip_address} [#{result.dns_settings.fqdn}]"
-          state[:hostname] = result.ip_address
-          if config[:use_fqdn_hostname]
-            info "Using FQDN to communicate instead of IP"
-            state[:hostname] = result.dns_settings.fqdn
-          end
+      # Builds the ARM parameter values for the virtual machine deployment.
+      #
+      # @param state [Hash] instance state, already through {#validate_state}.
+      # @return [Hash] parameter name to value, ready for
+      #   {#parameters_in_values_format}.
+      def build_deployment_parameters(state)
+        parameters = {
+          location: config[:location],
+          vmSize: config[:machine_size],
+          storageAccountType: config[:storage_account_type],
+          bootDiagnosticsEnabled: config[:boot_diagnostics_enabled],
+          newStorageAccountName: "storage#{state[:uuid]}",
+          adminUsername: config[:username],
+          dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
+          vmName: state[:vm_name],
+          systemAssignedIdentity: config[:system_assigned_identity],
+          userAssignedIdentities: config[:user_assigned_identities].to_h { |identity| [identity, {}] },
+          secretUrl: config[:secret_url],
+          vaultName: config[:vault_name],
+          vaultResourceGroup: config[:vault_resource_group],
+        }
+
+        parameters[:adminPassword] = config[:password] if instance.transport[:ssh_key].nil?
+
+        parameters[:publicIPSKU] = config[:public_ip_sku]
+        parameters[:publicIPAddressType] = "Static" if config[:public_ip_sku] == "Standard"
+
+        parameters["nicName"] = nic_name(state)
+        parameters["customData"] = prepared_custom_data unless config[:custom_data].to_s.empty?
+
+        # When deploying into a shared storage account we need a unique suffix
+        # so that multiple kitchen instances do not collide on OS disk names.
+        unless config[:existing_storage_account_blob_url].to_s.empty?
+          parameters["osDiskNameSuffix"] = "-#{state[:azure_resource_group_name]}"
+          parameters["existingStorageAccountBlobURL"] = config[:existing_storage_account_blob_url]
+        end
+
+        parameters["existingStorageAccountBlobContainer"] = config[:existing_storage_account_container] unless config[:existing_storage_account_container].to_s.empty?
+        parameters["osDiskSizeGb"] = config[:os_disk_size_gb] unless config[:os_disk_size_gb].to_s.empty?
+
+        parameters.merge(image_parameters)
+      end
+
+      # ARM parameters describing which image the VM boots from.
+      #
+      # Exactly one of three modes applies, in precedence order: a managed image
+      # by resource id, a VHD URL, or a Marketplace image URN.
+      #
+      # @return [Hash]
+      def image_parameters
+        if config[:image_id].to_s != ""
+          { "imageId" => config[:image_id] }
+        elsif config[:image_url].to_s != ""
+          { "imageUrl" => config[:image_url], "osType" => config[:os_type] }
         else
-          # Retrieve the internal IP from the resource group:
-          result = get_network_interface(state[:azure_resource_group_name], vmnic.to_s)
-          info "IP Address is: #{result.ip_configurations[0].private_ipaddress}"
-          state[:hostname] = result.ip_configurations[0].private_ipaddress
+          publisher, offer, sku, version = config[:image_urn].split(":", 4)
+          { "imagePublisher" => publisher, "imageOffer" => offer, "imageSku" => sku, "imageVersion" => version }
         end
       end
 
-      # Return a True of False if the state is already stored for a particular property.
+      # Name of the network interface the VM is attached to.
+      #
+      # @param state [Hash] instance state.
+      # @return [String] +nic_name+ from config, or one derived from the VM name.
+      def nic_name(state)
+        config[:nic_name].to_s.empty? ? "nic-#{state[:vm_name]}" : config[:nic_name].to_s
+      end
+
+      # Submits a named deployment and blocks until it reaches an end state.
+      #
+      # @param state [Hash] instance state, used for the resource group and uuid.
+      # @param prefix [String] deployment name prefix, e.g. +"pre-deploy"+.
+      # @param deployment [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @return [void]
+      def run_deployment(state, prefix, deployment)
+        name = "#{prefix}-#{state[:uuid]}"
+        info "Creating deployment: #{name}"
+        create_deployment_async(state[:azure_resource_group_name], name, deployment).value!
+        follow_deployment_until_end_state(state[:azure_resource_group_name], name)
+      end
+
+      # Persists the generated admin credentials into instance state, when
+      # +store_deployment_credentials_in_state+ is enabled.
+      #
+      # No password is stored when the transport authenticates with an SSH key -
+      # there is no password in that case, and writing a +nil+ one leaves a
+      # misleading empty entry in the state file.
+      #
+      # @param state [Hash] instance state, mutated in place.
+      # @param deployment_parameters [Hash] as built by {#build_deployment_parameters}.
+      # @return [void]
+      def store_deployment_credentials(state, deployment_parameters)
+        return unless config[:store_deployment_credentials_in_state] == true
+
+        state[:username] = deployment_parameters[:adminUsername] unless existing_state_value?(state, :username)
+
+        return unless instance.transport[:ssh_key].nil?
+
+        state[:password] = deployment_parameters[:adminPassword] unless existing_state_value?(state, :password)
+      end
+
+      # Determines the address the transport should connect to.
+      #
+      # Uses the public IP (or its FQDN, when +use_fqdn_hostname+ is set) unless
+      # the instance was deployed into a caller-supplied vnet without a public IP,
+      # in which case the NIC's private address is used.
+      #
+      # @param state [Hash] instance state.
+      # @param vmnic [String] name of the network interface.
+      # @return [String] IP address or fully-qualified domain name.
+      def resolve_hostname(state, vmnic)
+        if config[:vnet_id] == "" || config[:public_ip]
+          result = get_public_ip(state[:azure_resource_group_name], "publicip")
+          info "IP Address is: #{result.ip_address} [#{result.dns_settings.fqdn}]"
+          if config[:use_fqdn_hostname]
+            info "Using FQDN to communicate instead of IP"
+            result.dns_settings.fqdn
+          else
+            result.ip_address
+          end
+        else
+          result = get_network_interface(state[:azure_resource_group_name], vmnic.to_s)
+          info "IP Address is: #{result.ip_configurations[0].private_ipaddress}"
+          result.ip_configurations[0].private_ipaddress
+        end
+      end
+
+      # Whether a state property is already populated.
       #
       # @param state [Hash] Hash of existing state values.
-      # @param property [String] A property to check
-      # @return [Boolean]
+      # @param property [Symbol, String] the property to check.
+      # @return [Boolean] true when the key exists and its value is not nil.
       def existing_state_value?(state, property)
         state.key?(property) && !state[property].nil?
       end
 
-      # Leverage existing state values or bring state into existence from a configuration file.
+      # Fills in any state values that are not already present.
       #
-      # @param state [Hash] Existing Hash of state values.
-      # @return [Hash] Updated Hash of state values.
+      # @param state [Hash] existing Hash of state values.
+      # @return [Hash] the same Hash, with defaults applied.
       def validate_state(state = {})
         state[:uuid] = SecureRandom.hex(8) unless existing_state_value?(state, :uuid)
-        state[:vm_name] = config[:vm_name] || "#{config[:vm_prefix]}#{state[:uuid][0..11]}" unless existing_state_value?(state, :vm_name)
+        state[:vm_name] = generated_vm_name(state) unless existing_state_value?(state, :vm_name)
         state[:server_id] = "vm#{state[:uuid]}" unless existing_state_value?(state, :server_id)
         state[:azure_resource_group_name] = azure_resource_group_name unless existing_state_value?(state, :azure_resource_group_name)
         %i{subscription_id azure_environment use_managed_disks}.each do |config_element|
@@ -394,268 +451,349 @@ module Kitchen
         state
       end
 
-      def azure_resource_group_name
-        formatted_time = Time.now.utc.strftime "%Y%m%dT%H%M%S"
-        return "#{config[:azure_resource_group_prefix]}#{config[:azure_resource_group_name]}-#{formatted_time}#{config[:azure_resource_group_suffix]}" unless config[:explicit_resource_group_name]
+      # Maximum length of a generated VM name.
+      #
+      # Windows computer names are capped at 15 characters, which is the lower
+      # of the two Azure limits, so we honour it for every platform.
+      #
+      # @return [Integer]
+      MAX_VM_NAME_LENGTH = 15
 
-        config[:explicit_resource_group_name]
+      # The VM name to use, either the configured one or one generated from
+      # +vm_prefix+ plus part of the instance uuid.
+      #
+      # The generated name is truncated to {MAX_VM_NAME_LENGTH} so that a
+      # +vm_prefix+ longer than the documented three characters still yields a
+      # name Azure will accept.
+      #
+      # @param state [Hash] instance state, must already have a +:uuid+.
+      # @return [String]
+      def generated_vm_name(state)
+        return config[:vm_name] if config[:vm_name]
+
+        prefix = config[:vm_prefix].to_s
+        remaining = MAX_VM_NAME_LENGTH - prefix.length
+        return prefix[0, MAX_VM_NAME_LENGTH] if remaining <= 0
+
+        "#{prefix}#{state[:uuid][0, remaining]}"
       end
 
+      # Name of the resource group this instance deploys into.
+      #
+      # @return [String] +explicit_resource_group_name+ when set, otherwise
+      #   prefix + instance name + UTC timestamp + suffix.
+      def azure_resource_group_name
+        return config[:explicit_resource_group_name] if config[:explicit_resource_group_name]
+
+        formatted_time = Time.now.utc.strftime "%Y%m%dT%H%M%S"
+        "#{config[:azure_resource_group_prefix]}#{config[:azure_resource_group_name]}-#{formatted_time}#{config[:azure_resource_group_suffix]}"
+      end
+
+      # JSON fragment describing the data disks to attach to the VM.
+      #
+      # @return [String, nil] a JSON array, or nil when no +data_disks+ are
+      #   configured. Unmanaged disk deployments always get an empty array and
+      #   a warning, as data disks require managed disks.
       def data_disks_for_vm_json
         return nil if config[:data_disks].nil?
 
-        disks = []
-
-        if config[:use_managed_disks]
-          config[:data_disks].each do |data_disk|
-            disks << { name: "datadisk#{data_disk[:lun]}", lun: data_disk[:lun], diskSizeGB: data_disk[:disk_size_gb], createOption: "Empty" }
-          end
-          debug "Additional disks being added to configuration: #{disks.inspect}"
-        else
+        unless config[:use_managed_disks]
           warn 'Data disks are only supported when used with the "use_managed_disks" option. No additional disks were added to the configuration.'
+          return [].to_json
         end
+
+        disks = config[:data_disks].map do |data_disk|
+          { name: "datadisk#{data_disk[:lun]}", lun: data_disk[:lun], diskSizeGB: data_disk[:disk_size_gb], createOption: "Empty" }
+        end
+        debug "Additional disks being added to configuration: #{disks.inspect}"
         disks.to_json
       end
 
+      # The deployment template, adjusted for the transport in use.
+      #
+      # WinRM instances get a custom data bootstrap script and unattend content;
+      # SSH instances get the public half of the transport's key injected into
+      # the Linux configuration.
+      #
+      # @return [String] the deployment template as JSON.
       def template_for_transport_name
         template = JSON.parse(virtual_machine_deployment_template)
-        if instance.transport.name.casecmp("winrm") == 0
-          if instance.platform.name.index("nano").nil?
-            info "Adding WinRM configuration to provisioning profile."
-            encoded_command = Base64.strict_encode64(custom_data_script_windows)
-            template["resources"].select { |h| h["type"] == "Microsoft.Compute/virtualMachines" }.each do |resource|
-              resource["properties"]["osProfile"]["customData"] = encoded_command
-              resource["properties"]["osProfile"]["windowsConfiguration"] = windows_unattend_content
-            end
+
+        if instance.transport.name.casecmp("winrm") == 0 && instance.platform.name.to_s.index("nano").nil?
+          info "Adding WinRM configuration to provisioning profile."
+          encoded_command = Base64.strict_encode64(custom_data_script_windows)
+          virtual_machine_resources(template).each do |resource|
+            resource["properties"]["osProfile"]["customData"] = encoded_command
+            resource["properties"]["osProfile"]["windowsConfiguration"] = windows_unattend_content
           end
         end
 
         unless instance.transport[:ssh_key].nil?
           info "Adding public key from #{File.expand_path(instance.transport[:ssh_key])}.pub to the deployment."
           public_key = public_key_for_deployment(File.expand_path(instance.transport[:ssh_key]))
-          template["resources"].select { |h| h["type"] == "Microsoft.Compute/virtualMachines" }.each do |resource|
+          virtual_machine_resources(template).each do |resource|
             resource["properties"]["osProfile"]["linuxConfiguration"] = JSON.parse(custom_linux_configuration(public_key))
           end
         end
+
         template.to_json
       end
 
+      # Selects the virtual machine resources from a parsed ARM template.
+      #
+      # @param template [Hash] a parsed ARM template.
+      # @return [Array<Hash>]
+      def virtual_machine_resources(template)
+        template["resources"].select { |resource| resource["type"] == "Microsoft.Compute/virtualMachines" }
+      end
+
+      # Returns the public key to inject into the deployment, generating a new
+      # key pair on disk when the configured private key does not yet exist.
+      #
+      # @param private_key_filename [String] path to the transport's private key.
+      # @return [String] the OpenSSH-format public key, stripped of whitespace.
       def public_key_for_deployment(private_key_filename)
-        if File.file?(private_key_filename) == false
-          k = SSHKey.generate
+        unless File.file?(private_key_filename)
+          key = SSHKey.generate
 
           ::FileUtils.mkdir_p(File.dirname(private_key_filename))
+          File.write(private_key_filename, key.private_key)
+          File.chmod(0600, private_key_filename)
+          File.write("#{private_key_filename}.pub", key.ssh_public_key)
+          File.chmod(0600, "#{private_key_filename}.pub")
 
-          private_key_file = File.new(private_key_filename, "w")
-          private_key_file.syswrite(k.private_key)
-          private_key_file.chmod(0600)
-          private_key_file.close
-
-          public_key_file = File.new("#{private_key_filename}.pub", "w")
-          public_key_file.syswrite(k.ssh_public_key)
-          public_key_file.chmod(0600)
-          public_key_file.close
-
-          output = k.ssh_public_key
-        else
-          output = if instance.transport[:ssh_public_key].nil?
-                     File.read("#{private_key_filename}.pub")
-                   else
-                     File.read(instance.transport[:ssh_public_key])
-                   end
+          return key.ssh_public_key.strip
         end
-        output.strip
+
+        public_key_filename = instance.transport[:ssh_public_key] || "#{private_key_filename}.pub"
+        File.read(public_key_filename).strip
       end
 
+      # Builds the pre-deployment from a caller-supplied ARM template file.
+      #
+      # @param pre_deployment_template_filename [String] path to an ARM template.
+      # @param pre_deployment_parameters [Hash] parameter name to value.
+      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
       def pre_deployment(pre_deployment_template_filename, pre_deployment_parameters)
-        pre_deployment_template = ::File.read(pre_deployment_template_filename)
-        pre_deployment = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment.new
-        pre_deployment.properties = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentProperties.new
-        pre_deployment.properties.mode = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Incremental
-        pre_deployment.properties.template = JSON.parse(pre_deployment_template)
-        pre_deployment.properties.parameters = parameters_in_values_format(pre_deployment_parameters)
-        debug(pre_deployment.properties.template)
-        pre_deployment
+        build_deployment(::File.read(pre_deployment_template_filename), pre_deployment_parameters)
       end
 
+      # Builds the virtual machine deployment.
+      #
+      # @param parameters [Hash] parameter name to value.
+      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
       def deployment(parameters)
-        template = template_for_transport_name
-        deployment = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment.new
-        deployment.properties = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentProperties.new
-        deployment.properties.mode = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Incremental
-        deployment.properties.template = JSON.parse(template)
-        deployment.properties.parameters = parameters_in_values_format(parameters)
+        deployment = build_deployment(template_for_transport_name, parameters)
         debug(JSON.pretty_generate(deployment.properties.template))
         deployment
       end
 
+      # Builds the post-deployment from a caller-supplied ARM template file.
+      #
+      # @param post_deployment_template_filename [String] path to an ARM template.
+      # @param post_deployment_parameters [Hash] parameter name to value.
+      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
       def post_deployment(post_deployment_template_filename, post_deployment_parameters)
-        post_deployment_template = ::File.read(post_deployment_template_filename)
-        post_deployment = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment.new
-        post_deployment.properties = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentProperties.new
-        post_deployment.properties.mode = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Incremental
-        post_deployment.properties.template = JSON.parse(post_deployment_template)
-        post_deployment.properties.parameters = parameters_in_values_format(post_deployment_parameters)
-        debug(post_deployment.properties.template)
-        post_deployment
+        build_deployment(::File.read(post_deployment_template_filename), post_deployment_parameters)
       end
 
+      # An empty Complete-mode deployment, used to delete every resource inside
+      # a resource group while leaving the group itself in place.
+      #
+      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
       def empty_deployment
-        template = virtual_machine_deployment_template_file("empty.erb", nil)
-        empty_deployment = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment.new
-        empty_deployment.properties = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentProperties.new
-        empty_deployment.properties.mode = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Complete
-        empty_deployment.properties.template = JSON.parse(template)
-        debug(JSON.pretty_generate(empty_deployment.properties.template))
-        empty_deployment
+        deployment = build_deployment(virtual_machine_deployment_template_file("empty.erb", nil), nil, mode: ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Complete)
+        debug(JSON.pretty_generate(deployment.properties.template))
+        deployment
       end
 
+      # Assembles an ARM deployment object.
+      #
+      # @param template [String] the ARM template as JSON.
+      # @param parameters [Hash, nil] parameter name to value, or nil for none.
+      # @param mode [String] the ARM deployment mode.
+      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      def build_deployment(template, parameters, mode: ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Incremental)
+        deployment = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment.new
+        deployment.properties = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentProperties.new
+        deployment.properties.mode = mode
+        deployment.properties.template = JSON.parse(template)
+        deployment.properties.parameters = parameters_in_values_format(parameters) if parameters
+        deployment
+      end
+
+      # Renders resource tags as a JSON object body (no surrounding braces), for
+      # interpolation into the ERB deployment templates.
+      #
+      # Keys and values are JSON-encoded so that tags containing quotes or
+      # backslashes cannot produce an unparseable template.
+      #
+      # @param vm_tags_in [Hash] tag name to value.
+      # @return [String] e.g. +"os_type": "linux",\n"distro": "redhat"+
       def vm_tag_string(vm_tags_in)
-        tag_string = ""
-        unless vm_tags_in.empty?
-          tag_array = vm_tags_in.map do |key, value|
-            "\"#{key}\": \"#{value}\",\n"
-          end
-          # Strip punctuation from last item
-          tag_array[-1] = tag_array[-1][0..-3]
-          tag_string = tag_array.join
-        end
-        tag_string
+        return "" if vm_tags_in.nil? || vm_tags_in.empty?
+
+        vm_tags_in.map { |key, value| "#{key.to_s.to_json}: #{value.to_s.to_json}" }.join(",\n")
       end
 
+      # Converts a flat parameter Hash into the ARM +{name: {"value" => v}}+ shape.
+      #
+      # @param parameters_in [Hash] parameter name to value.
+      # @return [Hash, nil] nil when +parameters_in+ is empty.
       def parameters_in_values_format(parameters_in)
-        parameters = parameters_in.map do |key, value|
-          { key.to_sym => { "value" => value } }
+        return nil if parameters_in.nil? || parameters_in.empty?
+
+        parameters_in.each_with_object({}) do |(key, value), acc|
+          acc[key.to_sym] = { "value" => value }
         end
-        parameters.reduce(:merge!)
       end
 
+      # Polls a deployment until it reaches a terminal provisioning state,
+      # logging the resources still in flight along the way.
+      #
+      # @param resource_group [String] the resource group name.
+      # @param deployment_name [String] the deployment name.
+      # @return [void]
+      # @raise [RuntimeError] with the Azure status message if the deployment failed.
       def follow_deployment_until_end_state(resource_group, deployment_name)
-        end_provisioning_states = "Canceled,Failed,Deleted,Succeeded"
-        end_provisioning_state_reached = false
-        until end_provisioning_state_reached
+        end_provisioning_states = %w{Canceled Failed Deleted Succeeded}
+        deployment_provisioning_state = nil
+
+        until end_provisioning_states.include?(deployment_provisioning_state)
           list_outstanding_deployment_operations(resource_group, deployment_name)
           sleep config[:deployment_sleep]
           deployment_provisioning_state = get_deployment_state(resource_group, deployment_name)
-          end_provisioning_state_reached = end_provisioning_states.split(",").include?(deployment_provisioning_state)
         end
+
         info "Resource Template deployment reached end state of '#{deployment_provisioning_state}'."
         show_failed_operations(resource_group, deployment_name) if deployment_provisioning_state == "Failed"
       end
 
+      # Raises with the status messages of every failed operation in a deployment.
+      #
+      # @param resource_group [String] the resource group name.
+      # @param deployment_name [String] the deployment name.
+      # @return [void]
+      # @raise [RuntimeError] if any operation reported a non-OK status code.
       def show_failed_operations(resource_group, deployment_name)
-        failed_operations = list_deployment_operations(resource_group, deployment_name)
-        failed_operations.each do |val|
-          resource_code = val.properties.status_code
-          raise val.properties.status_message.inspect if resource_code != "OK"
+        failures = list_deployment_operations(resource_group, deployment_name).reject do |operation|
+          operation.properties.status_code == "OK"
         end
+        return if failures.empty?
+
+        raise failures.map { |operation| operation.properties.status_message.inspect }.join("\n")
       end
 
+      # Logs every deployment operation that has not yet reached a terminal state.
+      #
+      # @param resource_group [String] the resource group name.
+      # @param deployment_name [String] the deployment name.
+      # @return [void]
       def list_outstanding_deployment_operations(resource_group, deployment_name)
-        end_operation_states = "Failed,Succeeded"
-        deployment_operations = list_deployment_operations(resource_group, deployment_name)
-        deployment_operations.each do |val|
-          resource_provisioning_state = val.properties.provisioning_state
-          unless val.properties.target_resource.nil?
-            resource_name = val.properties.target_resource.resource_name
-            resource_type = val.properties.target_resource.resource_type
-          end
-          end_operation_state_reached = end_operation_states.split(",").include?(resource_provisioning_state)
-          unless end_operation_state_reached
-            info "Resource #{resource_type} '#{resource_name}' provisioning status is #{resource_provisioning_state}"
-          end
+        end_operation_states = %w{Failed Succeeded}
+        list_deployment_operations(resource_group, deployment_name).each do |operation|
+          resource_provisioning_state = operation.properties.provisioning_state
+          next if end_operation_states.include?(resource_provisioning_state)
+
+          target = operation.properties.target_resource
+          info "Resource #{target&.resource_type} '#{target&.resource_name}' provisioning status is #{resource_provisioning_state}"
         end
       end
 
+      # Tears down whatever {#create} built.
+      #
+      # @param state [Hash] the instance state, mutated in place.
+      # @return [void]
+      # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails.
       def destroy(state)
         # TODO: We have some not so fun state issues we need to clean up
         state[:azure_environment] = config[:azure_environment] unless state[:azure_environment]
         state[:subscription_id] = config[:subscription_id] unless state[:subscription_id]
 
-        # Setup our authentication components for the SDK
         options = Kitchen::Driver::AzureCredentials.new(subscription_id: state[:subscription_id],
           environment: state[:azure_environment]).azure_options
         @resource_management_client = ::Azure::Resources2::Profiles::Latest::Mgmt::Client.new(options)
 
-        # If we don't have any instances, let's check to see if the user wants to delete a resource group and if so let's delete!
-        if state[:server_id].nil? && state[:azure_resource_group_name].nil? && !config[:explicit_resource_group_name].nil? && config[:destroy_explicit_resource_group]
-          if resource_group_exists?(config[:explicit_resource_group_name])
-            info "This instance doesn't exist but you asked to delete the resource group."
-            begin
-              info "Destroying Resource Group: #{config[:explicit_resource_group_name]}"
-              delete_resource_group_async(config[:explicit_resource_group_name])
-              info "Destroy operation accepted and will continue in the background."
-              return
-            rescue ::MsRestAzure2::AzureOperationError => operation_error
-              error operation_error.body
-              raise operation_error
-            end
-          end
-        end
+        return if destroy_orphaned_explicit_resource_group(state)
 
-        # Our working environment
         info "Azure environment: #{state[:azure_environment]}"
 
-        # Skip if we don't have any instances
+        # Nothing was ever created for this instance.
         return if state[:server_id].nil?
 
-        # Destroy resource group contents
-        if config[:destroy_resource_group_contents] == true
-          info "Destroying individual resources within the Resource Group."
-          empty_deployment_name = "empty-deploy-#{state[:uuid]}"
-          begin
-            info "Creating deployment: #{empty_deployment_name}"
-            create_deployment_async(state[:azure_resource_group_name], empty_deployment_name, empty_deployment).value!
-            follow_deployment_until_end_state(state[:azure_resource_group_name], empty_deployment_name)
+        destroy_resource_group_contents(state) if config[:destroy_resource_group_contents] == true
 
-            # NOTE: We are using the internal wrapper function create_resource_group() which wraps the API
-            # method of create_or_update()
-            begin
-              # Maintain tags on the resource group
-              create_resource_group(state[:azure_resource_group_name], get_resource_group) unless config[:destroy_explicit_resource_group_tags] == true
-              warn 'The "destroy_explicit_resource_group_tags" setting value is set to "false". The tags on the resource group will NOT be removed.' unless config[:destroy_explicit_resource_group_tags] == true
-              # Corner case where we want to use kitchen to remove the tags
-              resource_group = get_resource_group
-              resource_group.tags = {}
-              create_resource_group(state[:azure_resource_group_name], resource_group) unless config[:destroy_explicit_resource_group_tags] == false
-              warn 'The "destroy_explicit_resource_group_tags" setting value is set to "true". The tags on the resource group will be removed.' unless config[:destroy_explicit_resource_group_tags] == false
-            rescue ::MsRestAzure2::AzureOperationError => operation_error
-              error operation_error.body
-              raise operation_error
-            end
-
-          rescue ::MsRestAzure2::AzureOperationError => operation_error
-            error operation_error.body
-            raise operation_error
-          end
-        end
-
-        # Do not remove the explicitly named resource group
         if config[:destroy_explicit_resource_group] == false && !config[:explicit_resource_group_name].nil?
           warn 'The "destroy_explicit_resource_group" setting value is set to "false". The resource group will not be deleted.'
           warn 'Remember to manually destroy resources, or set "destroy_resource_group_contents: true" to save costs!' unless config[:destroy_resource_group_contents] == true
           return state
         end
 
-        # Destroy the world
         begin
           info "Destroying Resource Group: #{state[:azure_resource_group_name]}"
           delete_resource_group_async(state[:azure_resource_group_name])
           info "Destroy operation accepted and will continue in the background."
-          # Remove resource group name from driver state
           state.delete(:azure_resource_group_name)
         rescue ::MsRestAzure2::AzureOperationError => operation_error
           error operation_error.body
           raise operation_error
         end
 
-        # Clear state of components
         state.delete(:server_id)
         state.delete(:hostname)
         state.delete(:username)
         state.delete(:password)
       end
 
+      # Deletes an explicitly-named resource group when the instance itself was
+      # never created but the user asked for the group to be removed.
+      #
+      # @param state [Hash] the instance state.
+      # @return [Boolean] true when the group was deleted and {#destroy} should stop.
+      # @raise [MsRestAzure2::AzureOperationError] if the delete request fails.
+      def destroy_orphaned_explicit_resource_group(state)
+        return false unless state[:server_id].nil? && state[:azure_resource_group_name].nil?
+        return false if config[:explicit_resource_group_name].nil?
+        return false unless config[:destroy_explicit_resource_group]
+        return false unless resource_group_exists?(config[:explicit_resource_group_name])
+
+        info "This instance doesn't exist but you asked to delete the resource group."
+        info "Destroying Resource Group: #{config[:explicit_resource_group_name]}"
+        delete_resource_group_async(config[:explicit_resource_group_name])
+        info "Destroy operation accepted and will continue in the background."
+        true
+      rescue ::MsRestAzure2::AzureOperationError => operation_error
+        error operation_error.body
+        raise operation_error
+      end
+
+      # Empties a resource group by deploying an empty template in Complete
+      # mode, then restores or clears the group's tags per configuration.
+      #
+      # @param state [Hash] the instance state.
+      # @return [void]
+      # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails.
+      def destroy_resource_group_contents(state)
+        info "Destroying individual resources within the Resource Group."
+        run_deployment(state, "empty-deploy", empty_deployment)
+
+        if config[:destroy_explicit_resource_group_tags] == false
+          warn 'The "destroy_explicit_resource_group_tags" setting value is set to "false". The tags on the resource group will NOT be removed.'
+          create_resource_group(state[:azure_resource_group_name], get_resource_group)
+        else
+          warn 'The "destroy_explicit_resource_group_tags" setting value is set to "true". The tags on the resource group will be removed.'
+          resource_group = get_resource_group
+          resource_group.tags = {}
+          create_resource_group(state[:azure_resource_group_name], resource_group)
+        end
+      rescue ::MsRestAzure2::AzureOperationError => operation_error
+        error operation_error.body
+        raise operation_error
+      end
+
+      # PowerShell that opens the WinRM HTTP and HTTPS listeners and firewall ports.
+      #
+      # @return [String] the configured script, or the built-in default.
       def enable_winrm_powershell_script
         config[:winrm_powershell_script] ||
           <<-PS1
@@ -670,6 +808,9 @@ module Kitchen
           PS1
       end
 
+      # PowerShell that initialises and NTFS-formats every raw data disk.
+      #
+      # @return [String, nil] nil unless +format_data_disks+ is enabled.
       def format_data_disks_powershell_script
         return unless config[:format_data_disks]
 
@@ -701,6 +842,9 @@ module Kitchen
           PS1
       end
 
+      # The full first-boot script handed to a Windows VM as custom data.
+      #
+      # @return [String]
       def custom_data_script_windows
         <<-EOH
   #{enable_winrm_powershell_script}
@@ -709,22 +853,29 @@ module Kitchen
         EOH
       end
 
+      # The ARM +linuxConfiguration+ block that installs an SSH public key and
+      # disables password authentication.
+      #
+      # @param public_key [String] an OpenSSH-format public key.
+      # @return [String] JSON.
       def custom_linux_configuration(public_key)
-        <<-EOH
         {
-          "disablePasswordAuthentication": "true",
-          "ssh": {
-            "publicKeys": [
+          "disablePasswordAuthentication" => "true",
+          "ssh" => {
+            "publicKeys" => [
               {
-                "path": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-                "keyData": "#{public_key}"
-              }
-            ]
-          }
-        }
-        EOH
+                "path" => "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+                "keyData" => public_key,
+              },
+            ],
+          },
+        }.to_json
       end
 
+      # The ARM +windowsConfiguration+ block that runs the custom data script on
+      # first logon.
+      #
+      # @return [Hash]
       def windows_unattend_content
         {
           additionalUnattendContent: [
@@ -744,66 +895,112 @@ module Kitchen
         }
       end
 
+      # Renders the virtual machine ARM template for the current configuration.
+      #
+      # Uses +internal.erb+ when the instance deploys into a caller-supplied
+      # vnet, otherwise +public.erb+.
+      #
+      # @return [String] the rendered ARM template as JSON.
       def virtual_machine_deployment_template
-        if config[:vnet_id] == ""
-          virtual_machine_deployment_template_file("public.erb", vm_tags: vm_tag_string(config[:vm_tags]), use_managed_disks: config[:use_managed_disks], image_url: config[:image_url], storage_account_type: config[:storage_account_type], existing_storage_account_blob_url: config[:existing_storage_account_blob_url], image_id: config[:image_id], existing_storage_account_container: config[:existing_storage_account_container], custom_data: config[:custom_data], os_disk_size_gb: config[:os_disk_size_gb], data_disks_for_vm_json:, use_ephemeral_osdisk: config[:use_ephemeral_osdisk], ssh_key: instance.transport[:ssh_key], plan_json:)
+        data = {
+          vm_tags: vm_tag_string(config[:vm_tags]),
+          use_managed_disks: config[:use_managed_disks],
+          image_url: config[:image_url],
+          storage_account_type: config[:storage_account_type],
+          existing_storage_account_blob_url: config[:existing_storage_account_blob_url],
+          image_id: config[:image_id],
+          existing_storage_account_container: config[:existing_storage_account_container],
+          custom_data: config[:custom_data],
+          os_disk_size_gb: config[:os_disk_size_gb],
+          data_disks_for_vm_json:,
+          use_ephemeral_osdisk: config[:use_ephemeral_osdisk],
+          ssh_key: instance.transport[:ssh_key],
+          plan_json:,
+          secret_url: config[:secret_url],
+          vault_name: config[:vault_name],
+          vault_resource_group: config[:vault_resource_group],
+        }
+
+        if config[:vnet_id].to_s.empty?
+          virtual_machine_deployment_template_file("public.erb", data)
         else
           info "Using custom vnet: #{config[:vnet_id]}"
-          virtual_machine_deployment_template_file("internal.erb", vnet_id: config[:vnet_id], subnet_id: config[:subnet_id], public_ip: config[:public_ip], vm_tags: vm_tag_string(config[:vm_tags]), use_managed_disks: config[:use_managed_disks], image_url: config[:image_url], storage_account_type: config[:storage_account_type], existing_storage_account_blob_url: config[:existing_storage_account_blob_url], image_id: config[:image_id], existing_storage_account_container: config[:existing_storage_account_container], custom_data: config[:custom_data], os_disk_size_gb: config[:os_disk_size_gb], data_disks_for_vm_json:, use_ephemeral_osdisk: config[:use_ephemeral_osdisk], ssh_key: instance.transport[:ssh_key], public_ip_sku: config[:public_ip_sku], plan_json:)
+          virtual_machine_deployment_template_file("internal.erb", data.merge(
+            vnet_id: config[:vnet_id],
+            subnet_id: config[:subnet_id],
+            public_ip: config[:public_ip],
+            public_ip_sku: config[:public_ip_sku]
+          ))
         end
       end
 
+      # Marketplace purchase plan for the image, when one is configured.
+      #
+      # @return [String, nil] JSON, or nil when no +plan+ is configured.
       def plan_json
-        return nil if config[:plan].empty?
+        plan_config = config[:plan]
+        return nil if plan_config.nil? || plan_config.empty?
 
         plan = {}
-        plan["name"] = config[:plan][:name]                    if config[:plan][:name]
-        plan["product"] = config[:plan][:product]              if config[:plan][:product]
-        plan["promotionCode"] = config[:plan][:promotion_code] if config[:plan][:promotion_code]
-        plan["publisher"] = config[:plan][:publisher]          if config[:plan][:publisher]
+        plan["name"] = plan_config[:name]                    if plan_config[:name]
+        plan["product"] = plan_config[:product]              if plan_config[:product]
+        plan["promotionCode"] = plan_config[:promotion_code] if plan_config[:promotion_code]
+        plan["publisher"] = plan_config[:publisher]          if plan_config[:publisher]
 
         plan.to_json
       end
 
+      # Renders one of the bundled ERB templates.
+      #
+      # @param template_file [String] file name within +templates/+.
+      # @param data [Hash, nil] values exposed to the template.
+      # @return [String] the rendered template.
       def virtual_machine_deployment_template_file(template_file, data = {})
         template = File.read(File.expand_path(File.join(__dir__, "../../../templates", template_file)))
         render_binding = OpenStruct.new(data)
         ERB.new(template, trim_mode: "-").result(render_binding.instance_eval { binding })
       end
 
-      def resource_manager_endpoint_url(azure_environment)
-        case azure_environment.downcase
-        when "azureusgovernment"
-          MsRestAzure2::AzureEnvironments::AzureUSGovernment.resource_manager_endpoint_url
-        when "azurechina"
-          MsRestAzure2::AzureEnvironments::AzureChinaCloud.resource_manager_endpoint_url
-        when "azuregermancloud"
-          MsRestAzure2::AzureEnvironments::AzureGermanCloud.resource_manager_endpoint_url
-        when "azure"
-          MsRestAzure2::AzureEnvironments::AzureCloud.resource_manager_endpoint_url
-        end
-      end
-
+      # Base64-encoded custom data for the VM.
+      #
+      # +custom_data+ may be either the literal content or a path to a file
+      # holding it.
+      #
+      # @return [String, nil] nil when no +custom_data+ is configured.
       def prepared_custom_data
-        # If user_data is a file reference, lets read it as such
         return nil if config[:custom_data].nil?
 
-        @custom_data ||= if File.file?(config[:custom_data])
-                           Base64.strict_encode64(File.read(config[:custom_data]))
-                         else
-                           Base64.strict_encode64(config[:custom_data])
-                         end
+        @prepared_custom_data ||= if readable_file?(config[:custom_data])
+                                    Base64.strict_encode64(File.read(config[:custom_data]))
+                                  else
+                                    Base64.strict_encode64(config[:custom_data])
+                                  end
       end
 
       private
+
+      # Whether a string can safely be treated as a path to an existing file.
+      #
+      # +custom_data+ is frequently a multi-line cloud-init document, which is
+      # not a path and which +File.file?+ may reject outright, so screen those
+      # out before touching the filesystem.
+      #
+      # @param path [String]
+      # @return [Boolean]
+      def readable_file?(path)
+        string = path.to_s
+        return false if string.empty? || string.include?("\n") || string.include?("\0")
+
+        File.file?(string)
+      end
 
       #
       # Wrapper methods for the Azure API calls to retry the calls when getting timeouts.
       #
 
-      # Create a new resource group object and set the location and tags attributes then return it.
+      # A new resource group object carrying the configured location and tags.
       #
-      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup] A new resource group object.
+      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup]
       def get_resource_group
         resource_group = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup.new
         resource_group.location = config[:location]
@@ -811,129 +1008,126 @@ module Kitchen
         resource_group
       end
 
+      # Runs an Azure API call, retrying on transient connection failures.
+      #
+      # @param description [String] describes the call, used in retry logging.
+      # @yield the API call to run.
+      # @return [Object] whatever the block returns.
+      # @raise [Faraday::Error] once the retry budget is exhausted.
+      def with_azure_retries(description)
+        retries = config[:azure_api_retries]
+        begin
+          yield
+        rescue Faraday::TimeoutError, Faraday::ClientError => exception
+          send_exception_message(exception, "#{description} #{retries} retries left.")
+          raise if retries <= 0
+
+          retries -= 1
+          retry
+        end
+      end
+
       # Checks whether a resource group exists.
       #
-      # @param resource_group_name [String] The name of the resource group to check.
-      # The name is case insensitive.
-      #
-      # @return [Boolean] operation results.
-      #
+      # @param resource_group_name [String] case-insensitive resource group name.
+      # @return [Boolean]
       def resource_group_exists?(resource_group_name)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while checking if resource group '#{resource_group_name}' exists.") do
           resource_management_client.resource_groups.check_existence(resource_group_name)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while checking if resource group '#{resource_group_name}' exists. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Creates or updates a resource group.
+      #
+      # @param resource_group_name [String] the resource group name.
+      # @param resource_group [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup]
+      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup]
       def create_resource_group(resource_group_name, resource_group)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while creating resource group '#{resource_group_name}'.") do
           resource_management_client.resource_groups.create_or_update(resource_group_name, resource_group)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while creating resource group '#{resource_group_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Submits a deployment without waiting for it to complete.
+      #
+      # @param resource_group [String] the resource group name.
+      # @param deployment_name [String] the deployment name.
+      # @param deployment [::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @return [Concurrent::Promise] resolves once the request is accepted.
       def create_deployment_async(resource_group, deployment_name, deployment)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while sending deployment creation request for deployment '#{deployment_name}'.") do
           resource_management_client.deployments.begin_create_or_update_async(resource_group, deployment_name, deployment)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while sending deployment creation request for deployment '#{deployment_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Fetches a public IP resource.
+      #
+      # @param resource_group_name [String] the resource group name.
+      # @param public_ip_name [String] the public IP resource name.
+      # @return [Object] the public IP address resource.
       def get_public_ip(resource_group_name, public_ip_name)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while fetching public ip '#{public_ip_name}' for resource group '#{resource_group_name}'.") do
           network_management_client.public_ipaddresses.get(resource_group_name, public_ip_name)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while fetching public ip '#{public_ip_name}' for resource group '#{resource_group_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Fetches a network interface resource.
+      #
+      # @param resource_group_name [String] the resource group name.
+      # @param network_interface_name [String] the NIC name.
+      # @return [Object] the network interface resource.
       def get_network_interface(resource_group_name, network_interface_name)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while fetching network interface '#{network_interface_name}' for resource group '#{resource_group_name}'.") do
           network_interfaces = ::Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces.new(network_management_client)
           network_interfaces.get(resource_group_name, network_interface_name)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while fetching network interface '#{network_interface_name}' for resource group '#{resource_group_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Lists every operation belonging to a deployment.
+      #
+      # @param resource_group [String] the resource group name.
+      # @param deployment_name [String] the deployment name.
+      # @return [Array<Object>]
       def list_deployment_operations(resource_group, deployment_name)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while listing deployment operations for deployment '#{deployment_name}'.") do
           resource_management_client.deployment_operations.list(resource_group, deployment_name)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while listing deployment operations for deployment '#{deployment_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Reads a deployment's current provisioning state.
+      #
+      # @param resource_group [String] the resource group name.
+      # @param deployment_name [String] the deployment name.
+      # @return [String] e.g. +"Running"+, +"Succeeded"+, +"Failed"+.
       def get_deployment_state(resource_group, deployment_name)
-        retries = config[:azure_api_retries]
-        begin
-          deployments = resource_management_client.deployments.get(resource_group, deployment_name)
-          deployments.properties.provisioning_state
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while retrieving state for deployment '#{deployment_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
+        with_azure_retries("while retrieving state for deployment '#{deployment_name}'.") do
+          resource_management_client.deployments.get(resource_group, deployment_name).properties.provisioning_state
         end
       end
 
+      # Requests deletion of a resource group without waiting for it to finish.
+      #
+      # @param resource_group_name [String] the resource group name.
+      # @return [Object] the operation response.
       def delete_resource_group_async(resource_group_name)
-        retries = config[:azure_api_retries]
-        begin
+        with_azure_retries("while sending resource group deletion request for '#{resource_group_name}'.") do
           resource_management_client.resource_groups.begin_delete(resource_group_name)
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
-          send_exception_message(exception, "while sending resource group deletion request for '#{resource_group_name}'. #{retries} retries left.")
-          raise if retries == 0
-
-          retries -= 1
-          retry
         end
       end
 
+      # Logs a human-readable reason for a retryable Azure API failure.
+      #
+      # @param exception [Exception] the raised error.
+      # @param message [String] context describing what was being attempted.
+      # @return [void]
       def send_exception_message(exception, message)
-        if exception.is_a?(Faraday::TimeoutError)
-          header = "Timed out"
-        elsif exception.is_a?(Faraday::ClientError)
-          header = "Connection reset by peer"
-        else
-          # Unhandled exception, return early
-          info "Unrecognized exception type."
-          return
-        end
+        header = case exception
+                 when Faraday::TimeoutError then "Timed out"
+                 when Faraday::ClientError then "Connection reset by peer"
+                 else
+                   info "Unrecognized exception type."
+                   return
+                 end
         info "#{header} #{message}"
       end
     end

--- a/lib/kitchen/driver/azurerm_version.rb
+++ b/lib/kitchen/driver/azurerm_version.rb
@@ -1,5 +1,11 @@
 module Kitchen
   module Driver
+    # Version of the kitchen-azurerm gem.
+    #
+    # Kept in its own file so the gemspec can read it without loading the
+    # driver and, with it, the whole Azure SDK.
+    #
+    # @return [String]
     AZURERM_VERSION = "1.13.6".freeze
   end
 end

--- a/spec/fixtures/azure_credentials
+++ b/spec/fixtures/azure_credentials
@@ -1,14 +1,21 @@
-# For client_id && client_secret tests
+# Fake credentials, one section per authentication shape the driver supports.
+# None of these values are real; they exist only so the INI parsing and token
+# provider selection can be exercised without touching Azure.
+
+# Service principal: client_id + client_secret + tenant_id
 [f02932df-7e1d-410f-b094-c626d447f4dc]
 client_id = "b5f3d6df-00bf-4451-a4f2-db3bc7731b58"
 client_secret = ":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV["
 tenant_id = "19d3ea3e-ea8f-48f3-9f7a-00ae2810991f"
 
-# For MSI test, with client_id
+# User-assigned managed identity: client_id + tenant_id
 [5d801ddc-acf4-406b-9830-587ca2c6fd80]
 client_id = "2801f9e6-c4c2-4667-a6e1-479f8827b0af"
 tenant_id = "1ba5986d-52e1-49eb-a77e-155b7440695f"
 
-# For MSI test, no client_id
+# System-assigned managed identity: tenant_id only
 [7c664d3f-6dca-4e6d-9637-13dadbbe59d3]
 tenant_id = "76d8fa56-d867-4819-9894-f6dd4e1d2079"
+
+# No usable credentials at all: falls back to the `az login` token cache
+[9f8b8a02-6e6e-4a1c-9d0f-8b3f0c2ec4a1]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -11,8 +10,88 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "rspec/its"
+require "simplecov"
+
+SimpleCov.start do
+  add_filter "/spec/"
+  enable_coverage :branch
+  # Only enforce the floor on a full-suite run; running a single spec file
+  # legitimately covers far less than the whole driver.
+  # The only uncovered branches are the `require "x" unless defined?(X)` guards
+  # at the top of the driver, which cannot both be taken in one process.
+  minimum_coverage(line: 100, branch: 95) if ARGV.grep(/_spec\.rb/).empty?
+end
+
+require "stringio"
+require "tmpdir"
+require "json"
+require "webmock/rspec"
+
+require "kitchen"
+require "kitchen/transport/dummy"
+
 require "ms_rest2"
 require "ms_rest_azure2"
 require "azure_mgmt_resources2"
+require "azure_mgmt_network2"
+
 require_relative "../lib/kitchen/driver/azurerm"
+
+Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |file| require file }
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.syntax = :expect
+    expectations.max_formatted_output_length = 400
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Fail loudly when a double is asked to stand in for a method the real
+    # object does not have. This is the single most valuable RSpec setting.
+    mocks.verify_partial_doubles = true
+    mocks.verify_doubled_constant_names = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.example_status_persistence_file_path = ".rspec_status"
+  config.default_formatter = "doc" if config.files_to_run.one?
+  config.order = :random
+  Kernel.srand config.seed
+
+  config.raise_errors_for_deprecations!
+
+  config.include EnvHelper
+  config.include DriverHelper
+  config.include AzureDoubles
+
+  # Restore the process environment after every example, so specs can set
+  # variables directly without leaking into their neighbours.
+  config.around do |example|
+    original_env = ENV.to_h
+    begin
+      example.run
+    ensure
+      ENV.replace(original_env)
+    end
+  end
+
+  # Point HOME at an empty directory so that no example can accidentally read
+  # the credentials of whoever is running the suite.
+  config.around do |example|
+    Dir.mktmpdir("kitchen-azurerm-home") do |home|
+      ENV["HOME"] = home
+      ENV.delete_if { |key, _| key.start_with?("AZURE_") }
+      example.run
+    end
+  end
+
+  # Silence Test Kitchen's logger. Examples that assert on log output replace
+  # it with their own StringIO-backed logger.
+  config.before do
+    Kitchen.logger = Kitchen::Logger.new(stdout: StringIO.new, level: :fatal, colorize: false)
+  end
+end

--- a/spec/support/azure_doubles.rb
+++ b/spec/support/azure_doubles.rb
@@ -1,0 +1,142 @@
+# Doubles and real SDK model objects standing in for the Azure Resource Manager
+# and Network management APIs.
+#
+# Where the SDK ships a plain model class (deployment operations, resource
+# groups) these helpers build the real object, so the driver is exercised
+# against the same attribute names Azure actually returns. Only the operation
+# groups that would perform HTTP are doubled.
+module AzureDoubles
+  RESOURCES = Azure::Resources2::Profiles::Latest::Mgmt
+  NETWORK = Azure::Network2::Profiles::Latest::Mgmt
+
+  # A doubled resource management client.
+  #
+  # @param resource_groups [Object] stand-in for the resource groups operations.
+  # @param deployments [Object] stand-in for the deployments operations.
+  # @param deployment_operations [Object] stand-in for the deployment operations.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def resource_client_double(resource_groups: resource_groups_double,
+    deployments: deployments_double,
+    deployment_operations: deployment_operations_double)
+    instance_double(RESOURCES::Client, resource_groups:, deployments:, deployment_operations:)
+  end
+
+  # @param exists [Boolean] what +check_existence+ reports.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def resource_groups_double(exists: true)
+    instance_double(RESOURCES::ResourceGroups, check_existence: exists, create_or_update: nil, begin_delete: nil)
+  end
+
+  # @param provisioning_state [String] the state reported by +get+.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def deployments_double(provisioning_state: "Succeeded")
+    instance_double(
+      RESOURCES::Deployments,
+      begin_create_or_update_async: accepted_request,
+      get: deployment_extended(provisioning_state)
+    )
+  end
+
+  # @param operations [Array] deployment operations returned by +list+.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def deployment_operations_double(operations: [])
+    instance_double(RESOURCES::DeploymentOperations, list: operations)
+  end
+
+  # The value returned by the SDK's +*_async+ methods: something answering
+  # +value!+ once the request has been accepted.
+  #
+  # @return [RSpec::Mocks::Double]
+  def accepted_request
+    double("MsRest::Promise", value!: nil)
+  end
+
+  # A real +DeploymentExtended+ carrying a provisioning state.
+  #
+  # @param provisioning_state [String]
+  # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentExtended]
+  def deployment_extended(provisioning_state)
+    deployment = RESOURCES::Models::DeploymentExtended.new
+    deployment.properties = RESOURCES::Models::DeploymentPropertiesExtended.new
+    deployment.properties.provisioning_state = provisioning_state
+    deployment
+  end
+
+  # A real +DeploymentOperation+.
+  #
+  # @param provisioning_state [String] e.g. +"Running"+ or +"Succeeded"+.
+  # @param status_code [String] e.g. +"OK"+ or +"Conflict"+.
+  # @param status_message [String, nil] Azure's failure detail.
+  # @param resource_name [String, nil] name of the resource being operated on.
+  # @param resource_type [String, nil] type of the resource being operated on.
+  # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentOperation]
+  def deployment_operation(provisioning_state: "Succeeded", status_code: "OK", status_message: nil,
+    resource_name: nil, resource_type: nil)
+    operation = RESOURCES::Models::DeploymentOperation.new
+    operation.properties = RESOURCES::Models::DeploymentOperationProperties.new
+    operation.properties.provisioning_state = provisioning_state
+    operation.properties.status_code = status_code
+    operation.properties.status_message = status_message
+
+    if resource_name || resource_type
+      operation.properties.target_resource = RESOURCES::Models::TargetResource.new
+      operation.properties.target_resource.resource_name = resource_name
+      operation.properties.target_resource.resource_type = resource_type
+    end
+
+    operation
+  end
+
+  # A doubled network management client.
+  #
+  # @param public_ipaddresses [Object] stand-in for the public IP operations.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def network_client_double(public_ipaddresses: public_ip_addresses_double)
+    instance_double(NETWORK::Client, public_ipaddresses:)
+  end
+
+  # @param ip_address [String] the address reported by +get+.
+  # @param fqdn [String] the DNS name reported by +get+.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def public_ip_addresses_double(ip_address: "40.121.0.1", fqdn: "kitchen-abc.eastus2.cloudapp.azure.com")
+    instance_double(NETWORK::PublicIPAddresses, get: public_ip(ip_address:, fqdn:))
+  end
+
+  # @param ip_address [String]
+  # @param fqdn [String]
+  # @return [RSpec::Mocks::Double]
+  def public_ip(ip_address: "40.121.0.1", fqdn: "kitchen-abc.eastus2.cloudapp.azure.com")
+    double("PublicIPAddress", ip_address:, dns_settings: double("PublicIPAddressDnsSettings", fqdn:))
+  end
+
+  # @param private_ip [String] the address of the NIC's first IP configuration.
+  # @return [RSpec::Mocks::Double]
+  def network_interface(private_ip: "10.0.0.4")
+    double("NetworkInterface", ip_configurations: [double("IPConfiguration", private_ipaddress: private_ip)])
+  end
+
+  # An +MsRestAzure2::AzureOperationError+ carrying an Azure error body.
+  #
+  # @param code [String] the Azure error code, e.g. +"DeploymentActive"+.
+  # @param message [String] the Azure error message.
+  # @return [MsRestAzure2::AzureOperationError]
+  def azure_operation_error(code:, message: "something went wrong")
+    error = MsRestAzure2::AzureOperationError.new("Azure operation failed")
+    error.body = { "error" => { "code" => code, "message" => message } }
+    error
+  end
+
+  # Wires a driver up so that every Azure client it constructs is a double.
+  #
+  # @param driver [Kitchen::Driver::Azurerm]
+  # @param resource_client [Object]
+  # @param network_client [Object]
+  # @return [void]
+  def stub_azure_clients(driver, resource_client: resource_client_double, network_client: network_client_double)
+    allow(RESOURCES::Client).to receive(:new).and_return(resource_client)
+    allow(NETWORK::Client).to receive(:new).and_return(network_client)
+    allow(Kitchen::Driver::AzureCredentials).to receive(:new).and_return(
+      instance_double(Kitchen::Driver::AzureCredentials, azure_options: { subscription_id: driver_config(driver)[:subscription_id] })
+    )
+  end
+end

--- a/spec/support/credentials_file_helper.rb
+++ b/spec/support/credentials_file_helper.rb
@@ -1,0 +1,64 @@
+require "fileutils"
+require "tmpdir"
+
+# Helpers for exercising the real Azure CLI credentials-file parsing path.
+#
+# These write an actual INI file into a temporary directory and point
+# +AZURE_CONFIG_FILE+ at it, so the tests drive +IniFile+ for real rather than
+# stubbing +File.file?+ and +IniFile.load+.
+module CredentialsFileHelper
+  # Subscription ids used by the fixture credentials file, one per
+  # authentication shape the driver supports.
+  SUBSCRIPTIONS = {
+    service_principal: "f02932df-7e1d-410f-b094-c626d447f4dc",
+    user_assigned_identity: "5d801ddc-acf4-406b-9830-587ca2c6fd80",
+    system_assigned_identity: "7c664d3f-6dca-4e6d-9637-13dadbbe59d3",
+    azure_cli: "9f8b8a02-6e6e-4a1c-9d0f-8b3f0c2ec4a1",
+  }.freeze
+
+  # Path of the fixture credentials file shipped with the suite.
+  #
+  # @return [String]
+  def fixture_credentials_path
+    File.expand_path("../fixtures/azure_credentials", __dir__)
+  end
+
+  # Copies the fixture credentials file somewhere writable and points
+  # +AZURE_CONFIG_FILE+ at the copy.
+  #
+  # @return [String] path of the credentials file now in use.
+  def use_fixture_credentials_file
+    use_credentials_file(File.read(fixture_credentials_path))
+  end
+
+  # Writes +content+ to a credentials file and points +AZURE_CONFIG_FILE+ at it.
+  #
+  # @param content [String] INI content.
+  # @return [String] path of the credentials file now in use.
+  def use_credentials_file(content)
+    path = File.join(tmp_home, "credentials.ini")
+    File.write(path, content)
+    ENV["AZURE_CONFIG_FILE"] = path
+    path
+  end
+
+  # Writes the fixture credentials file to the default location under +HOME+,
+  # without setting +AZURE_CONFIG_FILE+.
+  #
+  # @return [String] path of the credentials file now in use.
+  def use_default_location_credentials_file
+    path = Kitchen::Driver::AzureCredentials.default_config_path
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, File.read(fixture_credentials_path))
+    path
+  end
+
+  # A scratch directory that lives as long as the example does.
+  #
+  # @return [String]
+  def tmp_home
+    ENV.fetch("HOME")
+  end
+end
+
+RSpec.configure { |config| config.include CredentialsFileHelper }

--- a/spec/support/driver_helper.rb
+++ b/spec/support/driver_helper.rb
@@ -1,0 +1,70 @@
+# Helpers for building a driver wired to a doubled Test Kitchen instance.
+module DriverHelper
+  # Configuration every example starts from. Individual specs merge over it.
+  DEFAULT_CONFIG = {
+    subscription_id: "115b12cb-b0d3-4ed9-94db-f73733be6f3c",
+    location: "eastus2",
+    machine_size: "Standard_D4_v3",
+    image_urn: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+    azure_environment: "Azure",
+    # Keep the deployment poller from actually waiting.
+    deployment_sleep: 0,
+  }.freeze
+
+  # Builds a driver with a doubled instance already attached.
+  #
+  # @param transport [Object] the transport double, see {#transport_double}.
+  # @param platform_name [String] the platform name reported by the instance.
+  # @param instance_name [String] the instance name.
+  # @param config [Hash] driver configuration, merged over {DEFAULT_CONFIG}.
+  # @return [Kitchen::Driver::Azurerm]
+  def build_driver(transport: transport_double, platform_name: "ubuntu-22.04", instance_name: "default-ubuntu-2204", **config)
+    driver = Kitchen::Driver::Azurerm.new(DEFAULT_CONFIG.merge(config))
+    instance = instance_double(
+      Kitchen::Instance,
+      name: instance_name,
+      logger: Kitchen.logger,
+      transport:,
+      platform: Kitchen::Platform.new(name: platform_name),
+      to_str: "<#{instance_name}>"
+    )
+    allow(driver).to receive(:instance).and_return(instance)
+    allow(driver).to receive(:sleep)
+    driver
+  end
+
+  # A transport stand-in.
+  #
+  # @param name [String] the transport name, e.g. +"Ssh"+ or +"Winrm"+.
+  # @param settings [Hash] settings readable through +transport[:key]+.
+  # @return [RSpec::Mocks::InstanceVerifyingDouble]
+  def transport_double(name: "Dummy", **settings)
+    double = instance_double(Kitchen::Transport::Dummy, name:)
+    allow(double).to receive(:[]) { |key| settings[key] }
+    double
+  end
+
+  # Reads a driver's merged configuration, including defaults.
+  #
+  # @param driver [Kitchen::Driver::Azurerm]
+  # @return [Hash]
+  def driver_config(driver)
+    driver.instance_variable_get(:@config)
+  end
+
+  # Renders and parses the driver's virtual machine deployment template.
+  #
+  # @param driver [Kitchen::Driver::Azurerm]
+  # @return [Hash] the parsed ARM template.
+  def rendered_template(driver)
+    JSON.parse(driver.virtual_machine_deployment_template)
+  end
+
+  # Finds the virtual machine resource in a parsed ARM template.
+  #
+  # @param template [Hash] a parsed ARM template.
+  # @return [Hash, nil]
+  def vm_resource(template)
+    template["resources"].find { |resource| resource["type"] == "Microsoft.Compute/virtualMachines" }
+  end
+end

--- a/spec/support/env_helper.rb
+++ b/spec/support/env_helper.rb
@@ -1,0 +1,35 @@
+# Helpers for manipulating the process environment inside an example.
+#
+# The suite-wide +around+ hook in +spec_helper.rb+ snapshots and restores +ENV+
+# for every example, so these helpers can mutate it directly rather than
+# stubbing +ENV#[]+. Stubbing the accessor forces every incidental variable read
+# by any gem in the stack to be enumerated as well, which is how the previous
+# suite ended up asserting on +GEM_SKIP+.
+module EnvHelper
+  # Sets environment variables for the remainder of the example.
+  #
+  # @param vars [Hash{String,Symbol => String,nil}] a nil value deletes the key.
+  # @return [void]
+  def set_env(vars)
+    vars.each do |key, value|
+      if value.nil?
+        ENV.delete(key.to_s)
+      else
+        ENV[key.to_s] = value.to_s
+      end
+    end
+  end
+
+  # Sets environment variables for the duration of the block only.
+  #
+  # @param vars [Hash{String,Symbol => String,nil}]
+  # @yield with the variables applied.
+  # @return [Object] the block's return value.
+  def with_env(vars)
+    original = vars.keys.to_h { |key| [key.to_s, ENV[key.to_s]] }
+    set_env(vars)
+    yield
+  ensure
+    set_env(original)
+  end
+end

--- a/spec/support/matchers/be_a_valid_arm_template.rb
+++ b/spec/support/matchers/be_a_valid_arm_template.rb
@@ -1,0 +1,28 @@
+require "json"
+
+# Asserts that a String parses as JSON and looks like an ARM deployment template.
+#
+# Every ERB template in this gem is string-interpolated, so a conditional that
+# emits a stray comma produces a file that is structurally plausible but
+# unparseable. This matcher makes that failure mode explicit and gives a useful
+# message, rather than a JSON::ParserError from somewhere deep in the driver.
+RSpec::Matchers.define :be_a_valid_arm_template do
+  match do |actual|
+    @parsed = JSON.parse(actual)
+    @failure = "is not a JSON object" unless @parsed.is_a?(Hash)
+    @failure ||= "has no $schema" unless @parsed.key?("$schema")
+    @failure ||= "has no resources array" unless @parsed["resources"].is_a?(Array)
+    @failure.nil?
+  rescue JSON::ParserError => e
+    @failure = "is not parseable JSON: #{e.message}"
+    false
+  end
+
+  failure_message do |actual|
+    "expected an ARM template, but it #{@failure}\n\n#{actual.to_s[0, 2000]}"
+  end
+
+  failure_message_when_negated do
+    "expected the value not to be a valid ARM template, but it was"
+  end
+end

--- a/spec/unit/kitchen/driver/azure_credentials_spec.rb
+++ b/spec/unit/kitchen/driver/azure_credentials_spec.rb
@@ -1,264 +1,270 @@
-require "spec_helper"
-require "ms_rest_azure2"
+RSpec.describe Kitchen::Driver::AzureCredentials do
+  subject(:credentials) { described_class.new(subscription_id:, environment:) }
 
-describe Kitchen::Driver::AzureCredentials do
-  CLIENT_ID_AND_SECRET_SUB = 0
-  CLIENT_ID_SUB = 1
-  NO_CLIENT_SUB = 2
-
-  let(:instance) do
-    opts = {}
-    opts[:subscription_id] = subscription_id
-    opts[:environment] = environment if environment
-    described_class.new(**opts)
-  end
-
+  let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:service_principal] }
   let(:environment) { "Azure" }
-  let(:fixtures_path) { File.expand_path("../../../fixtures", __dir__) }
-  let(:subscription_id) { ini_credentials.sections[CLIENT_ID_AND_SECRET_SUB] }
-  let(:client_id) { ini_credentials[subscription_id]["client_id"] }
-  let(:client_secret) { ini_credentials[subscription_id]["client_secret"] }
-  let(:tenant_id) { ini_credentials[subscription_id]["tenant_id"] }
-  let(:default_config_path) { File.expand_path(described_class::CONFIG_PATH) }
-  let(:ini_credentials) { IniFile.load("#{fixtures_path}/azure_credentials") }
 
-  before do
-    allow(ENV).to receive(:[]).and_call_original
-    allow(ENV).to receive(:[]).with("AZURE_CONFIG_FILE").and_return(nil)
-    allow(ENV).to receive(:[]).with("AZURE_TENANT_ID").and_return(nil)
-    allow(ENV).to receive(:[]).with("AZURE_CLIENT_ID").and_return(nil)
-    allow(ENV).to receive(:[]).with("AZURE_CLIENT_SECRET").and_return(nil)
+  describe ".default_config_path" do
+    it "resolves against the current home directory rather than the one present at load time" do
+      first = described_class.default_config_path
 
-    allow(File).to receive(:file?).and_call_original
-    allow(File).to receive(:file?).with(default_config_path).and_return(true)
-
-    allow(IniFile).to receive(:load).with(default_config_path).and_return(ini_credentials)
+      Dir.mktmpdir do |elsewhere|
+        ENV["HOME"] = elsewhere
+        expect(described_class.default_config_path).to eq(File.join(elsewhere, ".azure", "credentials"))
+        expect(described_class.default_config_path).not_to eq(first)
+      end
+    end
   end
 
-  subject { instance }
-
-  it { is_expected.to respond_to(:subscription_id) }
-  it { is_expected.to respond_to(:environment) }
-  it { is_expected.to respond_to(:azure_options) }
-
-  describe "::new" do
-    it "sets subscription_id" do
-      expect(subject.subscription_id).to eq(subscription_id)
+  describe "#initialize" do
+    it "exposes the subscription id" do
+      expect(credentials.subscription_id).to eq(subscription_id)
     end
 
-    context "when an environment is provided" do
-      let(:environment) { "AzureChina" }
-
-      it "sets environment, when one is provided" do
-        expect(subject.environment).to eq(environment)
-      end
+    it "defaults the environment to Azure" do
+      expect(described_class.new(subscription_id:).environment).to eq("Azure")
     end
 
-    context "no environment is provided" do
-      let(:environment) { nil }
+    it "treats an explicit nil environment as Azure" do
+      expect(described_class.new(subscription_id:, environment: nil).environment).to eq("Azure")
+    end
 
-      it "sets Azure as the environment" do
-        expect(subject.environment).to eq("Azure")
-      end
+    it "keeps a supplied environment" do
+      expect(described_class.new(subscription_id:, environment: "AzureChina").environment).to eq("AzureChina")
+    end
+
+    it "rejects an unknown environment with an actionable message" do
+      expect { described_class.new(subscription_id:, environment: "AzureAtlantis") }
+        .to raise_error(Kitchen::UserError, /Unknown azure_environment 'AzureAtlantis'.*azure, azurechina/m)
+    end
+
+    it "accepts a known environment in any case" do
+      expect { described_class.new(subscription_id:, environment: "AZUREUSGOVERNMENT") }.not_to raise_error
+    end
+  end
+
+  describe "#config_path" do
+    it "defaults to ~/.azure/credentials" do
+      expect(credentials.config_path).to eq(described_class.default_config_path)
+    end
+
+    it "honours AZURE_CONFIG_FILE" do
+      path = use_fixture_credentials_file
+      expect(credentials.config_path).to eq(path)
+    end
+
+    it "expands a relative AZURE_CONFIG_FILE" do
+      ENV["AZURE_CONFIG_FILE"] = "creds.ini"
+      expect(credentials.config_path).to eq(File.expand_path("creds.ini"))
     end
   end
 
   describe "#azure_options" do
-    subject { azure_options }
+    subject(:options) { credentials.azure_options }
 
-    let(:azure_options) { instance.azure_options }
-    let(:credentials) { azure_options[:credentials] }
-    let(:token_provider) { credentials.instance_variable_get(:@token_provider) }
-    let(:active_directory_settings) { azure_options[:active_directory_settings] }
-
-    context "when AZURE_CONFIG_FILE is set" do
-      let(:overridden_config_path) { "/tmp/my-config" }
-
-      before do
-        allow(ENV).to receive(:[]).with("AZURE_CONFIG_FILE").and_return(overridden_config_path)
+    context "with no credentials file and no environment variables" do
+      it "logs which path it looked in" do
+        expect(Kitchen.logger).to receive(:debug).with(/#{Regexp.escape(described_class.default_config_path)} was not found/)
+        options
       end
 
-      it "loads credentials from the path specified in environment variable" do
-        allow(File).to receive(:file?).with(overridden_config_path).and_return(true)
-        expect(IniFile).to receive(:load).with(overridden_config_path).and_return(ini_credentials)
-        expect(IniFile).not_to receive(:load).with(default_config_path)
-        azure_options
-      end
-    end
-
-    context "when configuration file does not exist and at least one of the environment variables is not set" do
-      before do
-        allow(File).to receive(:file?).with(default_config_path).and_return(false)
-        allow(ENV).to receive(:[]).with("AZURE_TENANT_ID").and_return(tenant_id)
-        allow(ENV).to receive(:[]).with("AZURE_CLIENT_ID").and_return(client_id)
-        allow(ENV).to receive(:[]).with("AZURE_CLIENT_SECRET").and_return(nil)
+      it "warns that it is falling back to the Azure CLI" do
+        allow(Kitchen.logger).to receive(:warn)
+        options
+        expect(Kitchen.logger).to have_received(:warn).with("Using tenant id set through `az login`.")
       end
 
-      it "logs a warning" do
-        expect(Kitchen.logger).to receive(:debug).with("#{default_config_path} was not found or not accessible.")
-        azure_options
+      it "falls back to the Azure CLI token provider" do
+        expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::AzureCliTokenProvider)
+      end
+
+      it "omits client_id and client_secret" do
+        expect(options).not_to have_key(:client_id)
+        expect(options).not_to have_key(:client_secret)
       end
     end
 
-    context "when AZURE_TENANT_ID is set" do
-      let(:tenant_id) { "2d38055e-66a1-435c-be53-TENANT_ID" }
+    context "when reading the credentials file at its default location" do
+      before { use_default_location_credentials_file }
 
-      before do
-        allow(ENV).to receive(:[]).with("AZURE_TENANT_ID").and_return(tenant_id)
+      it "resolves the tenant id from the matching subscription section" do
+        expect(options[:tenant_id]).to eq("19d3ea3e-ea8f-48f3-9f7a-00ae2810991f")
       end
 
-      its([:tenant_id]) { is_expected.to eq(tenant_id) }
-    end
-
-    context "when AZURE_CLIENT_ID is set" do
-      let(:client_id) { "2e201a46-44a8-4508-84aa-CLIENT_ID" }
-
-      before do
-        allow(ENV).to receive(:[]).with("AZURE_CLIENT_ID").and_return(client_id)
+      it "does not read another subscription's section" do
+        other = described_class.new(subscription_id: CredentialsFileHelper::SUBSCRIPTIONS[:user_assigned_identity])
+        expect(other.azure_options[:tenant_id]).to eq("1ba5986d-52e1-49eb-a77e-155b7440695f")
       end
 
-      its([:client_id]) { is_expected.to eq(client_id) }
+      it "warns when the subscription has no section at all" do
+        unknown = described_class.new(subscription_id: "00000000-0000-0000-0000-000000000000")
+        allow(Kitchen.logger).to receive(:warn)
+        unknown.azure_options
+        expect(Kitchen.logger).to have_received(:warn).with(/does not contain tenant_id/)
+      end
     end
 
-    context "when AZURE_CLIENT_SECRET is set" do
-      let(:client_secret) { "2e201a46-44a8-4508-84aa-CLIENT_SECRET" }
+    context "when AZURE_CONFIG_FILE points somewhere else" do
+      it "reads that file instead of the default" do
+        use_default_location_credentials_file
+        use_credentials_file(<<~INI)
+          [#{subscription_id}]
+          tenant_id = "overridden-tenant"
+        INI
 
-      before do
-        allow(ENV).to receive(:[]).with("AZURE_CLIENT_SECRET").and_return(client_secret)
+        expect(options[:tenant_id]).to eq("overridden-tenant")
+      end
+    end
+
+    context "when the credentials file is malformed" do
+      it "surfaces the parse error rather than silently continuing" do
+        use_credentials_file("this is not = valid [ini\n[[[")
+        expect { options }.to raise_error(IniFile::Error)
+      end
+    end
+
+    describe "credential precedence" do
+      before { use_fixture_credentials_file }
+
+      it "prefers environment variables over the credentials file" do
+        set_env("AZURE_TENANT_ID" => "env-tenant", "AZURE_CLIENT_ID" => "env-client", "AZURE_CLIENT_SECRET" => "env-secret")
+
+        expect(options).to include(tenant_id: "env-tenant", client_id: "env-client", client_secret: "env-secret")
       end
 
-      its([:client_secret]) { is_expected.to eq(client_secret) }
+      it "ignores environment variables that are exported but empty" do
+        set_env("AZURE_CLIENT_SECRET" => "")
+
+        expect(options[:client_secret]).to eq(":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV[")
+      end
+
+      it "mixes environment and file values" do
+        set_env("AZURE_TENANT_ID" => "env-tenant")
+
+        expect(options).to include(tenant_id: "env-tenant", client_id: "b5f3d6df-00bf-4451-a4f2-db3bc7731b58")
+      end
     end
 
-    context "when environment is Azure" do
-      let(:environment) { "Azure" }
+    describe "token provider selection" do
+      before { use_fixture_credentials_file }
 
-      its([:base_url]) { is_expected.to eq("https://management.azure.com/") }
+      context "with client_id, client_secret and tenant_id" do
+        let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:service_principal] }
 
-      context "active_directory_settings" do
-        it "sets the authentication_endpoint correctly" do
-          expect(active_directory_settings.authentication_endpoint).to eq("https://login.microsoftonline.com/")
+        it "uses a service principal token provider" do
+          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::ApplicationTokenProvider)
         end
 
-        it "sets the token_audience correctly" do
-          expect(active_directory_settings.token_audience).to eq("https://management.core.windows.net/")
+        it "passes the client id and secret through" do
+          provider = token_provider_for(options)
+          expect(provider.send(:client_id)).to eq("b5f3d6df-00bf-4451-a4f2-db3bc7731b58")
+          expect(provider.send(:client_secret)).to eq(":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV[")
+        end
+
+        it "includes both in the options hash" do
+          expect(options).to include(:client_id, :client_secret)
+        end
+      end
+
+      context "with client_id and tenant_id but no secret" do
+        let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:user_assigned_identity] }
+
+        it "uses a managed identity token provider" do
+          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::MSITokenProvider)
+        end
+
+        it "binds the identity's client id" do
+          expect(token_provider_for(options).instance_variable_get(:@client_id))
+            .to eq("2801f9e6-c4c2-4667-a6e1-479f8827b0af")
+        end
+
+        it "omits client_secret from the options hash" do
+          expect(options).to include(:client_id)
+          expect(options).not_to have_key(:client_secret)
+        end
+      end
+
+      context "with only a tenant_id" do
+        let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:system_assigned_identity] }
+
+        it "uses a managed identity token provider" do
+          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::MSITokenProvider)
+        end
+
+        it "binds no client id" do
+          expect(token_provider_for(options).instance_variable_get(:@client_id)).to be_nil
+        end
+
+        it "omits both client_id and client_secret" do
+          expect(options).not_to have_key(:client_id)
+          expect(options).not_to have_key(:client_secret)
+        end
+      end
+
+      context "with an empty section" do
+        let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:azure_cli] }
+
+        it "falls back to the Azure CLI" do
+          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::AzureCliTokenProvider)
         end
       end
     end
 
-    context "when environment is AzureUSGovernment" do
-      let(:environment) { "AzureUSGovernment" }
+    describe "cloud endpoints" do
+      {
+        "Azure" => { base_url: "https://management.azure.com/",
+                     authentication_endpoint: "https://login.microsoftonline.com/",
+                     token_audience: "https://management.core.windows.net/" },
+        "AzureUSGovernment" => { base_url: "https://management.usgovcloudapi.net",
+                                 authentication_endpoint: "https://login.microsoftonline.us/",
+                                 token_audience: "https://management.core.usgovcloudapi.net/" },
+        "AzureChina" => { base_url: "https://management.chinacloudapi.cn",
+                          authentication_endpoint: "https://login.chinacloudapi.cn/",
+                          token_audience: "https://management.core.chinacloudapi.cn/" },
+        "AzureGermanCloud" => { base_url: "https://management.microsoftazure.de",
+                                authentication_endpoint: "https://login.microsoftonline.de/",
+                                token_audience: "https://management.core.cloudapi.de/" },
+      }.each do |cloud, expected|
+        context "for #{cloud}" do
+          let(:environment) { cloud }
 
-      its([:base_url]) { is_expected.to eq("https://management.usgovcloudapi.net") }
+          it "sets the resource manager base url" do
+            expect(options[:base_url]).to eq(expected[:base_url])
+          end
 
-      context "active_directory_settings" do
-        it "sets the authentication_endpoint correctly" do
-          expect(active_directory_settings.authentication_endpoint).to eq("https://login.microsoftonline.us/")
+          it "sets the authentication endpoint" do
+            expect(options[:active_directory_settings].authentication_endpoint).to eq(expected[:authentication_endpoint])
+          end
+
+          it "sets the token audience" do
+            expect(options[:active_directory_settings].token_audience).to eq(expected[:token_audience])
+          end
         end
 
-        it "sets the token_audience correctly" do
-          expect(active_directory_settings.token_audience).to eq("https://management.core.usgovcloudapi.net/")
-        end
-      end
-    end
+        context "for #{cloud} spelled in a different case" do
+          let(:environment) { cloud.downcase }
 
-    context "when environment is AzureChina" do
-      let(:environment) { "AzureChina" }
-
-      its([:base_url]) { is_expected.to eq("https://management.chinacloudapi.cn") }
-
-      context "active_directory_settings" do
-        it "sets the authentication_endpoint correctly" do
-          expect(active_directory_settings.authentication_endpoint).to eq("https://login.chinacloudapi.cn/")
-        end
-
-        it "sets the token_audience correctly" do
-          expect(active_directory_settings.token_audience).to eq("https://management.core.chinacloudapi.cn/")
-        end
-      end
-    end
-
-    context "when environment is AzureGermanCloud" do
-      let(:environment) { "AzureGermanCloud" }
-
-      its([:base_url]) { is_expected.to eq("https://management.microsoftazure.de") }
-
-      context "active_directory_settings" do
-        it "sets the authentication_endpoint correctly" do
-          expect(active_directory_settings.authentication_endpoint).to eq("https://login.microsoftonline.de/")
-        end
-
-        it "sets the token_audience correctly" do
-          expect(active_directory_settings.token_audience).to eq("https://management.core.cloudapi.de/")
+          it "resolves the same endpoints" do
+            expect(options[:base_url]).to eq(expected[:base_url])
+          end
         end
       end
     end
 
-    shared_examples "common option specs" do
-      it { is_expected.to be_instance_of(Hash) }
-      its([:tenant_id]) { is_expected.to eq(tenant_id) }
-      its([:subscription_id]) { is_expected.to eq(subscription_id) }
-      its([:credentials]) { is_expected.to be_instance_of(MsRest2::TokenCredentials) }
-      its([:client_id]) { is_expected.to eq(client_id) }
-      its([:client_secret]) { is_expected.to eq(client_secret) }
-      its([:base_url]) { is_expected.to eq("https://management.azure.com/") }
+    it "wraps the token provider in MsRest2 credentials" do
+      expect(options[:credentials]).to be_an_instance_of(MsRest2::TokenCredentials)
     end
 
-    context "when using client_id and client_secret" do
-      let(:subscription_id) { ini_credentials.sections[CLIENT_ID_AND_SECRET_SUB] }
-
-      include_examples "common option specs"
-
-      it "uses token provider: MsRestAzure2::ApplicationTokenProvider" do
-        expect(token_provider).to be_instance_of(MsRestAzure2::ApplicationTokenProvider)
-      end
-
-      it "sets the client_id" do
-        expect(token_provider.instance_variables).to include(:@client_id)
-        expect(token_provider.send(:client_id)).to eq(client_id)
-      end
-
-      it "sets the client_secret" do
-        expect(token_provider.instance_variables).to include(:@client_secret)
-        expect(token_provider.send(:client_secret)).to eq(client_secret)
-      end
+    it "carries the subscription id" do
+      expect(options[:subscription_id]).to eq(subscription_id)
     end
+  end
 
-    context "when using client_id, without client_secret" do
-      let(:subscription_id) { ini_credentials.sections[CLIENT_ID_SUB] }
-
-      include_examples "common option specs"
-
-      it "uses token provider: MsRestAzure2::MSITokenProvider" do
-        expect(token_provider).to be_instance_of(MsRestAzure2::MSITokenProvider)
-      end
-
-      it "sets the client_id" do
-        expect(token_provider.instance_variables).to include(:@client_id)
-        expect(token_provider.send(:client_id)).to eq(client_id)
-      end
-
-      it "does not set client_secret" do
-        expect(token_provider.instance_variables).not_to include(:@client_secret)
-      end
-    end
-
-    context "when not using client_id or client_secret" do
-      let(:subscription_id) { ini_credentials.sections[NO_CLIENT_SUB] }
-
-      include_examples "common option specs"
-
-      it "uses token provider: MsRestAzure2::MSITokenProvider" do
-        expect(token_provider).to be_instance_of(MsRestAzure2::MSITokenProvider)
-      end
-
-      it "does not set the client_id" do
-        expect(token_provider.instance_variables).not_to include(:@client_id)
-      end
-
-      it "does not set client_secret" do
-        expect(token_provider.instance_variables).not_to include(:@client_secret)
-      end
-    end
+  # Digs the token provider out of the MsRest2 credentials wrapper.
+  #
+  # @param options [Hash] the result of {Kitchen::Driver::AzureCredentials#azure_options}.
+  # @return [Object] the token provider.
+  def token_provider_for(options)
+    options[:credentials].instance_variable_get(:@token_provider)
   end
 end

--- a/spec/unit/kitchen/driver/azurerm/api_retry_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/api_retry_spec.rb
@@ -1,0 +1,198 @@
+RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
+  subject(:driver) { build_driver(**config) }
+
+  let(:config) { { azure_api_retries: 2 } }
+  let(:resource_client) { resource_client_double }
+  let(:network_client) { network_client_double }
+
+  before do
+    driver.resource_management_client = resource_client
+    driver.network_management_client = network_client
+    allow(Kitchen.logger).to receive(:info)
+  end
+
+  describe "#with_azure_retries" do
+    it "returns the block's value when nothing goes wrong" do
+      expect(driver.send(:with_azure_retries, "doing a thing.") { :the_result }).to eq(:the_result)
+    end
+
+    it "does not retry a successful call" do
+      calls = 0
+      driver.send(:with_azure_retries, "doing a thing.") { calls += 1 }
+      expect(calls).to eq(1)
+    end
+
+    it "retries a timeout up to the configured budget, then gives up" do
+      calls = 0
+      expect do
+        driver.send(:with_azure_retries, "doing a thing.") do
+          calls += 1
+          raise Faraday::TimeoutError
+        end
+      end.to raise_error(Faraday::TimeoutError)
+
+      # One initial attempt plus azure_api_retries retries.
+      expect(calls).to eq(3)
+    end
+
+    it "succeeds if a retry works" do
+      calls = 0
+      result = driver.send(:with_azure_retries, "doing a thing.") do
+        calls += 1
+        raise Faraday::TimeoutError if calls < 2
+
+        :recovered
+      end
+
+      expect(result).to eq(:recovered)
+      expect(calls).to eq(2)
+    end
+
+    it "retries connection resets too" do
+      calls = 0
+      expect do
+        driver.send(:with_azure_retries, "doing a thing.") do
+          calls += 1
+          raise Faraday::ClientError, "connection reset"
+        end
+      end.to raise_error(Faraday::ClientError)
+
+      expect(calls).to eq(3)
+    end
+
+    it "does not swallow errors it cannot retry" do
+      expect { driver.send(:with_azure_retries, "doing a thing.") { raise ArgumentError, "bad input" } }
+        .to raise_error(ArgumentError, "bad input")
+    end
+
+    it "raises immediately when the retry budget is zero" do
+      driver = build_driver(azure_api_retries: 0)
+      calls = 0
+
+      expect do
+        driver.send(:with_azure_retries, "doing a thing.") do
+          calls += 1
+          raise Faraday::TimeoutError
+        end
+      end.to raise_error(Faraday::TimeoutError)
+
+      expect(calls).to eq(1)
+    end
+
+    it "logs a timeout with its cause and the remaining budget" do
+      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise Faraday::TimeoutError } }
+      expect(Kitchen.logger).to have_received(:info).with("Timed out while doing a thing. 2 retries left.")
+    end
+
+    it "counts down the remaining budget in the log" do
+      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise Faraday::TimeoutError } }
+      expect(Kitchen.logger).to have_received(:info).with(/1 retries left/)
+      expect(Kitchen.logger).to have_received(:info).with(/0 retries left/)
+    end
+
+    it "logs a connection reset differently from a timeout" do
+      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise Faraday::ClientError, "reset" } }
+      expect(Kitchen.logger).to have_received(:info).with(/\AConnection reset by peer while doing a thing/).at_least(:once)
+    end
+  end
+
+  describe "#send_exception_message" do
+    it "says nothing useful about an exception it does not recognise" do
+      driver.send(:send_exception_message, ArgumentError.new, "while doing a thing.")
+      expect(Kitchen.logger).to have_received(:info).with("Unrecognized exception type.")
+    end
+  end
+
+  describe "the wrapped API calls" do
+    {
+      resource_group_exists?: %w{check_existence},
+      create_resource_group: %w{create_or_update},
+      delete_resource_group_async: %w{begin_delete},
+    }.each do |method, (api_call)|
+      it "retries ##{method}" do
+        calls = 0
+        allow(resource_client.resource_groups).to receive(api_call) do
+          calls += 1
+          raise Faraday::TimeoutError if calls < 2
+
+          :ok
+        end
+
+        expect(driver.send(method, *Array.new(driver.method(method).arity.abs, "arg"))).to eq(:ok)
+        expect(calls).to eq(2)
+      end
+    end
+
+    it "retries #create_deployment_async" do
+      calls = 0
+      allow(resource_client.deployments).to receive(:begin_create_or_update_async) do
+        calls += 1
+        raise Faraday::TimeoutError if calls < 2
+
+        :ok
+      end
+
+      expect(driver.send(:create_deployment_async, "rg", "deploy-1", :deployment)).to eq(:ok)
+    end
+
+    it "retries #list_deployment_operations" do
+      calls = 0
+      allow(resource_client.deployment_operations).to receive(:list) do
+        calls += 1
+        raise Faraday::ClientError, "reset" if calls < 2
+
+        []
+      end
+
+      expect(driver.send(:list_deployment_operations, "rg", "deploy-1")).to eq([])
+    end
+
+    it "retries #get_deployment_state and unwraps the provisioning state" do
+      calls = 0
+      allow(resource_client.deployments).to receive(:get) do
+        calls += 1
+        raise Faraday::TimeoutError if calls < 2
+
+        deployment_extended("Running")
+      end
+
+      expect(driver.send(:get_deployment_state, "rg", "deploy-1")).to eq("Running")
+    end
+
+    it "retries #get_public_ip" do
+      calls = 0
+      allow(network_client.public_ipaddresses).to receive(:get) do
+        calls += 1
+        raise Faraday::TimeoutError if calls < 2
+
+        public_ip(ip_address: "1.2.3.4")
+      end
+
+      expect(driver.send(:get_public_ip, "rg", "publicip").ip_address).to eq("1.2.3.4")
+    end
+
+    it "retries #get_network_interface" do
+      calls = 0
+      network_interfaces = instance_double(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces)
+      allow(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces).to receive(:new).and_return(network_interfaces)
+      allow(network_interfaces).to receive(:get) do
+        calls += 1
+        raise Faraday::TimeoutError if calls < 2
+
+        network_interface(private_ip: "10.0.0.9")
+      end
+
+      expect(driver.send(:get_network_interface, "rg", "nic-1").ip_configurations.first.private_ipaddress).to eq("10.0.0.9")
+    end
+  end
+
+  # Runs a block, discarding any error it raises.
+  #
+  # @yield the block to run.
+  # @return [void]
+  def suppress_error
+    yield
+  rescue StandardError
+    nil
+  end
+end

--- a/spec/unit/kitchen/driver/azurerm/create_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/create_spec.rb
@@ -1,0 +1,418 @@
+RSpec.describe Kitchen::Driver::Azurerm, "#create" do
+  subject(:driver) { build_driver(transport:, **config) }
+
+  let(:config) { {} }
+  let(:transport) { transport_double }
+  let(:state) { {} }
+  let(:resource_client) { resource_client_double }
+  let(:network_client) { network_client_double }
+
+  # Every deployment the driver submits, in the order it submitted them.
+  let(:submitted_deployments) { [] }
+
+  before do
+    stub_azure_clients(driver, resource_client:, network_client:)
+    record_deployments(resource_client)
+  end
+
+  describe "preconditions" do
+    it "refuses to run without a subscription_id" do
+      driver = build_driver(subscription_id: nil)
+      expect { driver.create({}) }.to raise_error(/subscription_id config value was not detected/)
+    end
+
+    it "refuses to run with a blank subscription_id" do
+      driver = build_driver(subscription_id: "")
+      expect { driver.create({}) }.to raise_error(/subscription_id config value was not detected/)
+    end
+  end
+
+  describe "resource group creation" do
+    it "creates the resource group before deploying" do
+      driver.create(state)
+      expect(resource_client.resource_groups).to have_received(:create_or_update)
+        .with(state[:azure_resource_group_name], anything)
+    end
+
+    it "tags the resource group" do
+      driver = build_driver(resource_group_tags: { owner: "platform-team" }, location: "westus3")
+      stub_azure_clients(driver, resource_client:, network_client:)
+      record_deployments(resource_client)
+      driver.create({})
+
+      expect(resource_client.resource_groups).to have_received(:create_or_update) do |_name, group|
+        expect(group.tags).to eq(owner: "platform-team")
+        expect(group.location).to eq("westus3")
+      end
+    end
+
+    it "re-raises an Azure failure after logging the body" do
+      allow(resource_client.resource_groups).to receive(:create_or_update)
+        .and_raise(azure_operation_error(code: "AuthorizationFailed"))
+
+      expect { driver.create(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+    end
+  end
+
+  describe "the main deployment" do
+    it "names the deployment after the instance uuid" do
+      driver.create(state)
+      expect(submitted_deployments.first).to include(
+        resource_group: state[:azure_resource_group_name],
+        name: "deploy-#{state[:uuid]}"
+      )
+    end
+
+    it "sends a deployment whose template is valid ARM JSON" do
+      driver.create(state)
+      expect(JSON.generate(submitted_deployments.first[:deployment].properties.template)).to be_a_valid_arm_template
+    end
+
+    it "passes the configured location and machine size through" do
+      driver.create(state)
+      expect(deployment_parameters).to include(
+        location: { "value" => "eastus2" },
+        vmSize: { "value" => "Standard_D4_v3" }
+      )
+    end
+
+    it "derives the storage account and DNS names from the uuid" do
+      driver.create(state)
+      expect(deployment_parameters).to include(
+        newStorageAccountName: { "value" => "storage#{state[:uuid]}" },
+        dnsNameForPublicIP: { "value" => "kitchen-#{state[:uuid]}" }
+      )
+    end
+
+    it "derives the nic name from the vm name" do
+      driver.create(state)
+      expect(deployment_parameters[:nicName]).to eq("value" => "nic-#{state[:vm_name]}")
+    end
+
+    context "with an explicit nic_name" do
+      let(:config) { { nic_name: "my-nic" } }
+
+      it "uses it verbatim" do
+        driver.create(state)
+        expect(deployment_parameters[:nicName]).to eq("value" => "my-nic")
+      end
+    end
+
+    it "splits the image urn into its four parts" do
+      driver = build_driver(image_urn: "RedHat:rhel-byos:rhel-raw76:7.6.20190620")
+      stub_azure_clients(driver, resource_client:, network_client:)
+      record_deployments(resource_client)
+      driver.create({})
+
+      expect(deployment_parameters).to include(
+        imagePublisher: { "value" => "RedHat" },
+        imageOffer: { "value" => "rhel-byos" },
+        imageSku: { "value" => "rhel-raw76" },
+        imageVersion: { "value" => "7.6.20190620" }
+      )
+    end
+
+    context "with an image_id" do
+      let(:config) { { image_id: "/subscriptions/x/images/my-image" } }
+
+      it "sends imageId and no marketplace parameters" do
+        driver.create(state)
+        expect(deployment_parameters).to include(imageId: { "value" => "/subscriptions/x/images/my-image" })
+        expect(deployment_parameters).not_to include(:imagePublisher)
+      end
+    end
+
+    context "with an image_url" do
+      let(:config) { { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd", os_type: "windows", use_managed_disks: false } }
+
+      it "sends imageUrl and the os type" do
+        driver.create(state)
+        expect(deployment_parameters).to include(
+          imageUrl: { "value" => "https://sa.blob.core.windows.net/vhds/my.vhd" },
+          osType: { "value" => "windows" }
+        )
+      end
+    end
+
+    describe "public IP SKU" do
+      it "defaults to Basic with no address type override" do
+        driver.create(state)
+        expect(deployment_parameters[:publicIPSKU]).to eq("value" => "Basic")
+        expect(deployment_parameters).not_to include(:publicIPAddressType)
+      end
+
+      context "with a Standard SKU" do
+        let(:config) { { public_ip_sku: "Standard" } }
+
+        it "forces a static address, which Standard SKUs require" do
+          driver.create(state)
+          expect(deployment_parameters[:publicIPAddressType]).to eq("value" => "Static")
+        end
+      end
+    end
+
+    describe "managed identities" do
+      let(:config) do
+        {
+          system_assigned_identity: true,
+          user_assigned_identities: ["/subscriptions/x/userAssignedIdentities/id-1"],
+        }
+      end
+
+      it "passes the system assigned identity flag" do
+        driver.create(state)
+        expect(deployment_parameters[:systemAssignedIdentity]).to eq("value" => true)
+      end
+
+      it "converts user assigned identities into the ARM map shape" do
+        driver.create(state)
+        expect(deployment_parameters[:userAssignedIdentities])
+          .to eq("value" => { "/subscriptions/x/userAssignedIdentities/id-1" => {} })
+      end
+    end
+
+    describe "shared storage accounts" do
+      let(:config) { { existing_storage_account_blob_url: "https://shared.blob.core.windows.net" } }
+
+      it "adds a per-resource-group suffix so instances do not collide on disk names" do
+        driver.create(state)
+        expect(deployment_parameters[:osDiskNameSuffix]).to eq("value" => "-#{state[:azure_resource_group_name]}")
+      end
+
+      it "passes the blob url through" do
+        driver.create(state)
+        expect(deployment_parameters[:existingStorageAccountBlobURL])
+          .to eq("value" => "https://shared.blob.core.windows.net")
+      end
+    end
+
+    it "does not send an osDiskNameSuffix without a shared storage account" do
+      driver.create(state)
+      expect(deployment_parameters).not_to include(:osDiskNameSuffix)
+    end
+
+    describe "custom data" do
+      let(:config) { { custom_data: "#!/bin/sh\necho hi\n" } }
+
+      it "sends it base64 encoded" do
+        driver.create(state)
+        expect(Base64.decode64(deployment_parameters[:customData]["value"])).to eq("#!/bin/sh\necho hi\n")
+      end
+    end
+
+    it "omits customData when none is configured" do
+      driver.create(state)
+      expect(deployment_parameters).not_to include(:customData)
+    end
+
+    describe "key vault settings" do
+      let(:config) { { secret_url: "https://v.vault.azure.net/secrets/c", vault_name: "v", vault_resource_group: "vault-rg" } }
+
+      it "passes all three through as parameters" do
+        driver.create(state)
+        expect(deployment_parameters).to include(
+          secretUrl: { "value" => "https://v.vault.azure.net/secrets/c" },
+          vaultName: { "value" => "v" },
+          vaultResourceGroup: { "value" => "vault-rg" }
+        )
+      end
+
+      it "renders the matching secrets block into the template" do
+        driver.create(state)
+        vm = vm_resource(submitted_deployments.first[:deployment].properties.template)
+        expect(vm["properties"]["osProfile"]).to have_key("secrets")
+      end
+    end
+  end
+
+  describe "pre and post deployments" do
+    let(:template_path) { File.join(ENV.fetch("HOME"), "extra.json") }
+
+    before do
+      File.write(template_path, JSON.generate("$schema" => "x", "contentVersion" => "1.0.0.0", "resources" => []))
+    end
+
+    it "skips both when no templates are configured" do
+      driver.create(state)
+      expect(deployment_names_submitted).to eq(["deploy-#{state[:uuid]}"])
+    end
+
+    context "with a pre-deployment template" do
+      let(:config) { { pre_deployment_template: template_path } }
+
+      it "runs it before the main deployment" do
+        driver.create(state)
+        expect(deployment_names_submitted).to eq(["pre-deploy-#{state[:uuid]}", "deploy-#{state[:uuid]}"])
+      end
+    end
+
+    context "with a post-deployment template" do
+      let(:config) { { post_deployment_template: template_path } }
+
+      it "runs it after the main deployment" do
+        driver.create(state)
+        expect(deployment_names_submitted).to eq(["deploy-#{state[:uuid]}", "post-deploy-#{state[:uuid]}"])
+      end
+    end
+
+    context "with both" do
+      let(:config) { { pre_deployment_template: template_path, post_deployment_template: template_path } }
+
+      it "runs them in order around the main deployment" do
+        driver.create(state)
+        expect(deployment_names_submitted).to eq(
+          ["pre-deploy-#{state[:uuid]}", "deploy-#{state[:uuid]}", "post-deploy-#{state[:uuid]}"]
+        )
+      end
+    end
+  end
+
+  describe "credentials in state" do
+    context "with a password transport" do
+      it "stores the username and generated password" do
+        driver.create(state)
+        expect(state[:username]).to eq("azure")
+        expect(state[:password]).to be_a(String).and(satisfy { |value| !value.empty? })
+      end
+
+      it "does not overwrite credentials already in state" do
+        state.merge!(username: "existing-user", password: "existing-password")
+        driver.create(state)
+        expect(state).to include(username: "existing-user", password: "existing-password")
+      end
+
+      context "when store_deployment_credentials_in_state is disabled" do
+        let(:config) { { store_deployment_credentials_in_state: false } }
+
+        it "stores neither" do
+          driver.create(state)
+          expect(state).not_to include(:username, :password)
+        end
+      end
+    end
+
+    context "with an SSH key transport" do
+      let(:transport) { transport_double(name: "Ssh", ssh_key: File.join(ENV.fetch("HOME"), "id_rsa")) }
+
+      it "stores the username" do
+        driver.create(state)
+        expect(state[:username]).to eq("azure")
+      end
+
+      # Writing a nil password leaves a misleading empty entry in the state
+      # file, and Test Kitchen will then hand it to the transport.
+      it "leaves no password key in state at all" do
+        driver.create(state)
+        expect(state).not_to have_key(:password)
+      end
+
+      it "sends no adminPassword parameter to ARM" do
+        driver.create(state)
+        expect(deployment_parameters).not_to include(:adminPassword)
+      end
+    end
+  end
+
+  describe "hostname resolution" do
+    it "uses the public IP address by default" do
+      driver.create(state)
+      expect(state[:hostname]).to eq("40.121.0.1")
+    end
+
+    context "with use_fqdn_hostname" do
+      let(:config) { { use_fqdn_hostname: true } }
+
+      it "uses the DNS name instead" do
+        driver.create(state)
+        expect(state[:hostname]).to eq("kitchen-abc.eastus2.cloudapp.azure.com")
+      end
+    end
+
+    context "in a custom vnet with no public IP" do
+      let(:config) { { vnet_id: "/vnet", subnet_id: "/subnet" } }
+      let(:network_interfaces) { instance_double(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces, get: network_interface(private_ip: "10.0.0.7")) }
+
+      before do
+        allow(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces).to receive(:new).and_return(network_interfaces)
+      end
+
+      it "uses the NIC's private address" do
+        driver.create(state)
+        expect(state[:hostname]).to eq("10.0.0.7")
+      end
+
+      it "looks up the NIC by the name it deployed" do
+        driver.create(state)
+        expect(network_interfaces).to have_received(:get).with(state[:azure_resource_group_name], "nic-#{state[:vm_name]}")
+      end
+    end
+
+    context "in a custom vnet that also has a public IP" do
+      let(:config) { { vnet_id: "/vnet", subnet_id: "/subnet", public_ip: true } }
+
+      it "prefers the public address" do
+        driver.create(state)
+        expect(state[:hostname]).to eq("40.121.0.1")
+      end
+    end
+  end
+
+  describe "when a deployment is already running" do
+    before do
+      allow(resource_client.deployments).to receive(:begin_create_or_update_async)
+        .and_raise(azure_operation_error(code: "DeploymentActive"))
+    end
+
+    it "does not raise, because the existing deployment will finish on its own" do
+      expect { driver.create(state) }.not_to raise_error
+    end
+
+    it "tells the user what happened" do
+      allow(Kitchen.logger).to receive(:info)
+      driver.create(state)
+      expect(Kitchen.logger).to have_received(:info).with(/Deployment for resource group .* is ongoing/)
+    end
+
+    it "still resolves a hostname" do
+      driver.create(state)
+      expect(state[:hostname]).to eq("40.121.0.1")
+    end
+  end
+
+  describe "when the deployment fails for any other reason" do
+    before do
+      allow(resource_client.deployments).to receive(:begin_create_or_update_async)
+        .and_raise(azure_operation_error(code: "InvalidTemplate", message: "the template is malformed"))
+    end
+
+    it "re-raises" do
+      expect { driver.create(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+    end
+  end
+
+  # Records every deployment submitted through a doubled client.
+  #
+  # @param client [Object] the doubled resource management client.
+  # @return [void]
+  def record_deployments(client)
+    allow(client.deployments).to receive(:begin_create_or_update_async) do |resource_group, name, deployment|
+      submitted_deployments << { resource_group:, name:, deployment: }
+      accepted_request
+    end
+  end
+
+  # The ARM parameters of the main virtual machine deployment.
+  #
+  # @return [Hash, nil]
+  def deployment_parameters
+    main = submitted_deployments.find { |entry| entry[:name].start_with?("deploy-") }
+    main && main[:deployment].properties.parameters
+  end
+
+  # Names of every deployment submitted, in order.
+  #
+  # @return [Array<String>]
+  def deployment_names_submitted
+    submitted_deployments.map { |entry| entry[:name] }
+  end
+end

--- a/spec/unit/kitchen/driver/azurerm/deployment_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/deployment_spec.rb
@@ -1,0 +1,241 @@
+RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
+  subject(:driver) { build_driver(**config) }
+
+  let(:config) { {} }
+  let(:models) { Azure::Resources2::Profiles::Latest::Mgmt::Models }
+  let(:incremental) { models::DeploymentMode::Incremental }
+  let(:complete) { models::DeploymentMode::Complete }
+
+  describe "#parameters_in_values_format" do
+    it "wraps each value in the ARM value envelope" do
+      expect(driver.parameters_in_values_format(location: "eastus2", vmSize: "Standard_D2_v3")).to eq(
+        location: { "value" => "eastus2" },
+        vmSize: { "value" => "Standard_D2_v3" }
+      )
+    end
+
+    it "symbolizes string keys" do
+      expect(driver.parameters_in_values_format("nicName" => "nic-1")).to eq(nicName: { "value" => "nic-1" })
+    end
+
+    it "preserves non-string values" do
+      expect(driver.parameters_in_values_format(count: 3, enabled: false)).to eq(
+        count: { "value" => 3 },
+        enabled: { "value" => false }
+      )
+    end
+
+    it "is nil for an empty Hash" do
+      expect(driver.parameters_in_values_format({})).to be_nil
+    end
+
+    it "is nil for nil" do
+      expect(driver.parameters_in_values_format(nil)).to be_nil
+    end
+  end
+
+  describe "#deployment" do
+    subject(:deployment) { driver.deployment(location: "eastus2") }
+
+    it "uses Incremental mode" do
+      expect(deployment.properties.mode).to eq(incremental)
+    end
+
+    it "carries the rendered virtual machine template" do
+      expect(deployment.properties.template["resources"].map { |r| r["type"] })
+        .to include("Microsoft.Compute/virtualMachines")
+    end
+
+    it "carries the parameters in ARM value format" do
+      expect(deployment.properties.parameters).to eq(location: { "value" => "eastus2" })
+    end
+  end
+
+  describe "#pre_deployment and #post_deployment" do
+    let(:template_path) { File.join(ENV.fetch("HOME"), "extra.json") }
+    let(:template) do
+      {
+        "$schema" => "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        "contentVersion" => "1.0.0.0",
+        "resources" => [],
+      }
+    end
+
+    before { File.write(template_path, JSON.generate(template)) }
+
+    it "reads and parses the pre-deployment template from disk" do
+      deployment = driver.pre_deployment(template_path, {})
+      expect(deployment.properties.template).to eq(template)
+    end
+
+    it "reads and parses the post-deployment template from disk" do
+      deployment = driver.post_deployment(template_path, {})
+      expect(deployment.properties.template).to eq(template)
+    end
+
+    it "uses Incremental mode so existing resources survive" do
+      expect(driver.pre_deployment(template_path, {}).properties.mode).to eq(incremental)
+    end
+
+    it "formats supplied parameters" do
+      deployment = driver.pre_deployment(template_path, storageName: "mystorage")
+      expect(deployment.properties.parameters).to eq(storageName: { "value" => "mystorage" })
+    end
+
+    it "leaves parameters unset when none are supplied" do
+      expect(driver.pre_deployment(template_path, {}).properties.parameters).to be_nil
+    end
+
+    it "raises a readable error when the template file is missing" do
+      expect { driver.pre_deployment("/nope/missing.json", {}) }.to raise_error(Errno::ENOENT)
+    end
+  end
+
+  describe "#empty_deployment" do
+    subject(:deployment) { driver.empty_deployment }
+
+    it "uses Complete mode, which is what actually deletes the resources" do
+      expect(deployment.properties.mode).to eq(complete)
+    end
+
+    it "contains no resources" do
+      expect(deployment.properties.template["resources"]).to eq([])
+    end
+
+    it "sets no parameters" do
+      expect(deployment.properties.parameters).to be_nil
+    end
+  end
+
+  describe "#follow_deployment_until_end_state" do
+    before { driver.resource_management_client = resource_client }
+
+    let(:resource_client) do
+      resource_client_double(deployments: deployments, deployment_operations: deployment_operations_double)
+    end
+    let(:deployments) { deployments_double(provisioning_state: "Succeeded") }
+
+    it "returns once the deployment succeeds" do
+      expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
+    end
+
+    it "reports the end state it reached" do
+      allow(Kitchen.logger).to receive(:info)
+      driver.follow_deployment_until_end_state("rg", "deploy-1")
+      expect(Kitchen.logger).to have_received(:info).with(/reached end state of 'Succeeded'/)
+    end
+
+    it "sleeps between polls for the configured interval" do
+      driver = build_driver(deployment_sleep: 42)
+      driver.resource_management_client = resource_client
+      driver.follow_deployment_until_end_state("rg", "deploy-1")
+      expect(driver).to have_received(:sleep).with(42)
+    end
+
+    it "keeps polling until a terminal state is reached" do
+      allow(deployments).to receive(:get).and_return(
+        deployment_extended("Running"),
+        deployment_extended("Running"),
+        deployment_extended("Succeeded")
+      )
+
+      driver.follow_deployment_until_end_state("rg", "deploy-1")
+      expect(deployments).to have_received(:get).exactly(3).times
+    end
+
+    %w{Canceled Deleted Succeeded}.each do |state|
+      it "treats #{state} as terminal" do
+        allow(deployments).to receive(:get).and_return(deployment_extended(state))
+        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
+      end
+    end
+
+    context "when the deployment fails" do
+      let(:deployments) { deployments_double(provisioning_state: "Failed") }
+      let(:resource_client) do
+        resource_client_double(deployments:, deployment_operations: deployment_operations_double(operations:))
+      end
+      let(:operations) do
+        [
+          deployment_operation(status_code: "OK"),
+          deployment_operation(status_code: "Conflict", status_message: "VM size not available in this region"),
+        ]
+      end
+
+      it "raises with the failing operation's message" do
+        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }
+          .to raise_error(/VM size not available in this region/)
+      end
+
+      it "reports every failure, not just the first" do
+        allow(resource_client.deployment_operations).to receive(:list).and_return(
+          [
+            deployment_operation(status_code: "Conflict", status_message: "first problem"),
+            deployment_operation(status_code: "BadRequest", status_message: "second problem"),
+          ]
+        )
+
+        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }
+          .to raise_error(/first problem.*second problem/m)
+      end
+
+      it "does not raise when every operation reported OK" do
+        allow(resource_client.deployment_operations).to receive(:list).and_return([deployment_operation(status_code: "OK")])
+        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#list_outstanding_deployment_operations" do
+    before do
+      driver.resource_management_client = resource_client_double(deployment_operations: deployment_operations_double(operations:))
+      allow(Kitchen.logger).to receive(:info)
+    end
+
+    let(:operations) do
+      [
+        deployment_operation(provisioning_state: "Running", resource_name: "my-vm", resource_type: "Microsoft.Compute/virtualMachines"),
+        deployment_operation(provisioning_state: "Succeeded", resource_name: "my-nic", resource_type: "Microsoft.Network/networkInterfaces"),
+        deployment_operation(provisioning_state: "Failed", resource_name: "my-ip", resource_type: "Microsoft.Network/publicIPAddresses"),
+      ]
+    end
+
+    it "logs operations that are still in flight" do
+      driver.list_outstanding_deployment_operations("rg", "deploy-1")
+      expect(Kitchen.logger).to have_received(:info)
+        .with("Resource Microsoft.Compute/virtualMachines 'my-vm' provisioning status is Running")
+    end
+
+    it "stays quiet about operations that already finished" do
+      driver.list_outstanding_deployment_operations("rg", "deploy-1")
+      expect(Kitchen.logger).not_to have_received(:info).with(/my-nic|my-ip/)
+    end
+
+    context "when an operation has no target resource yet" do
+      let(:operations) { [deployment_operation(provisioning_state: "Accepted")] }
+
+      it "logs without a name rather than raising" do
+        expect { driver.list_outstanding_deployment_operations("rg", "deploy-1") }.not_to raise_error
+        expect(Kitchen.logger).to have_received(:info).with(/provisioning status is Accepted/)
+      end
+    end
+  end
+
+  describe "#run_deployment" do
+    let(:state) { { uuid: "abc123", azure_resource_group_name: "kitchen-rg" } }
+    let(:resource_client) { resource_client_double }
+
+    before { driver.resource_management_client = resource_client }
+
+    it "names the deployment from the prefix and the instance uuid" do
+      driver.run_deployment(state, "pre-deploy", driver.empty_deployment)
+      expect(resource_client.deployments).to have_received(:begin_create_or_update_async)
+        .with("kitchen-rg", "pre-deploy-abc123", anything)
+    end
+
+    it "waits for the deployment to finish before returning" do
+      expect(driver).to receive(:follow_deployment_until_end_state).with("kitchen-rg", "deploy-abc123")
+      driver.run_deployment(state, "deploy", driver.empty_deployment)
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
@@ -1,0 +1,206 @@
+RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
+  subject(:driver) { build_driver(**config) }
+
+  let(:config) { {} }
+  let(:resource_client) { resource_client_double }
+  let(:resource_groups) { resource_client.resource_groups }
+  let(:state) do
+    {
+      uuid: "abc123",
+      server_id: "vmabc123",
+      vm_name: "tk-abc123",
+      azure_resource_group_name: "kitchen-default-20260822T134505",
+      hostname: "40.121.0.1",
+      username: "azure",
+      password: "hunter2",
+      subscription_id: "115b12cb-b0d3-4ed9-94db-f73733be6f3c",
+      azure_environment: "Azure",
+    }
+  end
+
+  before { stub_azure_clients(driver, resource_client:) }
+
+  describe "the ordinary case" do
+    it "deletes the resource group" do
+      driver.destroy(state)
+      expect(resource_groups).to have_received(:begin_delete).with("kitchen-default-20260822T134505")
+    end
+
+    it "clears the resource group name from state" do
+      driver.destroy(state)
+      expect(state).not_to have_key(:azure_resource_group_name)
+    end
+
+    it "clears the instance identity and credentials from state" do
+      driver.destroy(state)
+      expect(state).not_to include(:server_id, :hostname, :username, :password)
+    end
+
+    it "does not empty the resource group first by default" do
+      driver.destroy(state)
+      expect(resource_client.deployments).not_to have_received(:begin_create_or_update_async)
+    end
+
+    it "re-raises an Azure failure" do
+      allow(resource_groups).to receive(:begin_delete).and_raise(azure_operation_error(code: "InUseSubnetCannotBeDeleted"))
+      expect { driver.destroy(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+    end
+  end
+
+  describe "state backfill" do
+    it "falls back to config for a missing azure_environment" do
+      driver = build_driver(azure_environment: "AzureUSGovernment")
+      stub_azure_clients(driver, resource_client:)
+      state.delete(:azure_environment)
+
+      driver.destroy(state)
+      expect(state[:azure_environment]).to eq("AzureUSGovernment")
+    end
+
+    it "falls back to config for a missing subscription_id" do
+      state.delete(:subscription_id)
+      driver.destroy(state)
+      expect(state[:subscription_id]).to eq("115b12cb-b0d3-4ed9-94db-f73733be6f3c")
+    end
+  end
+
+  describe "when the instance was never created" do
+    let(:state) { {} }
+
+    it "does nothing" do
+      driver.destroy(state)
+      expect(resource_groups).not_to have_received(:begin_delete)
+    end
+
+    context "with an explicit resource group the user asked to destroy" do
+      let(:config) { { explicit_resource_group_name: "my-shared-rg" } }
+
+      it "deletes the group anyway" do
+        driver.destroy(state)
+        expect(resource_groups).to have_received(:begin_delete).with("my-shared-rg")
+      end
+
+      it "explains why it is doing so" do
+        allow(Kitchen.logger).to receive(:info)
+        driver.destroy(state)
+        expect(Kitchen.logger).to have_received(:info).with(/This instance doesn't exist but you asked to delete the resource group/)
+      end
+
+      it "does nothing when the group does not exist" do
+        allow(resource_groups).to receive(:check_existence).and_return(false)
+        driver.destroy(state)
+        expect(resource_groups).not_to have_received(:begin_delete)
+      end
+
+      it "re-raises an Azure failure" do
+        allow(resource_groups).to receive(:begin_delete).and_raise(azure_operation_error(code: "AuthorizationFailed"))
+        expect { driver.destroy(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+      end
+
+      context "but destroy_explicit_resource_group is off" do
+        let(:config) { super().merge(destroy_explicit_resource_group: false) }
+
+        it "leaves the group alone" do
+          driver.destroy(state)
+          expect(resource_groups).not_to have_received(:begin_delete)
+        end
+      end
+    end
+  end
+
+  describe "with destroy_explicit_resource_group disabled" do
+    let(:config) { { explicit_resource_group_name: "my-shared-rg", destroy_explicit_resource_group: false } }
+
+    it "keeps the resource group" do
+      driver.destroy(state)
+      expect(resource_groups).not_to have_received(:begin_delete)
+    end
+
+    it "warns the user that resources are still running" do
+      allow(Kitchen.logger).to receive(:warn)
+      driver.destroy(state)
+      expect(Kitchen.logger).to have_received(:warn).with(/Remember to manually destroy resources/)
+    end
+
+    it "returns the state untouched" do
+      expect(driver.destroy(state)).to include(server_id: "vmabc123", hostname: "40.121.0.1")
+    end
+
+    context "and destroy_resource_group_contents enabled" do
+      let(:config) { super().merge(destroy_resource_group_contents: true) }
+
+      it "empties the group instead of deleting it" do
+        driver.destroy(state)
+        expect(resource_client.deployments).to have_received(:begin_create_or_update_async)
+          .with("kitchen-default-20260822T134505", "empty-deploy-abc123", anything)
+      end
+
+      it "does not nag about manual cleanup" do
+        allow(Kitchen.logger).to receive(:warn)
+        driver.destroy(state)
+        expect(Kitchen.logger).not_to have_received(:warn).with(/Remember to manually destroy resources/)
+      end
+    end
+  end
+
+  describe "with destroy_resource_group_contents enabled" do
+    let(:config) { { destroy_resource_group_contents: true, location: "eastus2", resource_group_tags: { owner: "platform" } } }
+
+    it "submits an empty Complete-mode deployment" do
+      driver.destroy(state)
+      expect(resource_client.deployments).to have_received(:begin_create_or_update_async) do |_rg, _name, deployment|
+        expect(deployment.properties.mode).to eq(Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Complete)
+        expect(deployment.properties.template["resources"]).to eq([])
+      end
+    end
+
+    it "then deletes the group itself" do
+      driver.destroy(state)
+      expect(resource_groups).to have_received(:begin_delete).with("kitchen-default-20260822T134505")
+    end
+
+    describe "tag handling" do
+      it "clears the tags by default" do
+        driver.destroy(state)
+        expect(resource_groups).to have_received(:create_or_update) do |_name, group|
+          expect(group.tags).to eq({})
+        end
+      end
+
+      it "says so" do
+        allow(Kitchen.logger).to receive(:warn)
+        driver.destroy(state)
+        expect(Kitchen.logger).to have_received(:warn).with(/tags on the resource group will be removed/)
+      end
+
+      context "with destroy_explicit_resource_group_tags disabled" do
+        let(:config) { super().merge(destroy_explicit_resource_group_tags: false) }
+
+        it "restores the configured tags instead" do
+          driver.destroy(state)
+          expect(resource_groups).to have_received(:create_or_update) do |_name, group|
+            expect(group.tags).to eq(owner: "platform")
+          end
+        end
+
+        it "says so" do
+          allow(Kitchen.logger).to receive(:warn)
+          driver.destroy(state)
+          expect(Kitchen.logger).to have_received(:warn).with(/tags on the resource group will NOT be removed/)
+        end
+
+        it "does not also clear them" do
+          driver.destroy(state)
+          expect(resource_groups).to have_received(:create_or_update).once
+        end
+      end
+    end
+
+    it "re-raises an Azure failure from the empty deployment" do
+      allow(resource_client.deployments).to receive(:begin_create_or_update_async)
+        .and_raise(azure_operation_error(code: "DeploymentFailed"))
+
+      expect { driver.destroy(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azurerm/state_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/state_spec.rb
@@ -1,0 +1,168 @@
+RSpec.describe Kitchen::Driver::Azurerm, "state management" do
+  subject(:driver) { build_driver(transport:, **config) }
+
+  let(:config) { {} }
+  let(:transport) { transport_double }
+  let(:state) { {} }
+
+  describe "#existing_state_value?" do
+    it "is false when the key is absent" do
+      expect(driver.existing_state_value?({}, :uuid)).to be false
+    end
+
+    it "is false when the value is nil" do
+      expect(driver.existing_state_value?({ uuid: nil }, :uuid)).to be false
+    end
+
+    it "is true when the value is present" do
+      expect(driver.existing_state_value?({ uuid: "abc" }, :uuid)).to be true
+    end
+
+    it "is true for a falsey but non-nil value" do
+      expect(driver.existing_state_value?({ use_managed_disks: false }, :use_managed_disks)).to be true
+    end
+  end
+
+  describe "#validate_state" do
+    it "returns the same Hash it was given" do
+      expect(driver.validate_state(state)).to equal(state)
+    end
+
+    it "defaults to an empty state" do
+      expect(driver.validate_state).to include(:uuid, :vm_name, :server_id)
+    end
+
+    describe "uuid" do
+      it "generates a 16 character hex uuid" do
+        driver.validate_state(state)
+        expect(state[:uuid]).to match(/\A[0-9a-f]{16}\z/)
+      end
+
+      it "generates a different uuid each time" do
+        first = driver.validate_state({})[:uuid]
+        expect(driver.validate_state({})[:uuid]).not_to eq(first)
+      end
+
+      it "keeps an existing uuid" do
+        expect(driver.validate_state(uuid: "deadbeefdeadbeef")[:uuid]).to eq("deadbeefdeadbeef")
+      end
+    end
+
+    describe "server_id" do
+      it "derives from the uuid" do
+        driver.validate_state(state)
+        expect(state[:server_id]).to eq("vm#{state[:uuid]}")
+      end
+
+      it "keeps an existing server_id" do
+        expect(driver.validate_state(server_id: "vmexisting")[:server_id]).to eq("vmexisting")
+      end
+    end
+
+    describe "vm_name" do
+      it "uses the configured vm_name verbatim" do
+        driver = build_driver(vm_name: "my-awesome-vm")
+        expect(driver.validate_state({})[:vm_name]).to eq("my-awesome-vm")
+      end
+
+      it "generates a name from the default prefix and the uuid" do
+        driver.validate_state(state)
+        expect(state[:vm_name]).to start_with("tk-")
+        expect(state[:vm_name].length).to eq(15)
+      end
+
+      it "honours a custom vm_prefix" do
+        driver = build_driver(vm_prefix: "ab-")
+        expect(driver.validate_state({})[:vm_name]).to start_with("ab-")
+      end
+
+      # Azure caps Windows computer names at 15 characters. A prefix longer
+      # than the documented three characters used to push the generated name
+      # past that limit, producing a deployment Azure rejects.
+      it "never exceeds 15 characters, whatever the prefix" do
+        driver = build_driver(vm_prefix: "a-very-long-prefix-")
+        expect(driver.validate_state({})[:vm_name].length).to eq(15)
+      end
+
+      it "still includes uuid entropy with a longer-than-documented prefix" do
+        driver = build_driver(vm_prefix: "kitchen-")
+        name = driver.validate_state({})[:vm_name]
+        expect(name).to start_with("kitchen-")
+        expect(name.length).to eq(15)
+      end
+
+      it "keeps an existing vm_name" do
+        expect(driver.validate_state(vm_name: "from-state")[:vm_name]).to eq("from-state")
+      end
+    end
+
+    describe "azure_resource_group_name" do
+      it "is generated when absent" do
+        driver.validate_state(state)
+        expect(state[:azure_resource_group_name]).to start_with("kitchen-default-ubuntu-2204-")
+      end
+
+      it "keeps an existing name, so a re-run targets the same group" do
+        expect(driver.validate_state(azure_resource_group_name: "kitchen-existing")[:azure_resource_group_name])
+          .to eq("kitchen-existing")
+      end
+    end
+
+    describe "config values copied into state" do
+      let(:config) { { subscription_id: "sub-123", azure_environment: "AzureChina", use_managed_disks: false } }
+
+      it "copies subscription_id, azure_environment and use_managed_disks" do
+        driver.validate_state(state)
+        expect(state).to include(subscription_id: "sub-123", azure_environment: "AzureChina", use_managed_disks: false)
+      end
+
+      it "does not overwrite values already in state" do
+        driver.validate_state(state.merge!(subscription_id: "sub-from-state"))
+        expect(state[:subscription_id]).to eq("sub-from-state")
+      end
+    end
+
+    describe "password handling" do
+      context "when the transport uses a password" do
+        it "leaves an existing password alone" do
+          expect(driver.validate_state(password: "hunter2")[:password]).to eq("hunter2")
+        end
+      end
+
+      context "when the transport uses an SSH key" do
+        let(:transport) { transport_double(name: "Ssh", ssh_key: "~/.ssh/id_rsa") }
+
+        it "removes any password from state" do
+          expect(driver.validate_state(password: "hunter2")).not_to have_key(:password)
+        end
+      end
+    end
+  end
+
+  describe "#azure_resource_group_name" do
+    # Freeze time so the timestamp component is deterministic. The clock is
+    # deliberately set to a non-UTC zone so that a missing .utc call shows up.
+    before { allow(Time).to receive(:now).and_return(Time.new(2026, 8, 22, 18, 45, 5, "+05:00")) }
+
+    it "combines the prefix, instance name, timestamp and suffix" do
+      expect(driver.azure_resource_group_name).to eq("kitchen-default-ubuntu-2204-20260822T134505")
+    end
+
+    it "applies a configured prefix and suffix" do
+      driver = build_driver(azure_resource_group_prefix: "tk_", azure_resource_group_suffix: "_ci")
+      expect(driver.azure_resource_group_name).to eq("tk_default-ubuntu-2204-20260822T134505_ci")
+    end
+
+    it "stamps the name in UTC rather than the local zone" do
+      expect(driver.azure_resource_group_name).to end_with("20260822T134505")
+    end
+
+    context "when explicit_resource_group_name is set" do
+      let(:config) { { explicit_resource_group_name: "my-existing-rg" } }
+
+      it "uses it verbatim, with no timestamp" do
+        expect(driver.azure_resource_group_name).to eq("my-existing-rg")
+      end
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -1,0 +1,503 @@
+RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
+  subject(:driver) { build_driver(transport:, platform_name:, **config) }
+
+  let(:config) { {} }
+  let(:transport) { transport_double }
+  let(:platform_name) { "ubuntu-22.04" }
+
+  describe "#virtual_machine_deployment_template" do
+    it "renders valid JSON for the default configuration" do
+      expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+    end
+
+    it "uses the public template when no vnet is configured" do
+      expect(driver).to receive(:virtual_machine_deployment_template_file).with("public.erb", any_args)
+      driver.virtual_machine_deployment_template
+    end
+
+    context "when a vnet_id is configured" do
+      let(:config) { { vnet_id: "/subscriptions/x/resourceGroups/y/providers/Microsoft.Network/virtualNetworks/vnet", subnet_id: "subnet-1" } }
+
+      it "renders valid JSON" do
+        expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+      end
+
+      it "uses the internal template" do
+        expect(driver).to receive(:virtual_machine_deployment_template_file).with("internal.erb", any_args)
+        driver.virtual_machine_deployment_template
+      end
+
+      it "logs which vnet is in use" do
+        allow(Kitchen.logger).to receive(:info)
+        driver.virtual_machine_deployment_template
+        expect(Kitchen.logger).to have_received(:info).with(%r{Using custom vnet: .*virtualNetworks/vnet})
+      end
+
+      it "references the configured subnet" do
+        expect(driver.virtual_machine_deployment_template).to include("subnet-1")
+      end
+
+      it "creates no public IP resource by default" do
+        expect(resource_types(rendered_template(driver))).not_to include("Microsoft.Network/publicIPAddresses")
+      end
+
+      context "with public_ip enabled" do
+        let(:config) { super().merge(public_ip: true) }
+
+        it "creates a public IP resource" do
+          expect(resource_types(rendered_template(driver))).to include("Microsoft.Network/publicIPAddresses")
+        end
+      end
+    end
+
+    describe "marketplace plan" do
+      context "when a plan is configured" do
+        let(:config) do
+          {
+            plan: { name: "plan-abc", product: "my-product", publisher: "captain-america", promotion_code: "50-percent-off" },
+          }
+        end
+
+        it "puts the plan on the virtual machine resource" do
+          expect(vm_resource(rendered_template(driver))["plan"]).to eq(
+            "name" => "plan-abc",
+            "product" => "my-product",
+            "publisher" => "captain-america",
+            "promotionCode" => "50-percent-off"
+          )
+        end
+      end
+
+      context "when no plan is configured" do
+        it "omits the plan" do
+          expect(vm_resource(rendered_template(driver))).not_to have_key("plan")
+        end
+      end
+
+      context "when a partial plan is configured" do
+        let(:config) { { plan: { name: "plan-abc", publisher: "captain-america" } } }
+
+        it "emits only the keys that were given" do
+          expect(vm_resource(rendered_template(driver))["plan"].keys).to contain_exactly("name", "publisher")
+        end
+      end
+
+      context "when the plan omits the name and publisher" do
+        let(:config) { { plan: { product: "my-product", promotion_code: "code" } } }
+
+        it "emits only the keys that were given" do
+          expect(vm_resource(rendered_template(driver))["plan"])
+            .to eq("product" => "my-product", "promotionCode" => "code")
+        end
+      end
+    end
+
+    describe "key vault certificates" do
+      # These three settings had never reached the template - the renderer did
+      # not pass them into the ERB binding, so OpenStruct returned nil and the
+      # block was always skipped.
+      context "when secret_url, vault_name and vault_resource_group are set" do
+        let(:config) do
+          {
+            secret_url: "https://my-vault.vault.azure.net/secrets/winrm/abc123",
+            vault_name: "my-vault",
+            vault_resource_group: "vault-rg",
+          }
+        end
+
+        it "still renders valid JSON" do
+          expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+        end
+
+        it "adds a secrets block to the osProfile" do
+          os_profile = vm_resource(rendered_template(driver))["properties"]["osProfile"]
+          expect(os_profile["secrets"]).to eq(
+            [
+              {
+                "sourceVault" => { "id" => "[resourceId(parameters('vaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]" },
+                "vaultCertificates" => [{ "certificateUrl" => "[parameters('secretUrl')]", "certificateStore" => "My" }],
+              },
+            ]
+          )
+        end
+
+        it "uses the correct resource provider namespace" do
+          expect(driver.virtual_machine_deployment_template).to include("Microsoft.KeyVault/vaults")
+          expect(driver.virtual_machine_deployment_template).not_to include("Microsoft,KeyVault")
+        end
+
+        it "renders for the internal template too" do
+          driver = build_driver(**config, vnet_id: "/vnet", subnet_id: "/subnet")
+          expect(vm_resource(rendered_template(driver))["properties"]["osProfile"]).to have_key("secrets")
+        end
+      end
+
+      context "when only some of the key vault settings are given" do
+        let(:config) { { vault_name: "my-vault" } }
+
+        it "still emits the secrets block, so ARM reports the missing pieces" do
+          expect(vm_resource(rendered_template(driver))["properties"]["osProfile"]).to have_key("secrets")
+        end
+      end
+
+      context "when none are set" do
+        it "omits the secrets block" do
+          expect(vm_resource(rendered_template(driver))["properties"]["osProfile"]).not_to have_key("secrets")
+        end
+      end
+    end
+
+    describe "vm tags" do
+      let(:config) { { vm_tags: { os_type: "linux", distro: "redhat" } } }
+
+      it "applies the tags to the virtual machine" do
+        expect(vm_resource(rendered_template(driver))["tags"]).to eq("os_type" => "linux", "distro" => "redhat")
+      end
+
+      it "applies the tags to every taggable resource" do
+        tagged = rendered_template(driver)["resources"].select { |r| r["tags"]&.any? }
+        expect(tagged.length).to be > 1
+      end
+
+      context "when a tag value contains a double quote" do
+        let(:config) { { vm_tags: { note: 'he said "hello"' } } }
+
+        it "does not produce an unparseable template" do
+          expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+        end
+
+        it "round-trips the value intact" do
+          expect(vm_resource(rendered_template(driver))["tags"]["note"]).to eq('he said "hello"')
+        end
+      end
+
+      context "when a tag value contains a backslash" do
+        let(:config) { { vm_tags: { path: 'C:\\Windows' } } }
+
+        it "round-trips the value intact" do
+          expect(vm_resource(rendered_template(driver))["tags"]["path"]).to eq('C:\\Windows')
+        end
+      end
+    end
+
+    describe "image selection" do
+      it "defaults to a marketplace image reference" do
+        image = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["imageReference"]
+        expect(image).to include("publisher", "offer", "sku", "version")
+      end
+
+      context "with an image_id" do
+        let(:config) { { image_id: "/subscriptions/x/resourceGroups/y/providers/Microsoft.Compute/images/my-image" } }
+
+        it "references the managed image by id" do
+          image = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["imageReference"]
+          expect(image).to eq("id" => "[parameters('imageId')]")
+        end
+      end
+
+      context "with an image_url" do
+        let(:config) { { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd", use_managed_disks: false } }
+
+        it "renders valid JSON" do
+          expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+        end
+
+        it "does not reference a marketplace image" do
+          expect(vm_resource(rendered_template(driver))["properties"]["storageProfile"]).not_to have_key("imageReference")
+        end
+      end
+    end
+
+    describe "os disk options" do
+      context "with use_ephemeral_osdisk" do
+        let(:config) { { use_ephemeral_osdisk: true } }
+
+        it "sets the ephemeral disk placement" do
+          os_disk = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["osDisk"]
+          expect(os_disk["diffDiskSettings"]).to eq("option" => "Local")
+        end
+      end
+
+      context "with os_disk_size_gb" do
+        let(:config) { { os_disk_size_gb: 128 } }
+
+        it "sets the disk size from the parameter" do
+          os_disk = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["osDisk"]
+          expect(os_disk["diskSizeGB"]).to eq("[parameters('osDiskSizeGb')]")
+        end
+      end
+
+      context "with no os_disk_size_gb" do
+        it "omits the disk size" do
+          os_disk = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["osDisk"]
+          expect(os_disk).not_to have_key("diskSizeGB")
+        end
+      end
+    end
+
+    describe "data disks" do
+      context "with managed disks" do
+        let(:config) { { data_disks: [{ lun: 0, disk_size_gb: 128 }, { lun: 1, disk_size_gb: 256 }] } }
+
+        it "adds one entry per configured disk" do
+          disks = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["dataDisks"]
+          expect(disks).to eq(
+            [
+              { "name" => "datadisk0", "lun" => 0, "diskSizeGB" => 128, "createOption" => "Empty" },
+              { "name" => "datadisk1", "lun" => 1, "diskSizeGB" => 256, "createOption" => "Empty" },
+            ]
+          )
+        end
+      end
+
+      context "without data_disks" do
+        it "omits the dataDisks key entirely" do
+          expect(vm_resource(rendered_template(driver))["properties"]["storageProfile"]).not_to have_key("dataDisks")
+        end
+      end
+    end
+  end
+
+  describe "#data_disks_for_vm_json" do
+    it "is nil when no data disks are configured" do
+      expect(driver.data_disks_for_vm_json).to be_nil
+    end
+
+    context "with unmanaged disks" do
+      let(:config) { { use_managed_disks: false, data_disks: [{ lun: 0, disk_size_gb: 128 }] } }
+
+      it "warns that data disks need managed disks" do
+        allow(Kitchen.logger).to receive(:warn)
+        driver.data_disks_for_vm_json
+        expect(Kitchen.logger).to have_received(:warn).with(/only supported when used with the "use_managed_disks" option/)
+      end
+
+      it "returns an empty JSON array" do
+        expect(driver.data_disks_for_vm_json).to eq("[]")
+      end
+    end
+  end
+
+  describe "#vm_tag_string" do
+    it "is empty for no tags" do
+      expect(driver.vm_tag_string({})).to eq("")
+    end
+
+    it "is empty for nil" do
+      expect(driver.vm_tag_string(nil)).to eq("")
+    end
+
+    it "renders a single tag with no trailing comma" do
+      expect(driver.vm_tag_string(env: "prod")).to eq('"env": "prod"')
+    end
+
+    it "separates multiple tags with a comma and newline" do
+      expect(driver.vm_tag_string(a: "1", b: "2")).to eq(%{"a": "1",\n"b": "2"})
+    end
+
+    it "escapes characters that would break the surrounding JSON" do
+      expect(driver.vm_tag_string(note: 'a "quoted" value')).to eq('"note": "a \"quoted\" value"')
+    end
+
+    it "stringifies non-string values" do
+      expect(driver.vm_tag_string(count: 3)).to eq('"count": "3"')
+    end
+  end
+
+  describe "#plan_json" do
+    it "is nil when no plan is configured" do
+      expect(driver.plan_json).to be_nil
+    end
+
+    context "when plan is explicitly nil" do
+      let(:config) { { plan: nil } }
+
+      it "is nil rather than raising" do
+        expect(driver.plan_json).to be_nil
+      end
+    end
+
+    context "with a full plan" do
+      let(:config) { { plan: { name: "n", product: "p", publisher: "pub", promotion_code: "code" } } }
+
+      it "maps promotion_code to the ARM promotionCode key" do
+        expect(JSON.parse(driver.plan_json)).to eq("name" => "n", "product" => "p", "promotionCode" => "code", "publisher" => "pub")
+      end
+    end
+  end
+
+  describe "#template_for_transport_name" do
+    context "with an SSH transport carrying a key" do
+      let(:transport) { transport_double(name: "Ssh", ssh_key: ssh_key_path) }
+      let(:ssh_key_path) { File.join(ENV.fetch("HOME"), "id_rsa") }
+
+      it "generates a key pair when the private key does not exist" do
+        driver.template_for_transport_name
+        expect(File).to exist(ssh_key_path)
+        expect(File).to exist("#{ssh_key_path}.pub")
+      end
+
+      it "creates the private key with 0600 permissions" do
+        driver.template_for_transport_name
+        expect(File.stat(ssh_key_path).mode & 0777).to eq(0600)
+      end
+
+      it "injects the public key into the linux configuration" do
+        template = JSON.parse(driver.template_for_transport_name)
+        linux = vm_resource(template)["properties"]["osProfile"]["linuxConfiguration"]
+        expect(linux["disablePasswordAuthentication"]).to eq("true")
+        expect(linux["ssh"]["publicKeys"].first["keyData"]).to start_with("ssh-rsa ")
+      end
+
+      it "omits adminPassword from the template" do
+        expect(driver.template_for_transport_name).not_to include("adminPassword")
+      end
+
+      context "when the private key already exists" do
+        before do
+          File.write(ssh_key_path, "an existing private key")
+          File.write("#{ssh_key_path}.pub", "ssh-rsa AAAAEXISTING existing@key\n")
+        end
+
+        it "reads the adjacent .pub file rather than generating a new key" do
+          template = JSON.parse(driver.template_for_transport_name)
+          key_data = vm_resource(template)["properties"]["osProfile"]["linuxConfiguration"]["ssh"]["publicKeys"].first["keyData"]
+          expect(key_data).to eq("ssh-rsa AAAAEXISTING existing@key")
+        end
+
+        it "does not overwrite the existing private key" do
+          driver.template_for_transport_name
+          expect(File.read(ssh_key_path)).to eq("an existing private key")
+        end
+
+        context "and ssh_public_key names a different file" do
+          let(:transport) { transport_double(name: "Ssh", ssh_key: ssh_key_path, ssh_public_key: explicit_public_key) }
+          let(:explicit_public_key) { File.join(ENV.fetch("HOME"), "elsewhere.pub") }
+
+          before { File.write(explicit_public_key, "ssh-rsa AAAAEXPLICIT explicit@key\n") }
+
+          it "uses the explicitly configured public key" do
+            template = JSON.parse(driver.template_for_transport_name)
+            key_data = vm_resource(template)["properties"]["osProfile"]["linuxConfiguration"]["ssh"]["publicKeys"].first["keyData"]
+            expect(key_data).to eq("ssh-rsa AAAAEXPLICIT explicit@key")
+          end
+        end
+      end
+    end
+
+    context "with a WinRM transport" do
+      let(:transport) { transport_double(name: "Winrm") }
+      let(:platform_name) { "windows-2022" }
+      let(:os_profile) { vm_resource(JSON.parse(driver.template_for_transport_name))["properties"]["osProfile"] }
+
+      it "adds base64 custom data that configures WinRM" do
+        expect(Base64.decode64(os_profile["customData"])).to include("winrm create winrm/config/listener")
+      end
+
+      it "adds the unattend content that runs the script on first logon" do
+        content = os_profile["windowsConfiguration"]["additionalUnattendContent"]
+        expect(content.map { |entry| entry["settingName"] }).to contain_exactly("FirstLogonCommands", "AutoLogon")
+      end
+
+      it "still renders valid JSON" do
+        expect(driver.template_for_transport_name).to be_a_valid_arm_template
+      end
+
+      context "on Nano Server, which has no WinRM bootstrap" do
+        let(:platform_name) { "windows-nano" }
+
+        it "adds no custom data" do
+          expect(os_profile).not_to have_key("customData")
+        end
+      end
+
+      context "with format_data_disks enabled" do
+        let(:config) { { format_data_disks: true, data_disks: [{ lun: 0, disk_size_gb: 128 }] } }
+
+        it "includes the disk formatting script in custom data" do
+          expect(Base64.decode64(os_profile["customData"])).to include("Initializing and formatting raw disks")
+        end
+
+        it "announces that the disks will be formatted" do
+          allow(Kitchen.logger).to receive(:info)
+          os_profile
+          expect(Kitchen.logger).to have_received(:info).with(/Data disks will be initialized and formatted NTFS/)
+        end
+      end
+
+      context "with format_data_disks enabled but no data disks" do
+        let(:config) { { format_data_disks: true } }
+
+        it "still emits the formatting script, harmlessly" do
+          expect(Base64.decode64(os_profile["customData"])).to include("Initializing and formatting raw disks")
+        end
+
+        it "does not claim any disks will be formatted" do
+          allow(Kitchen.logger).to receive(:info)
+          os_profile
+          expect(Kitchen.logger).not_to have_received(:info).with(/Data disks will be initialized/)
+        end
+      end
+
+      context "with a custom winrm_powershell_script" do
+        let(:config) { { winrm_powershell_script: "Write-Host 'my own bootstrap'" } }
+
+        it "uses the supplied script instead of the default" do
+          decoded = Base64.decode64(os_profile["customData"])
+          expect(decoded).to include("my own bootstrap")
+          expect(decoded).not_to include("New-SelfSignedCertificate")
+        end
+      end
+    end
+
+    context "with a transport that is neither SSH-keyed nor WinRM" do
+      it "leaves the template untouched" do
+        expect(JSON.parse(driver.template_for_transport_name)).to eq(rendered_template(driver))
+      end
+    end
+  end
+
+  describe "#prepared_custom_data" do
+    it "is nil when custom_data is not configured" do
+      expect(build_driver(custom_data: nil).prepared_custom_data).to be_nil
+    end
+
+    context "with inline content" do
+      let(:config) { { custom_data: "#!/bin/sh\necho hello\n" } }
+
+      it "base64 encodes it" do
+        expect(Base64.decode64(driver.prepared_custom_data)).to eq("#!/bin/sh\necho hello\n")
+      end
+
+      it "memoizes the result" do
+        expect(driver.prepared_custom_data).to equal(driver.prepared_custom_data)
+      end
+    end
+
+    context "with a path to a file" do
+      let(:path) { File.join(ENV.fetch("HOME"), "cloud-init.yml") }
+      let(:config) { { custom_data: path } }
+
+      before { File.write(path, "#cloud-config\npackages:\n  - htop\n") }
+
+      it "base64 encodes the file's contents" do
+        expect(Base64.decode64(driver.prepared_custom_data)).to eq("#cloud-config\npackages:\n  - htop\n")
+      end
+    end
+
+    context "with a multi-line document that resembles nothing on disk" do
+      let(:config) { { custom_data: "#cloud-config\n#{"x" * 5000}\n" } }
+
+      it "encodes it inline without touching the filesystem" do
+        expect(File).not_to receive(:file?)
+        expect(Base64.decode64(driver.prepared_custom_data)).to start_with("#cloud-config")
+      end
+    end
+  end
+
+  # @param template [Hash] a parsed ARM template.
+  # @return [Array<String>] the type of every resource in the template.
+  def resource_types(template)
+    template["resources"].map { |resource| resource["type"] }
+  end
+end

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -1,328 +1,118 @@
-require "spec_helper"
-require "kitchen/transport/dummy"
+RSpec.describe Kitchen::Driver::Azurerm do
+  subject(:driver) { build_driver }
 
-describe Kitchen::Driver::Azurerm do
-  let(:logged_output) { StringIO.new }
-  let(:logger)        { Logger.new(logged_output) }
-  let(:platform)      { Kitchen::Platform.new(name: "fake_platform") }
-  let(:transport)     { Kitchen::Transport::Dummy.new }
-  let(:instance_name) { "my-instance-name" }
-  let(:driver)        { described_class.new(config) }
+  describe "plugin identity" do
+    it "declares driver API version 2" do
+      expect(driver.diagnose_plugin[:api_version]).to eq(2)
+    end
 
-  let(:subscription_id) { "115b12cb-b0d3-4ed9-94db-f73733be6f3c" }
-  let(:location) { "eastus2" }
-  let(:machine_size) { "Standard_D4_v3" }
-  let(:vm_tags) do
-    {
-      os_type: "linux",
-      distro: "redhat",
-    }
-  end
-
-  let(:azure_environment) { "AzureChina" }
-
-  let(:image_urn) { "RedHat:rhel-byos:rhel-raw76:7.6.20190620" }
-  let(:vm_name) { "my-awesome-vm" }
-
-  let(:config) do
-    {
-      subscription_id: subscription_id,
-      location: location,
-      machine_size: machine_size,
-      vm_tags: vm_tags,
-      image_urn: image_urn,
-      vm_name: vm_name,
-      azure_environment: azure_environment,
-    }
-  end
-
-  let(:credentials) do
-    Kitchen::Driver::AzureCredentials.new(subscription_id: config[:subscription_id],
-      environment: config[:azure_environment])
-  end
-
-  let(:options) do
-    credentials.azure_options
-  end
-
-  let(:client) do
-    Azure::Resources2::Profiles::Latest::Mgmt::Client.new(options)
-  end
-
-  let(:instance) do
-    instance_double(Kitchen::Instance,
-      name:      instance_name,
-      logger:    logger,
-      transport: transport,
-      platform:  platform,
-      to_str:    "instance_str")
-  end
-
-  let(:resource_group) do
-    Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup.new
-  end
-
-  let(:resource_groups) do
-    client.resource_groups
-  end
-
-  before do
-    allow(driver).to receive(:instance).and_return(instance)
-  end
-
-  it "driver API version is 2" do
-    expect(driver.diagnose_plugin[:api_version]).to eq(2)
-  end
-
-  describe "#name" do
-    it "has an overridden name" do
+    it "is named Azurerm" do
       expect(driver.name).to eq("Azurerm")
     end
-  end
 
-  describe "#default_config" do
-    let(:default_config) { driver.instance_variable_get(:@config) }
-
-    it "Should have the username option available" do
-      expect(default_config).to have_key(:username)
-    end
-
-    it "Should use 'azure' as the default username" do
-      expect(default_config[:username]).to eq("azure")
-    end
-
-    it "Should have the password option available" do
-      expect(default_config).to have_key(:password)
-    end
-
-    it "Should have the use_fqdn_hostname option available" do
-      expect(default_config).to have_key(:use_fqdn_hostname)
-    end
-
-    it "Should use the IP to communicate with VM by default" do
-      expect(default_config[:use_fqdn_hostname]).to eq(false)
-    end
-
-    it "Should use basic public IP resources" do
-      expect(default_config[:public_ip_sku]).to eq("Basic")
-    end
-
-    it "should set store_deployment_credentials_in_state to true" do
-      expect(default_config[:store_deployment_credentials_in_state]).to eq(true)
-    end
-
-    it "Should use tk- vm prefix" do
-      expect(default_config[:vm_prefix]).to eq("tk-")
+    it "is a Test Kitchen driver" do
+      expect(driver).to be_a(Kitchen::Driver::Base)
     end
   end
 
-  describe "#validate_state" do
-    let(:state) { {} }
-    let(:uuid) { SecureRandom.hex(8) }
+  describe "default configuration" do
+    subject(:config) { driver_config(driver) }
 
-    it "generates uuid, when one does not exist" do
-      driver.validate_state(state)
-      expect(state[:uuid].length).to eq(16)
-      expect(state[:uuid]).to be_an_instance_of(String)
-      expect(state[:uuid]).not_to eq(uuid)
+    # Every default that a user could reasonably depend on. Changing one of
+    # these is a breaking change for someone's kitchen.yml, so they are pinned
+    # explicitly rather than asserted loosely.
+    {
+      azure_resource_group_prefix: "kitchen-",
+      azure_resource_group_suffix: "",
+      explicit_resource_group_name: nil,
+      resource_group_tags: {},
+      image_url: "",
+      image_id: "",
+      use_ephemeral_osdisk: false,
+      os_disk_size_gb: "",
+      os_type: "linux",
+      custom_data: "",
+      username: "azure",
+      vm_prefix: "tk-",
+      vm_name: nil,
+      store_deployment_credentials_in_state: true,
+      nic_name: "",
+      vnet_id: "",
+      subnet_id: "",
+      storage_account_type: "Standard_LRS",
+      existing_storage_account_blob_url: "",
+      existing_storage_account_container: "vhds",
+      boot_diagnostics_enabled: "true",
+      winrm_powershell_script: false,
+      azure_environment: "Azure",
+      pre_deployment_template: "",
+      pre_deployment_parameters: {},
+      post_deployment_template: "",
+      post_deployment_parameters: {},
+      plan: {},
+      vm_tags: {},
+      public_ip: false,
+      use_managed_disks: true,
+      data_disks: nil,
+      format_data_disks: false,
+      format_data_disks_powershell_script: false,
+      system_assigned_identity: false,
+      user_assigned_identities: [],
+      destroy_explicit_resource_group: true,
+      destroy_explicit_resource_group_tags: true,
+      destroy_resource_group_contents: false,
+      deployment_sleep: 10,
+      secret_url: "",
+      vault_name: "",
+      vault_resource_group: "",
+      public_ip_sku: "Basic",
+      azure_api_retries: 5,
+      use_fqdn_hostname: false,
+    }.each do |key, expected|
+      it "defaults #{key} to #{expected.inspect}" do
+        # deployment_sleep is overridden by the test helper so the poller does
+        # not wait; assert on a driver built without that override.
+        driver = described_class.new({})
+        allow(driver).to receive(:instance).and_return(instance_double(Kitchen::Instance, name: "default-ubuntu-2204"))
+        expect(driver_config(driver)[key]).to eq(expected)
+      end
     end
 
-    it "does not set uuid, when one exists" do
-      state[:uuid] = uuid
-      driver.validate_state(state)
-      expect(state[:uuid]).to eq(uuid)
+    # Canonical retired the "UbuntuServer" offer after 18.04, so the old
+    # default could not be deployed at all.
+    it "defaults image_urn to a Marketplace image that still exists" do
+      expect(described_class.new({}).instance_variable_get(:@config)[:image_urn])
+        .to eq("Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest")
     end
 
-    context "when vm_name is set in config" do
-      before do
-        config[:vm_name] = vm_name
-      end
-
-      it "sets state[:vm_name] to config vm_name" do
-        driver.validate_state(state)
-        expect(state[:vm_name]).to eq(vm_name)
-      end
+    it "generates a random password" do
+      expect(config[:password]).to be_a(String)
+      expect(config[:password].length).to be >= 32
     end
 
-    context "when vm_name is not set in config" do
-      before do
-        config.delete(:vm_name)
-      end
+    it "generates a different password for every instance" do
+      expect(build_driver_password).not_to eq(build_driver_password)
+    end
 
-      it "generates vm_name, when one does not exist in state" do
-        driver.validate_state(state)
-        expect(state[:vm_name].length).to eq(15)
-        expect(state[:vm_name]).to be_an_instance_of(String)
-        expect(state[:vm_name]).not_to eq(vm_name)
-        expect(state[:vm_name]).to start_with("tk-")
-      end
+    it "names the resource group after the instance" do
+      other = build_driver(instance_name: "windows-2022")
+      expect(driver_config(other)[:azure_resource_group_name]).to eq("windows-2022")
+    end
 
-      it "does not generate vm_name, when one exists in state" do
-        vm_name_in_state = "blah-doh"
-        state[:vm_name] = vm_name_in_state
-        driver.validate_state(state)
-        expect(state[:vm_name]).to eq(vm_name_in_state)
-      end
+    it "reads subscription_id from AZURE_SUBSCRIPTION_ID when unset" do
+      ENV["AZURE_SUBSCRIPTION_ID"] = "from-the-environment"
+      driver = described_class.new({})
+      allow(driver).to receive(:instance).and_return(instance_double(Kitchen::Instance, name: "default"))
+      expect(driver_config(driver)[:subscription_id]).to eq("from-the-environment")
+    end
 
-      context "when vm_prefix is set in config" do
-        before do
-          config[:vm_prefix] = "ab-"
-        end
-
-        it "generates vm_name with prefix, when one does not exist in state" do
-          driver.validate_state(state)
-          expect(state[:vm_name].length).to eq(15)
-          expect(state[:vm_name]).to be_an_instance_of(String)
-          expect(state[:vm_name]).not_to eq(vm_name)
-          expect(state[:vm_name]).to start_with("ab-")
-        end
-      end
+    it "lets kitchen.yml override subscription_id" do
+      ENV["AZURE_SUBSCRIPTION_ID"] = "from-the-environment"
+      expect(driver_config(build_driver(subscription_id: "explicit"))[:subscription_id]).to eq("explicit")
     end
   end
 
-  describe "#create" do
-    let(:tenant_id) { "2d38055e-66a1-435c-be53-TENANT_ID" }
-    let(:client_id) { "2e201a46-44a8-4508-84aa-CLIENT_ID" }
-    let(:client_secret) { "2e201a46-44a8-4508-84aa-CLIENT_SECRET" }
-    let(:environment) { "AzureChina" }
-    let(:resource_group_name) { "testingrocks" }
-    let(:base_url) { "https://management.chinacloudapi.cn" }
-
-    let(:deployment_double) { double("DeploymentDouble", value!: nil) }
-    let(:network_interfaces_double) { double("NetworkInterfacesDouble", ip_configurations: [ip_configuration_double]) }
-    let(:ip_configuration_double) { double("IPConfigurationDouble", private_ipaddress: "192.168.1.5") }
-    let(:public_ip_double) { double("PublicIPDouble", ip_address: "100.100.2.5", dns_settings: dns_settings_double) }
-    let(:dns_settings_double) { double("DNSSettingsDouble", fqdn: "dns-settings-fqdn") }
-
-    before do
-      allow(ENV).to receive(:[]).with("AZURE_TENANT_ID").and_return(tenant_id)
-      allow(ENV).to receive(:[]).with("AZURE_CLIENT_ID").and_return(client_id)
-      allow(ENV).to receive(:[]).with("AZURE_CLIENT_SECRET").and_return(client_secret)
-      allow(ENV).to receive(:[]).with("AZURE_SUBSCRIPTION_ID").and_return(subscription_id)
-      allow(ENV).to receive(:[]).with("https_proxy").and_return("")
-      allow(ENV).to receive(:[]).with("AZURE_HTTP_LOGGING").and_return("")
-      allow(ENV).to receive(:[]).with("GEM_SKIP").and_return("")
-      allow(ENV).to receive(:[]).with("http_proxy").and_return("")
-      allow(ENV).to receive(:[]).with("GEM_REQUIREMENT_AZURE_MGMT_RESOURCES").and_return("azure_mgmt_resources")
-      allow(ENV).to receive(:[]).with("SSL_CERT_FILE").and_call_original
-    end
-
-    it "has credentials available" do
-      expect(credentials).to be_an_instance_of(Kitchen::Driver::AzureCredentials)
-    end
-
-    it "has options" do
-      expect(options[:tenant_id]).to eq(tenant_id)
-      expect(options[:client_id]).to eq(client_id)
-      expect(options[:client_secret]).to eq(client_secret)
-    end
-
-    # it "fails to create or update a resource group because we are not authenticated" do
-    #   rgn = resource_group_name
-    #   rg = resource_group
-    #   rg.location = location
-    #   rg.tags = vm_tags
-
-    #   # https://github.com/Azure/azure-sdk-for-ruby/blob/master/runtime/ms_rest_azure2/spec/azure_operation_error_spec.rb
-    #   expect { resource_groups.create_or_update(rgn, rg) }.to raise_error( an_instance_of(MsRestAzure2::AzureOperationError) )
-    # end
-
-    # it "saves deployment credentials to state, when store_deployment_credentials_in_state is true" do
-    #   # This MUST come first
-    #   config[:store_deployment_credentials_in_state] = true
-    #   config[:username] = "azure"
-    #   config[:password] = "admin-password"
-
-    #   allow(driver).to receive(:create_resource_group)
-    #   allow(driver).to receive(:deployment)
-    #   allow(driver).to receive(:create_deployment_async).and_return(deployment_double)
-    #   allow(driver).to receive(:follow_deployment_until_end_state)
-    #   allow(driver).to receive(:get_network_interface).and_return(network_interfaces_double)
-    #   allow(driver).to receive(:get_public_ip).and_return(public_ip_double)
-
-    #   state = {}
-    #   driver.create(state)
-    #   expect(state[:username]).to eq("azure")
-    #   expect(state[:password]).to eq("admin-password")
-    # end
-
-    # it "does not save deployment credentials to state, when store_deployment_credentials_in_state is false" do
-    #   # This MUST come first
-    #   config[:store_deployment_credentials_in_state] = false
-    #   config[:username] = "azure"
-    #   config[:password] = "admin-password"
-
-    #   allow(driver).to receive(:create_resource_group)
-    #   allow(driver).to receive(:deployment)
-    #   allow(driver).to receive(:create_deployment_async).and_return(deployment_double)
-    #   allow(driver).to receive(:follow_deployment_until_end_state)
-    #   allow(driver).to receive(:get_network_interface).and_return(network_interfaces_double)
-    #   allow(driver).to receive(:get_public_ip).and_return(public_ip_double)
-
-    #   state = {}
-    #   driver.create(state)
-    #   expect(state[:username]).to eq(nil)
-    #   expect(state[:password]).to eq(nil)
-    # end
-  end
-
-  describe "#virtual_machine_deployment_template" do
-    subject { driver.send(:virtual_machine_deployment_template) }
-
-    let(:parsed_json) { JSON.parse(subject) }
-    let(:vm_resource) { parsed_json["resources"].find { |x| x["type"] == "Microsoft.Compute/virtualMachines" } }
-
-    context "when plan config is provided" do
-      let(:plan_name) { "plan-abc" }
-      let(:plan_product) { "my-product" }
-      let(:plan_publisher) { "captain-america" }
-      let(:plan_promotion_code) { "50-percent-off" }
-
-      let(:plan) do
-        {
-          name: plan_name,
-          product: plan_product,
-          publisher: plan_publisher,
-          promotion_code: plan_promotion_code,
-        }
-      end
-
-      let(:config) do
-        {
-          subscription_id: subscription_id,
-          location: location,
-          machine_size: machine_size,
-          vm_tags: vm_tags,
-          plan: plan,
-          image_urn: image_urn,
-          vm_name: vm_name,
-        }
-      end
-
-      it "includes plan information in deployment template" do
-        expect(vm_resource).to have_key("plan")
-        expect(vm_resource["plan"]["name"]).to eq(plan_name)
-        expect(vm_resource["plan"]["product"]).to eq(plan_product)
-        expect(vm_resource["plan"]["publisher"]).to eq(plan_publisher)
-        expect(vm_resource["plan"]["promotionCode"]).to eq(plan_promotion_code)
-      end
-    end
-
-    context "when plan config is not provided" do
-      let(:config) do
-        {
-          subscription_id: subscription_id,
-          location: location,
-          machine_size: machine_size,
-          vm_tags: vm_tags,
-          image_urn: image_urn,
-          vm_name: vm_name,
-        }
-      end
-
-      it "does not include plan information in deployment template" do
-        expect(vm_resource).not_to have_key("plan")
-      end
-    end
+  def build_driver_password
+    driver_config(described_class.new({}))[:password]
   end
 end

--- a/spec/unit/kitchen/driver/azurerm_version_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_version_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe "Kitchen::Driver::AZURERM_VERSION" do
+  subject(:version) { Kitchen::Driver::AZURERM_VERSION }
+
+  it "is a semantic version string" do
+    expect(version).to match(/\A\d+\.\d+\.\d+(\.[\w.]+)?\z/)
+  end
+
+  it "is what the gemspec publishes" do
+    gemspec = Gem::Specification.load(File.expand_path("../../../../kitchen-azurerm.gemspec", __dir__))
+    expect(gemspec.version.to_s).to eq(version)
+  end
+
+  it "is frozen" do
+    expect(version).to be_frozen
+  end
+end

--- a/spec/unit/templates_spec.rb
+++ b/spec/unit/templates_spec.rb
@@ -1,0 +1,142 @@
+# The ARM templates are string-interpolated ERB, so any conditional that emits
+# a stray comma or an unbalanced brace produces a template that only fails at
+# deploy time. These specs render every template across the option matrix and
+# assert the result actually parses.
+RSpec.describe "ARM deployment templates" do
+  let(:driver) { build_driver }
+
+  # Options that change the shape of the rendered template. Each is toggled
+  # independently against the default configuration.
+  TEMPLATE_VARIATIONS = {
+    "defaults" => {},
+    "unmanaged disks" => { use_managed_disks: false },
+    "ephemeral os disk" => { use_ephemeral_osdisk: true },
+    "sized os disk" => { os_disk_size_gb: 128 },
+    "custom data" => { custom_data: "#cloud-config\npackages:\n  - htop\n" },
+    "data disks" => { data_disks: [{ lun: 0, disk_size_gb: 128 }] },
+    "data disks, unmanaged" => { data_disks: [{ lun: 0, disk_size_gb: 128 }], use_managed_disks: false },
+    "vhd image" => { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd", use_managed_disks: false },
+    "managed image" => { image_id: "/subscriptions/x/images/my-image" },
+    "shared storage account" => { existing_storage_account_blob_url: "https://shared.blob.core.windows.net", use_managed_disks: false },
+    "shared storage account, no container" => { existing_storage_account_blob_url: "https://shared.blob.core.windows.net", existing_storage_account_container: "", use_managed_disks: false },
+    "marketplace plan" => { plan: { name: "n", product: "p", publisher: "pub" } },
+    "vm tags" => { vm_tags: { owner: "platform", env: "ci" } },
+    "key vault certificate" => { secret_url: "https://v.vault.azure.net/secrets/c", vault_name: "v", vault_resource_group: "rg" },
+    "standard public ip" => { public_ip_sku: "Standard" },
+    "everything at once" => {
+      os_disk_size_gb: 256,
+      custom_data: "#cloud-config\n",
+      data_disks: [{ lun: 0, disk_size_gb: 128 }],
+      plan: { name: "n", product: "p", publisher: "pub", promotion_code: "c" },
+      vm_tags: { owner: "platform" },
+      secret_url: "https://v.vault.azure.net/secrets/c",
+      vault_name: "v",
+      vault_resource_group: "rg",
+      public_ip_sku: "Standard",
+    },
+  }.freeze
+
+  TEMPLATE_VARIATIONS.each do |label, options|
+    context "with #{label}" do
+      %i{password ssh_key}.each do |auth|
+        context "authenticating by #{auth}" do
+          let(:transport) do
+            auth == :ssh_key ? transport_double(name: "Ssh", ssh_key: File.join(ENV.fetch("HOME"), "id_rsa")) : transport_double
+          end
+
+          it "renders a valid public template" do
+            driver = build_driver(transport:, **options)
+            expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+          end
+
+          it "renders a valid internal template" do
+            driver = build_driver(transport:, vnet_id: "/vnet", subnet_id: "/subnet", **options)
+            expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+          end
+
+          it "renders a valid internal template with a public IP" do
+            driver = build_driver(transport:, vnet_id: "/vnet", subnet_id: "/subnet", public_ip: true, **options)
+            expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+          end
+        end
+      end
+    end
+  end
+
+  describe "structural invariants" do
+    %w{public internal}.each do |name|
+      context "#{name}.erb" do
+        let(:template) do
+          driver = name == "public" ? build_driver : build_driver(vnet_id: "/vnet", subnet_id: "/subnet")
+          rendered_template(driver)
+        end
+
+        it "declares the 2015-01-01 deployment template schema" do
+          expect(template["$schema"]).to eq("https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#")
+        end
+
+        it "declares a content version" do
+          expect(template["contentVersion"]).to eq("1.0.0.0")
+        end
+
+        it "contains exactly one virtual machine" do
+          expect(template["resources"].count { |r| r["type"] == "Microsoft.Compute/virtualMachines" }).to eq(1)
+        end
+
+        it "contains exactly one network interface" do
+          expect(template["resources"].count { |r| r["type"] == "Microsoft.Network/networkInterfaces" }).to eq(1)
+        end
+
+        it "gives every resource a type, name and apiVersion" do
+          template["resources"].each do |resource|
+            expect(resource).to include("type", "name", "apiVersion")
+          end
+        end
+
+        it "references only parameters it declares" do
+          declared = template["parameters"].keys.map(&:downcase)
+          referenced = JSON.generate(template).scan(/parameters\('([^']+)'\)/).flatten.map(&:downcase).uniq
+
+          expect(referenced - declared).to be_empty
+        end
+
+        it "references only variables it declares" do
+          declared = template["variables"].keys.map(&:downcase)
+          referenced = JSON.generate(template).scan(/variables\('([^']+)'\)/).flatten.map(&:downcase).uniq
+
+          expect(referenced - declared).to be_empty
+        end
+      end
+    end
+  end
+
+  describe "empty.erb" do
+    subject(:template) { driver.send(:virtual_machine_deployment_template_file, "empty.erb", nil) }
+
+    it "is valid ARM JSON" do
+      expect(template).to be_a_valid_arm_template
+    end
+
+    it "declares no resources, which is what makes a Complete deployment delete everything" do
+      expect(JSON.parse(template)["resources"]).to eq([])
+    end
+
+    it "declares no parameters" do
+      expect(JSON.parse(template)["parameters"]).to eq({})
+    end
+  end
+
+  describe "every parameter the driver sends is declared by the template" do
+    let(:state) { { uuid: "abc123", vm_name: "tk-abc123", azure_resource_group_name: "kitchen-rg" } }
+
+    TEMPLATE_VARIATIONS.each do |label, options|
+      it "holds for #{label}" do
+        driver = build_driver(**options)
+        sent = driver.build_deployment_parameters(state).keys.map { |key| key.to_s.downcase }
+        declared = rendered_template(driver)["parameters"].keys.map(&:downcase)
+
+        expect(sent - declared).to be_empty
+      end
+    end
+  end
+end

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -327,17 +327,19 @@
                     <%- unless custom_data.empty? -%>
                     "customData": "[parameters('customData')]",
                     <%- end -%>
-                    <%- unless secretUrl.to_s.empty? && vaultName.to_s.empty? && vaultResourceGroup.to_s.empty? -%>
-                    "secret": [
-                        "sourceVault": {
-                            "id": "[resourceId(parameters('vaultResourceGroup'), 'Microsoft,KeyVault/vaults', parameters('vaultName'))]"
-                        },
-                        "vaultCertificates": [
-                            {
-                                "certificateUrl": "[parameters('secretUrl')]",
-                                "certificateStore": "My"
-                            }
-                        ]
+                    <%- unless secret_url.to_s.empty? && vault_name.to_s.empty? && vault_resource_group.to_s.empty? -%>
+                    "secrets": [
+                        {
+                            "sourceVault": {
+                                "id": "[resourceId(parameters('vaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]"
+                            },
+                            "vaultCertificates": [
+                                {
+                                    "certificateUrl": "[parameters('secretUrl')]",
+                                    "certificateStore": "My"
+                                }
+                            ]
+                        }
                     ],
                     <%- end -%>
                     <%- if ssh_key.nil? -%>
@@ -370,7 +372,7 @@
                     "osDisk": {
                         "name": "[concat('disk-', parameters('vmName'))]",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
-                        "diskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "diskSizeGB": "[parameters('osDiskSizeGb')]",
                         <%- end -%>
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
@@ -381,7 +383,7 @@
                     "osDisk": {
                         "name": "[concat('disk-', parameters('vmName'))]",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
-                        "diskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "diskSizeGB": "[parameters('osDiskSizeGb')]",
                         <%- end -%>
                         <%- if !image_url.empty? -%>
                         "image": {

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -346,17 +346,19 @@
                     <%- unless custom_data.empty? -%>
                     "customData": "[parameters('customData')]",
                     <%- end -%>
-                    <%- unless secretUrl.to_s.empty? && vaultName.to_s.empty? && vaultResourceGroup.to_s.empty? -%>
-                    "secret": [
-                        "sourceVault": {
-                            "id": "[resourceId(parameters('vaultResourceGroup'), 'Microsoft,KeyVault/vaults', parameters('vaultName'))]"
-                        },
-                        "vaultCertificates": [
-                            {
-                                "certificateUrl": "[parameters('secretUrl')]",
-                                "certificateStore": "My"
-                            }
-                        ]
+                    <%- unless secret_url.to_s.empty? && vault_name.to_s.empty? && vault_resource_group.to_s.empty? -%>
+                    "secrets": [
+                        {
+                            "sourceVault": {
+                                "id": "[resourceId(parameters('vaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]"
+                            },
+                            "vaultCertificates": [
+                                {
+                                    "certificateUrl": "[parameters('secretUrl')]",
+                                    "certificateStore": "My"
+                                }
+                            ]
+                        }
                     ],
                     <%- end -%>
                     <%- if ssh_key.nil? -%>
@@ -389,7 +391,7 @@
                     "osDisk": {
                         "name": "osdisk",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
-                        "diskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "diskSizeGB": "[parameters('osDiskSizeGb')]",
                         <%- end -%>
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
@@ -401,7 +403,7 @@
                         "name": "osdisk",
                         <%- if !image_url.empty? -%>
                         <%- unless os_disk_size_gb.to_s.empty? -%>
-                        "diskSizeGB": "[parameters('osDiskSizeGB')]",
+                        "diskSizeGB": "[parameters('osDiskSizeGb')]",
                         <%- end -%>
                         "image": {
                             "uri": "[parameters('imageUrl')]"


### PR DESCRIPTION
Rewrites the unit test suite from scratch and fixes the bugs that writing it exposed.

`bundle exec rake` (test + style) is green: **451 examples, 0 failures, 100% line / 96.6% branch coverage, 0 lint offenses**, stable across seeds.

## Bugs fixed

**Key Vault certificates never worked.** `virtual_machine_deployment_template` never passed `secret_url`/`vault_name`/`vault_resource_group` into the ERB binding. `OpenStruct` returns `nil` for undefined attributes, so `secretUrl.to_s.empty?` was always true and the block never rendered — the three config options had no effect at all.

Fixing the binding alone would have crashed the driver, because the block underneath was wrong in two more ways:

- `"secret": [ "sourceVault": {…} ]` — a JSON array containing key/value pairs, which is not valid JSON. `JSON.parse` in `template_for_transport_name` would have raised. Now `"secrets": [{ … }]`, matching the ARM schema.
- `'Microsoft,KeyVault/vaults'` — comma instead of period in the resource provider namespace.

**Default `image_urn` was Ubuntu 14.04.3-LTS** — EOL since 2019, and Canonical retired the `UbuntuServer` offer entirely after 18.04, so `kitchen create` with no `image_urn` could not succeed. Now `Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest` (URN form verified against Microsoft Learn). ⚠️ **This changes a user-visible default** — happy to pin something else if you'd prefer. The README's example URNs carried the same dead value and are updated too.

Also fixed:

- `state[:password] = nil` was written back for SSH-key instances immediately after `validate_state` had deleted it — an operator precedence bug in `unless existing_state_value?(state, :password) && instance.transport[:ssh_key].nil?`.
- An unrecognised `azure_environment` produced `NoMethodError` on nil, because `endpoint_settings` returned `nil` and then `.resource_manager_endpoint_url` was called on it. Now raises `Kitchen::UserError` naming the valid values.
- `CONFIG_PATH` baked `ENV["HOME"]` in at file-load time and broke where `HOME` is unset. Replaced with `AzureCredentials.default_config_path`, resolved lazily via `Dir.home`.
- A `vm_prefix` longer than three characters produced VM names over Azure's 15-character Windows limit. The code comment said "MUST be no longer than 3 characters" but nothing enforced it. Generated names are now capped at 15; 3-character prefixes behave exactly as before.
- Tag values containing `"` or `\` produced an unparseable template. `vm_tag_string` hand-built JSON with string interpolation; it now JSON-encodes each key and value.
- `show_failed_operations` raised on the first non-OK operation and discarded the rest. It now reports all of them.
- `plan_json` raised `NoMethodError` when `plan` was explicitly `nil`.
- `resource_manager_endpoint_url` was dead code duplicating `AzureCredentials#endpoint_settings` — removed.
- `osDiskSizeGb` was declared with one casing and referenced with another. Latent only because ARM is case-insensitive; normalized.

## Test suite

73 examples → 451.

- **No more `allow(ENV).to receive(:[])`.** The old suite had to stub `GEM_SKIP`, `https_proxy`, `SSL_CERT_FILE`… one line per variable any gem in the stack happened to read. A suite-wide `around` hook snapshots and restores `ENV` instead. `HOME` is redirected to a fresh tmpdir per example, so no test can reach the developer's real `~/.azure/credentials`.
- **Real files over stubs.** Credentials specs write actual INI files and drive `IniFile` for real; the old ones stubbed `File.file?` and `IniFile.load` and so never exercised parsing at all.
- **`verify_partial_doubles` + `instance_double` throughout**, with real SDK model objects (`DeploymentOperation`, `DeploymentExtended`) where the SDK ships plain models — so a renamed Azure attribute fails the suite instead of passing against a permissive `double`.
- **`webmock`** makes any accidental real HTTP call a loud failure.
- **`create` and `destroy` are actually tested.** Both were entirely commented out before. That includes the `DeploymentActive` recovery path, pre/post-deployment ordering, hostname resolution across all four vnet/public-IP/FQDN combinations, and the resource-group tag handling on destroy.
- **New `spec/unit/templates_spec.rb`** renders both ERB templates across 16 option combinations × 2 auth modes × 3 network shapes and asserts each parses, plus invariants: every `parameters('x')` reference is declared, every `variables('x')` reference is declared, and every parameter the driver sends is one the template declares. That last invariant is what catches the Key Vault class of bug.
- Retry/backoff had zero coverage. The eight copy-pasted `rescue Faraday::… ; retry` blocks are now one `with_azure_retries` method, with its budget, logging, and non-retryable-error behaviour tested directly.
- Specs are linted too — dropped the `spec/**/*` exclusion from `.rubocop.yml`.

## Documentation

Every method, constant, and attribute carries YARD tags — `rake yard` reports 100.00% documented. Adds `.yardopts` and four tasks: `rake yard`, `rake doc`, `rake yard:stats`, `rake yard:server`.

**The default rake task remains `test` + `style` only**, so documentation never gates CI. The CI workflow is untouched.

## Note

`Gemfile.lock` (gitignored) was regenerated because the pinned `mixlib-install-4.1.0` has been yanked from RubyGems and `bundle install` fails against the old lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
