### PR TITLE
Modernize for current Azure: replace retired defaults and prune retired features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :test do
   gem "webmock", "~> 3.19"
 end
 
-group :docs do
+group :development do
   gem "yard", "~> 0.9"
 end
 

--- a/README.md
+++ b/README.md
@@ -95,14 +95,12 @@ All options below are set under the `driver:` key in `kitchen.yml`, or per platf
 
 #### Image
 
-Set exactly one of `image_urn`, `image_url`, or `image_id`.
+Set one of `image_urn` or `image_id`.
 
 | Option | Default | Description |
 | --- | --- | --- |
 | `image_urn` | `Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest` | Marketplace image, as `Publisher:Offer:Sku:Version`. See [How to retrieve the image_urn](#how-to-retrieve-the-image_urn). |
-| `image_url` | `""` | URL of a private classic (unmanaged) OS image VHD. |
-| `image_id` | `""` | Resource ID of a private managed image. |
-| `os_type` | `"linux"` | `linux` or `windows`. Must match the image. |
+| `image_id` | `""` | Resource ID of a private managed image or an Azure Compute Gallery image version. |
 | `plan` | *unset* | Purchase plan for a Marketplace image that requires one. A hash accepting `name`, `product`, `publisher`, and `promotion_code`. |
 
 #### Virtual machine
@@ -122,15 +120,14 @@ Set exactly one of `image_urn`, `image_url`, or `image_id`.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `use_managed_disks` | `true` | Use managed disks. Disable only for classic unmanaged storage. |
 | `use_ephemeral_osdisk` | `false` | Use an ephemeral OS disk, which is faster and cheaper but lost on deallocation. |
 | `os_disk_size_gb` | *image default* | Size of the OS disk in GB. Must be at least the image's own size. |
-| `storage_account_type` | `"Standard_LRS"` | Storage account type, e.g. `Standard_LRS`, `Premium_LRS`. |
+| `storage_account_type` | `"StandardSSD_LRS"` | Managed disk type, e.g. `StandardSSD_LRS`, `Premium_LRS`. |
 | `data_disks` | `nil` | Array of data disks to attach, each a hash with `lun` and `disk_size_gb`. |
 | `format_data_disks` | `false` | Format and mount attached data disks. Windows only. |
 | `format_data_disks_powershell_script` | `false` | Custom PowerShell script used to format the data disks. |
-| `existing_storage_account_blob_url` | `""` | Blob URL of an existing storage account, for unmanaged disks. |
-| `existing_storage_account_container` | `"vhds"` | Container within that storage account. |
+
+All deployments use managed disks. Azure retired unmanaged disks on 31 March 2026.
 
 #### Networking
 
@@ -140,7 +137,31 @@ Set exactly one of `image_urn`, `image_url`, or `image_id`.
 | `subnet_id` | `""` | Name of the subnet within `vnet_id`. |
 | `nic_name` | `""` | Name of an existing network interface to attach. |
 | `public_ip` | `false` | Assign a public IP address. Required unless you reach the VM over ExpressRoute or a VPN. |
-| `public_ip_sku` | `"Basic"` | Public IP SKU, `Basic` or `Standard`. |
+| `public_ip_sku` | `"Standard"` | Public IP SKU. Azure retired the `Basic` SKU on 30 September 2025. |
+| `nsg_id` | `""` | Resource ID of an existing network security group to attach to the network interface. When unset, one is created for you. |
+| `open_ports` | `[]` | Extra inbound TCP ports to open, on top of the transport's own port. |
+
+Standard SKU public IPs are closed to inbound traffic unless a network security
+group allows it. When the driver creates a public IP and you have not supplied
+`nsg_id`, it also creates a security group allowing inbound TCP on the port your
+transport uses - 22 for SSH, 5985 and 5986 for WinRM - plus anything in
+`open_ports`. Those rules allow any source address, matching the connectivity a
+Basic SKU public IP used to provide. To restrict the source, create your own
+security group and pass it as `nsg_id`.
+
+#### Retired settings
+
+These settings are still accepted so that an existing `kitchen.yml` keeps
+loading, but Azure retirements have made them inoperable. The driver logs a
+warning and ignores them.
+
+| Option | Retired because |
+| --- | --- |
+| `use_managed_disks` | Azure retired unmanaged disks on 31 March 2026. Every deployment now uses managed disks. |
+| `image_url` | Deploying from a VHD URL required unmanaged disks. Use `image_id` with a managed image or an Azure Compute Gallery image instead. |
+| `os_type` | Only ever applied to `image_url` deployments. |
+| `existing_storage_account_blob_url` | OS disks are no longer placed in a storage account you supply. |
+| `existing_storage_account_container` | As above. |
 
 #### Resource group
 
@@ -184,7 +205,7 @@ Set exactly one of `image_urn`, `image_url`, or `image_id`.
 | Option | Default | Description |
 | --- | --- | --- |
 | `azure_environment` | `"Azure"` | Cloud to target: `Azure`, `AzureUSGovernment`, `AzureChina`, `AzureGermanCloud`. See [Support for Government and Sovereign Clouds](#support-for-government-and-sovereign-clouds-china-and-germany). |
-| `boot_diagnostics_enabled` | `"true"` | Enable boot diagnostics on the VM. |
+| `boot_diagnostics_enabled` | `true` | Enable managed boot diagnostics on the VM. |
 | `winrm_powershell_script` | `false` | Custom PowerShell script used to configure WinRM. Windows only. |
 | `deployment_sleep` | `10` | Seconds to wait between polls of the deployment status. |
 | `azure_api_retries` | `5` | Number of times to retry a failed Azure API call. |
@@ -427,14 +448,13 @@ platforms:
       image_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/RESGROUP/providers/Microsoft.Compute/images/IMAGENAME
       vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
       subnet_id: subnet-10.1.0
-      use_managed_disk: true
 
 suites:
   - name: default
     attributes:
 ```
 
-### kitchen.yml example 7 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with Private Classic OS Image
+### kitchen.yml example 7 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with a private managed image
 
 This example a classic Custom VM Image (aka a VHD file) is used. As the Image VHD must be in the same storage account then the disk of the instance, the os disk is created in an existing image account.
 
@@ -463,10 +483,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_url: https://yourstorageaccount.blob.core.windows.net/system/Microsoft.Compute/Images/images/Cent7_P4-osDisk.170dd1b7-7dc3-4496-b248-f47c49f63965.vhd
-      existing_storage_account_blob_url: https://yourstorageaccount.blob.core.windows.net
-      os_type: linux
-      use_managed_disk: false
+      image_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Compute/images/Cent7_P4
       vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
       subnet_id: subnet-10.1.0
 
@@ -475,7 +492,7 @@ suites:
     attributes:
 ```
 
-### kitchen.yml example 8 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with Private Classic OS Image and providing custom data and extra large os disk
+### kitchen.yml example 8 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with a private managed image, custom data and an extra large os disk
 
 This is the same as above, but uses custom data to customize the instance.
 
@@ -498,10 +515,7 @@ provisioner:
 platforms:
   - name: ubuntu-1404
     driver:
-      image_url: https://yourstorageaccount.blob.core.windows.net/system/Microsoft.Compute/Images/images/Cent7_P4-osDisk.170dd1b7-7dc3-4496-b248-f47c49f63965.vhd
-      existing_storage_account_blob_url: https://yourstorageaccount.blob.core.windows.net
-      os_type: linux
-      use_managed_disk: false
+      image_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Compute/images/Cent7_P4
       vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
       subnet_id: subnet-10.1.0
       os_disk_size_gb: 100
@@ -704,8 +718,6 @@ suites:
 
 Starting with v0.9.0 this driver has support for Azure Government and Sovereign Clouds via the use of the ```azure_environment``` setting. Valid Azure environments are ```Azure```, ```AzureUSGovernment```, ```AzureChina``` and ```AzureGermanCloud```
 
-Note that the ```use_managed_disks``` option should be set to false until supported by AzureUSGovernment.
-
 ### Example kitchen.yml for Azure US Government cloud
 
 ```yaml
@@ -716,7 +728,6 @@ driver:
   azure_environment: 'AzureUSGovernment'
   location: 'US Gov Iowa'
   machine_size: 'Standard_D2_v2_Promo'
-  use_managed_disks: false
 
 provisioner:
   name: chef_zero

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -44,6 +44,19 @@ module Kitchen
 
       kitchen_driver_api_version 2
 
+      # Settings that Azure retirements have made inoperable. They are still
+      # accepted so that an existing kitchen.yml keeps loading, but they no
+      # longer do anything and {#warn_about_deprecated_config} says so.
+      #
+      # @return [Hash{Symbol => String}]
+      DEPRECATED_CONFIG = {
+        use_managed_disks: "Azure retired unmanaged disks on 31 March 2026; every deployment now uses managed disks.",
+        image_url: "Deploying from a VHD URL required unmanaged disks, which Azure retired on 31 March 2026. Use image_id with a managed image or an Azure Compute Gallery image instead.",
+        os_type: "os_type only ever applied to VHD (image_url) deployments, which Azure retired on 31 March 2026.",
+        existing_storage_account_blob_url: "Azure retired unmanaged disks on 31 March 2026, so OS disks are no longer placed in a storage account you supply.",
+        existing_storage_account_container: "Azure retired unmanaged disks on 31 March 2026, so OS disks are no longer placed in a storage account you supply.",
+      }.freeze
+
       default_config(:azure_resource_group_prefix) do |_config|
         "kitchen-"
       end
@@ -70,10 +83,6 @@ module Kitchen
         "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
       end
 
-      default_config(:image_url) do |_config|
-        ""
-      end
-
       default_config(:image_id) do |_config|
         ""
       end
@@ -84,10 +93,6 @@ module Kitchen
 
       default_config(:os_disk_size_gb) do |_config|
         ""
-      end
-
-      default_config(:os_type) do |_config|
-        "linux"
       end
 
       default_config(:custom_data) do |_config|
@@ -123,20 +128,14 @@ module Kitchen
         ""
       end
 
+      # Standard HDD OS disks are retired in September 2028, and Standard SSD is
+      # the current baseline for a short-lived test instance.
       default_config(:storage_account_type) do |_config|
-        "Standard_LRS"
-      end
-
-      default_config(:existing_storage_account_blob_url) do |_config|
-        ""
-      end
-
-      default_config(:existing_storage_account_container) do |_config|
-        "vhds"
+        "StandardSSD_LRS"
       end
 
       default_config(:boot_diagnostics_enabled) do |_config|
-        "true"
+        true
       end
 
       default_config(:winrm_powershell_script) do |_config|
@@ -173,10 +172,6 @@ module Kitchen
 
       default_config(:public_ip) do |_config|
         false
-      end
-
-      default_config(:use_managed_disks) do |_config|
-        true
       end
 
       default_config(:data_disks) do |_config|
@@ -231,8 +226,10 @@ module Kitchen
         ENV["AZURE_SUBSCRIPTION_ID"]
       end
 
+      # Basic SKU public IPs were retired on 30 September 2025 and can no longer
+      # be created, so Standard is the only usable value.
       default_config(:public_ip_sku) do |_config|
-        "Basic"
+        "Standard"
       end
 
       default_config(:azure_api_retries) do |_config|
@@ -241,6 +238,18 @@ module Kitchen
 
       default_config(:use_fqdn_hostname) do |_config|
         false
+      end
+
+      # Resource id of an existing network security group to attach to the NIC.
+      # When empty, and a public IP is being created, one is generated with rules
+      # for the transport in use.
+      default_config(:nsg_id) do |_config|
+        ""
+      end
+
+      # Extra inbound TCP ports to open, on top of the transport's own port.
+      default_config(:open_ports) do |_config|
+        []
       end
 
       # Provisions the Azure resource group and ARM deployment backing this
@@ -256,6 +265,7 @@ module Kitchen
       # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails
       #   for any reason other than an already-running deployment.
       def create(state)
+        warn_about_deprecated_config
         state = validate_state(state)
         deployment_parameters = build_deployment_parameters(state)
 
@@ -309,8 +319,7 @@ module Kitchen
           location: config[:location],
           vmSize: config[:machine_size],
           storageAccountType: config[:storage_account_type],
-          bootDiagnosticsEnabled: config[:boot_diagnostics_enabled],
-          newStorageAccountName: "storage#{state[:uuid]}",
+          bootDiagnosticsEnabled: boot_diagnostics_enabled?,
           adminUsername: config[:username],
           dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
           vmName: state[:vm_name],
@@ -328,35 +337,35 @@ module Kitchen
 
         parameters["nicName"] = nic_name(state)
         parameters["customData"] = prepared_custom_data unless config[:custom_data].to_s.empty?
-
-        # When deploying into a shared storage account we need a unique suffix
-        # so that multiple kitchen instances do not collide on OS disk names.
-        unless config[:existing_storage_account_blob_url].to_s.empty?
-          parameters["osDiskNameSuffix"] = "-#{state[:azure_resource_group_name]}"
-          parameters["existingStorageAccountBlobURL"] = config[:existing_storage_account_blob_url]
-        end
-
-        parameters["existingStorageAccountBlobContainer"] = config[:existing_storage_account_container] unless config[:existing_storage_account_container].to_s.empty?
         parameters["osDiskSizeGb"] = config[:os_disk_size_gb] unless config[:os_disk_size_gb].to_s.empty?
+        parameters["nsgId"] = config[:nsg_id] unless config[:nsg_id].to_s.empty?
 
         parameters.merge(image_parameters)
       end
 
-      # ARM parameters describing which image the VM boots from.
-      #
-      # Exactly one of three modes applies, in precedence order: a managed image
-      # by resource id, a VHD URL, or a Marketplace image URN.
+      # ARM parameters describing which image the VM boots from: either a managed
+      # image (or Azure Compute Gallery image) by resource id, or a Marketplace
+      # image URN.
       #
       # @return [Hash]
       def image_parameters
-        if config[:image_id].to_s != ""
-          { "imageId" => config[:image_id] }
-        elsif config[:image_url].to_s != ""
-          { "imageUrl" => config[:image_url], "osType" => config[:os_type] }
-        else
-          publisher, offer, sku, version = config[:image_urn].split(":", 4)
-          { "imagePublisher" => publisher, "imageOffer" => offer, "imageSku" => sku, "imageVersion" => version }
-        end
+        return { "imageId" => config[:image_id] } if config[:image_id].to_s != ""
+
+        publisher, offer, sku, version = config[:image_urn].split(":", 4)
+        { "imagePublisher" => publisher, "imageOffer" => offer, "imageSku" => sku, "imageVersion" => version }
+      end
+
+      # Whether managed boot diagnostics should be switched on.
+      #
+      # Historically this setting defaulted to the *string* +"true"+, and plenty
+      # of kitchen.yml files still say +"false"+, so both spellings are honoured.
+      #
+      # @return [Boolean]
+      def boot_diagnostics_enabled?
+        value = config[:boot_diagnostics_enabled]
+        return false if value.to_s.casecmp("false") == 0
+
+        !!value
       end
 
       # Name of the network interface the VM is attached to.
@@ -410,7 +419,7 @@ module Kitchen
       # @param vmnic [String] name of the network interface.
       # @return [String] IP address or fully-qualified domain name.
       def resolve_hostname(state, vmnic)
-        if config[:vnet_id] == "" || config[:public_ip]
+        if public_ip?
           result = get_public_ip(state[:azure_resource_group_name], "publicip")
           info "IP Address is: #{result.ip_address} [#{result.dns_settings.fqdn}]"
           if config[:use_fqdn_hostname]
@@ -492,15 +501,9 @@ module Kitchen
       # JSON fragment describing the data disks to attach to the VM.
       #
       # @return [String, nil] a JSON array, or nil when no +data_disks+ are
-      #   configured. Unmanaged disk deployments always get an empty array and
-      #   a warning, as data disks require managed disks.
+      #   configured.
       def data_disks_for_vm_json
         return nil if config[:data_disks].nil?
-
-        unless config[:use_managed_disks]
-          warn 'Data disks are only supported when used with the "use_managed_disks" option. No additional disks were added to the configuration.'
-          return [].to_json
-        end
 
         disks = config[:data_disks].map do |data_disk|
           { name: "datadisk#{data_disk[:lun]}", lun: data_disk[:lun], diskSizeGB: data_disk[:disk_size_gb], createOption: "Empty" }
@@ -904,12 +907,8 @@ module Kitchen
       def virtual_machine_deployment_template
         data = {
           vm_tags: vm_tag_string(config[:vm_tags]),
-          use_managed_disks: config[:use_managed_disks],
-          image_url: config[:image_url],
           storage_account_type: config[:storage_account_type],
-          existing_storage_account_blob_url: config[:existing_storage_account_blob_url],
           image_id: config[:image_id],
-          existing_storage_account_container: config[:existing_storage_account_container],
           custom_data: config[:custom_data],
           os_disk_size_gb: config[:os_disk_size_gb],
           data_disks_for_vm_json:,
@@ -919,6 +918,10 @@ module Kitchen
           secret_url: config[:secret_url],
           vault_name: config[:vault_name],
           vault_resource_group: config[:vault_resource_group],
+          create_nsg: create_nsg?,
+          attach_nsg: attach_nsg?,
+          nsg_id: config[:nsg_id],
+          nsg_rules_json: nsg_rules.to_json,
         }
 
         if config[:vnet_id].to_s.empty?
@@ -931,6 +934,83 @@ module Kitchen
             public_ip: config[:public_ip],
             public_ip_sku: config[:public_ip_sku]
           ))
+        end
+      end
+
+      # Warns about settings that Azure retirements have made inoperable.
+      #
+      # @return [void]
+      def warn_about_deprecated_config
+        DEPRECATED_CONFIG.each do |option, reason|
+          next unless config.key?(option)
+
+          warn "The '#{option}' setting is no longer supported and is being ignored. #{reason}"
+        end
+      end
+
+      # Whether this deployment gets a public IP address.
+      #
+      # @return [Boolean]
+      def public_ip?
+        config[:vnet_id].to_s.empty? || !!config[:public_ip]
+      end
+
+      # Whether the deployment should create its own network security group.
+      #
+      # Standard SKU public IPs are closed to inbound traffic unless a security
+      # group opens it, so one is generated whenever a public IP is created and
+      # the user has not supplied their own group. Instances that live purely
+      # inside a caller-supplied vnet are left alone - their subnet may already
+      # carry the rules the user wants.
+      #
+      # @return [Boolean]
+      def create_nsg?
+        config[:nsg_id].to_s.empty? && public_ip?
+      end
+
+      # Whether the network interface references a security group at all.
+      #
+      # @return [Boolean]
+      def attach_nsg?
+        create_nsg? || !config[:nsg_id].to_s.empty?
+      end
+
+      # Inbound TCP ports the generated security group opens.
+      #
+      # @return [Array<Integer>] the transport's own port(s) plus +open_ports+.
+      def nsg_ports
+        (transport_ports + Array(config[:open_ports]).map(&:to_i)).uniq
+      end
+
+      # The port(s) the configured transport connects on.
+      #
+      # @return [Array<Integer>] 5985 and 5986 for WinRM, otherwise 22.
+      def transport_ports
+        instance.transport.name.to_s.casecmp("winrm") == 0 ? [5985, 5986] : [22]
+      end
+
+      # ARM security rules for the generated network security group.
+      #
+      # The source prefix is left wide open, which matches the connectivity a
+      # Basic SKU public IP used to give with no security group at all. Narrow
+      # it by supplying your own group through +nsg_id+.
+      #
+      # @return [Array<Hash>]
+      def nsg_rules
+        nsg_ports.each_with_index.map do |port, index|
+          {
+            "name" => "allow-tcp-#{port}",
+            "properties" => {
+              "protocol" => "Tcp",
+              "sourcePortRange" => "*",
+              "destinationPortRange" => port.to_s,
+              "sourceAddressPrefix" => "*",
+              "destinationAddressPrefix" => "*",
+              "access" => "Allow",
+              "priority" => 1000 + index,
+              "direction" => "Inbound",
+            },
+          }
         end
       end
 

--- a/spec/unit/kitchen/driver/azurerm/create_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/create_spec.rb
@@ -76,12 +76,14 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
       )
     end
 
-    it "derives the storage account and DNS names from the uuid" do
+    it "derives the public DNS label from the uuid" do
       driver.create(state)
-      expect(deployment_parameters).to include(
-        newStorageAccountName: { "value" => "storage#{state[:uuid]}" },
-        dnsNameForPublicIP: { "value" => "kitchen-#{state[:uuid]}" }
-      )
+      expect(deployment_parameters[:dnsNameForPublicIP]).to eq("value" => "kitchen-#{state[:uuid]}")
+    end
+
+    it "no longer creates a storage account for the OS disk" do
+      driver.create(state)
+      expect(deployment_parameters).not_to include(:newStorageAccountName)
     end
 
     it "derives the nic name from the vm name" do
@@ -122,31 +124,41 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
       end
     end
 
-    context "with an image_url" do
-      let(:config) { { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd", os_type: "windows", use_managed_disks: false } }
+    context "with a retired image_url" do
+      let(:config) { { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd" } }
 
-      it "sends imageUrl and the os type" do
+      it "ignores it and falls back to the marketplace image" do
         driver.create(state)
-        expect(deployment_parameters).to include(
-          imageUrl: { "value" => "https://sa.blob.core.windows.net/vhds/my.vhd" },
-          osType: { "value" => "windows" }
-        )
+        expect(deployment_parameters).to include(:imagePublisher)
+        expect(deployment_parameters).not_to include(:imageUrl)
       end
     end
 
     describe "public IP SKU" do
-      it "defaults to Basic with no address type override" do
+      # Basic SKU public IPs were retired on 30 September 2025.
+      it "defaults to Standard" do
         driver.create(state)
-        expect(deployment_parameters[:publicIPSKU]).to eq("value" => "Basic")
-        expect(deployment_parameters).not_to include(:publicIPAddressType)
+        expect(deployment_parameters[:publicIPSKU]).to eq("value" => "Standard")
       end
 
-      context "with a Standard SKU" do
-        let(:config) { { public_ip_sku: "Standard" } }
+      it "forces a static address, which Standard SKUs require" do
+        driver.create(state)
+        expect(deployment_parameters[:publicIPAddressType]).to eq("value" => "Static")
+      end
+    end
 
-        it "forces a static address, which Standard SKUs require" do
+    describe "network security group" do
+      it "sends no nsgId when it creates its own group" do
+        driver.create(state)
+        expect(deployment_parameters).not_to include(:nsgId)
+      end
+
+      context "with an existing nsg_id" do
+        let(:config) { { nsg_id: "/subscriptions/x/networkSecurityGroups/mine" } }
+
+        it "passes it through" do
           driver.create(state)
-          expect(deployment_parameters[:publicIPAddressType]).to eq("value" => "Static")
+          expect(deployment_parameters[:nsgId]).to eq("value" => "/subscriptions/x/networkSecurityGroups/mine")
         end
       end
     end
@@ -171,24 +183,57 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
       end
     end
 
-    describe "shared storage accounts" do
-      let(:config) { { existing_storage_account_blob_url: "https://shared.blob.core.windows.net" } }
-
-      it "adds a per-resource-group suffix so instances do not collide on disk names" do
+    describe "boot diagnostics" do
+      it "enables managed boot diagnostics by default" do
         driver.create(state)
-        expect(deployment_parameters[:osDiskNameSuffix]).to eq("value" => "-#{state[:azure_resource_group_name]}")
+        expect(deployment_parameters[:bootDiagnosticsEnabled]).to eq("value" => true)
       end
 
-      it "passes the blob url through" do
-        driver.create(state)
-        expect(deployment_parameters[:existingStorageAccountBlobURL])
-          .to eq("value" => "https://shared.blob.core.windows.net")
+      it "coerces the historical string spelling" do
+        driver = build_driver(boot_diagnostics_enabled: "false")
+        stub_azure_clients(driver, resource_client:, network_client:)
+        record_deployments(resource_client)
+        driver.create({})
+
+        expect(deployment_parameters[:bootDiagnosticsEnabled]).to eq("value" => false)
       end
     end
 
-    it "does not send an osDiskNameSuffix without a shared storage account" do
-      driver.create(state)
-      expect(deployment_parameters).not_to include(:osDiskNameSuffix)
+    describe "retired settings" do
+      let(:config) { { use_managed_disks: false, existing_storage_account_blob_url: "https://shared.blob.core.windows.net" } }
+
+      it "warns once per retired setting rather than failing" do
+        allow(Kitchen.logger).to receive(:warn)
+        driver.create(state)
+
+        expect(Kitchen.logger).to have_received(:warn).with(/'use_managed_disks' setting is no longer supported/)
+        expect(Kitchen.logger).to have_received(:warn).with(/'existing_storage_account_blob_url' setting is no longer supported/)
+      end
+
+      it "explains why" do
+        allow(Kitchen.logger).to receive(:warn)
+        driver.create(state)
+        expect(Kitchen.logger).to have_received(:warn).with(/retired unmanaged disks on 31 March 2026/).at_least(:once)
+      end
+
+      it "sends none of them to ARM" do
+        driver.create(state)
+        expect(deployment_parameters.keys.map(&:to_s)).not_to include("existingStorageAccountBlobURL", "osDiskNameSuffix")
+      end
+
+      it "still deploys" do
+        expect { driver.create(state) }.not_to raise_error
+      end
+
+      it "says nothing when no retired setting is used" do
+        driver = build_driver
+        stub_azure_clients(driver, resource_client:, network_client:)
+        record_deployments(resource_client)
+        allow(Kitchen.logger).to receive(:warn)
+        driver.create({})
+
+        expect(Kitchen.logger).not_to have_received(:warn).with(/no longer supported/)
+      end
     end
 
     describe "custom data" do

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -195,15 +195,16 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
         end
       end
 
-      context "with an image_url" do
-        let(:config) { { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd", use_managed_disks: false } }
+      context "with an Azure Compute Gallery image id" do
+        let(:config) { { image_id: "/subscriptions/x/resourceGroups/y/providers/Microsoft.Compute/galleries/g/images/i/versions/1.0.0" } }
 
         it "renders valid JSON" do
           expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
         end
 
-        it "does not reference a marketplace image" do
-          expect(vm_resource(rendered_template(driver))["properties"]["storageProfile"]).not_to have_key("imageReference")
+        it "references it by id" do
+          image = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["imageReference"]
+          expect(image).to eq("id" => "[parameters('imageId')]")
         end
       end
     end
@@ -258,22 +259,140 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
     end
   end
 
+  describe "network security group" do
+    let(:nsg) { rendered_template(driver)["resources"].find { |r| r["type"] == "Microsoft.Network/networkSecurityGroups" } }
+    let(:nic) { rendered_template(driver)["resources"].find { |r| r["type"] == "Microsoft.Network/networkInterfaces" } }
+
+    # Standard SKU public IPs are closed to inbound traffic unless a security
+    # group opens it, so a public instance without one is unreachable.
+    it "is created alongside a public IP" do
+      expect(nsg).not_to be_nil
+    end
+
+    it "is attached to the network interface" do
+      expect(nic["properties"]["networkSecurityGroup"]["id"])
+        .to eq("[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]")
+    end
+
+    it "is created before the interface that references it" do
+      expect(nic["dependsOn"]).to include("[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]")
+    end
+
+    it "opens SSH for an SSH transport" do
+      expect(rule_ports(nsg)).to eq(["22"])
+    end
+
+    it "gives each rule a distinct priority" do
+      priorities = nsg["properties"]["securityRules"].map { |r| r["properties"]["priority"] }
+      expect(priorities).to eq(priorities.uniq)
+    end
+
+    it "allows inbound TCP" do
+      properties = nsg["properties"]["securityRules"].first["properties"]
+      expect(properties).to include("protocol" => "Tcp", "access" => "Allow", "direction" => "Inbound")
+    end
+
+    context "with a WinRM transport" do
+      let(:transport) { transport_double(name: "Winrm") }
+      let(:platform_name) { "windows-2022" }
+
+      it "opens both WinRM ports" do
+        expect(rule_ports(nsg)).to contain_exactly("5985", "5986")
+      end
+    end
+
+    context "with extra open_ports" do
+      let(:config) { { open_ports: [443, 8080] } }
+
+      it "opens them alongside the transport's own port" do
+        expect(rule_ports(nsg)).to contain_exactly("22", "443", "8080")
+      end
+
+      it "does not duplicate a port the transport already opened" do
+        driver = build_driver(open_ports: [22, 443])
+        nsg = rendered_template(driver)["resources"].find { |r| r["type"] == "Microsoft.Network/networkSecurityGroups" }
+        expect(rule_ports(nsg)).to contain_exactly("22", "443")
+      end
+    end
+
+    context "when an existing nsg_id is supplied" do
+      let(:config) { { nsg_id: "/subscriptions/x/resourceGroups/y/providers/Microsoft.Network/networkSecurityGroups/mine" } }
+
+      it "creates no security group of its own" do
+        expect(nsg).to be_nil
+      end
+
+      it "attaches the supplied one instead" do
+        expect(nic["properties"]["networkSecurityGroup"]["id"]).to eq("[parameters('nsgId')]")
+      end
+    end
+
+    context "in a caller-supplied vnet with no public IP" do
+      let(:config) { { vnet_id: "/vnet", subnet_id: "/subnet" } }
+
+      it "creates no security group, leaving the subnet's rules alone" do
+        expect(nsg).to be_nil
+      end
+
+      it "attaches nothing to the interface" do
+        expect(nic["properties"]).not_to have_key("networkSecurityGroup")
+      end
+
+      context "but with a public IP" do
+        let(:config) { super().merge(public_ip: true) }
+
+        it "creates one, because the public IP needs it" do
+          expect(nsg).not_to be_nil
+        end
+      end
+    end
+  end
+
+  describe "boot diagnostics" do
+    let(:boot_diagnostics) { vm_resource(rendered_template(driver))["properties"]["diagnosticsProfile"]["bootDiagnostics"] }
+
+    # This block used to be emitted only for unmanaged-disk deployments, so on
+    # the default path boot diagnostics silently did nothing.
+    it "is present on the default managed-disk path" do
+      expect(boot_diagnostics).to eq("enabled" => "[parameters('bootDiagnosticsEnabled')]")
+    end
+
+    it "needs no storage account" do
+      expect(boot_diagnostics).not_to have_key("storageUri")
+    end
+  end
+
+  describe "#boot_diagnostics_enabled?" do
+    it "defaults to enabled" do
+      expect(driver.boot_diagnostics_enabled?).to be true
+    end
+
+    it "accepts a boolean false" do
+      expect(build_driver(boot_diagnostics_enabled: false).boot_diagnostics_enabled?).to be false
+    end
+
+    # The setting used to default to the string "true", so kitchen.yml files in
+    # the wild carry both spellings.
+    it "accepts the string \"false\"" do
+      expect(build_driver(boot_diagnostics_enabled: "false").boot_diagnostics_enabled?).to be false
+    end
+
+    it "accepts the string \"true\"" do
+      expect(build_driver(boot_diagnostics_enabled: "true").boot_diagnostics_enabled?).to be true
+    end
+  end
+
   describe "#data_disks_for_vm_json" do
     it "is nil when no data disks are configured" do
       expect(driver.data_disks_for_vm_json).to be_nil
     end
 
-    context "with unmanaged disks" do
-      let(:config) { { use_managed_disks: false, data_disks: [{ lun: 0, disk_size_gb: 128 }] } }
+    context "with data disks" do
+      let(:config) { { data_disks: [{ lun: 3, disk_size_gb: 64 }] } }
 
-      it "warns that data disks need managed disks" do
-        allow(Kitchen.logger).to receive(:warn)
-        driver.data_disks_for_vm_json
-        expect(Kitchen.logger).to have_received(:warn).with(/only supported when used with the "use_managed_disks" option/)
-      end
-
-      it "returns an empty JSON array" do
-        expect(driver.data_disks_for_vm_json).to eq("[]")
+      it "describes each disk for the template" do
+        expect(JSON.parse(driver.data_disks_for_vm_json))
+          .to eq([{ "name" => "datadisk3", "lun" => 3, "diskSizeGB" => 64, "createOption" => "Empty" }])
       end
     end
   end
@@ -493,6 +612,12 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
         expect(Base64.decode64(driver.prepared_custom_data)).to start_with("#cloud-config")
       end
     end
+  end
+
+  # @param nsg [Hash] a parsed network security group resource.
+  # @return [Array<String>] the destination port of every rule.
+  def rule_ports(nsg)
+    nsg["properties"]["securityRules"].map { |rule| rule["properties"]["destinationPortRange"] }
   end
 
   # @param template [Hash] a parsed ARM template.

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -26,11 +26,8 @@ RSpec.describe Kitchen::Driver::Azurerm do
       azure_resource_group_suffix: "",
       explicit_resource_group_name: nil,
       resource_group_tags: {},
-      image_url: "",
-      image_id: "",
       use_ephemeral_osdisk: false,
       os_disk_size_gb: "",
-      os_type: "linux",
       custom_data: "",
       username: "azure",
       vm_prefix: "tk-",
@@ -39,10 +36,9 @@ RSpec.describe Kitchen::Driver::Azurerm do
       nic_name: "",
       vnet_id: "",
       subnet_id: "",
-      storage_account_type: "Standard_LRS",
-      existing_storage_account_blob_url: "",
-      existing_storage_account_container: "vhds",
-      boot_diagnostics_enabled: "true",
+      image_id: "",
+      storage_account_type: "StandardSSD_LRS",
+      boot_diagnostics_enabled: true,
       winrm_powershell_script: false,
       azure_environment: "Azure",
       pre_deployment_template: "",
@@ -52,7 +48,6 @@ RSpec.describe Kitchen::Driver::Azurerm do
       plan: {},
       vm_tags: {},
       public_ip: false,
-      use_managed_disks: true,
       data_disks: nil,
       format_data_disks: false,
       format_data_disks_powershell_script: false,
@@ -65,9 +60,11 @@ RSpec.describe Kitchen::Driver::Azurerm do
       secret_url: "",
       vault_name: "",
       vault_resource_group: "",
-      public_ip_sku: "Basic",
+      public_ip_sku: "Standard",
       azure_api_retries: 5,
       use_fqdn_hostname: false,
+      nsg_id: "",
+      open_ports: [],
     }.each do |key, expected|
       it "defaults #{key} to #{expected.inspect}" do
         # deployment_sleep is overridden by the test helper so the poller does
@@ -109,6 +106,14 @@ RSpec.describe Kitchen::Driver::Azurerm do
     it "lets kitchen.yml override subscription_id" do
       ENV["AZURE_SUBSCRIPTION_ID"] = "from-the-environment"
       expect(driver_config(build_driver(subscription_id: "explicit"))[:subscription_id]).to eq("explicit")
+    end
+  end
+
+  describe "retired settings" do
+    Kitchen::Driver::Azurerm::DEPRECATED_CONFIG.each_key do |option|
+      it "no longer ships a default for #{option}" do
+        expect(driver_config(described_class.new({}))).not_to have_key(option)
+      end
     end
   end
 

--- a/spec/unit/templates_spec.rb
+++ b/spec/unit/templates_spec.rb
@@ -9,20 +9,26 @@ RSpec.describe "ARM deployment templates" do
   # independently against the default configuration.
   TEMPLATE_VARIATIONS = {
     "defaults" => {},
-    "unmanaged disks" => { use_managed_disks: false },
     "ephemeral os disk" => { use_ephemeral_osdisk: true },
     "sized os disk" => { os_disk_size_gb: 128 },
+    "premium os disk" => { storage_account_type: "Premium_LRS" },
     "custom data" => { custom_data: "#cloud-config\npackages:\n  - htop\n" },
     "data disks" => { data_disks: [{ lun: 0, disk_size_gb: 128 }] },
-    "data disks, unmanaged" => { data_disks: [{ lun: 0, disk_size_gb: 128 }], use_managed_disks: false },
-    "vhd image" => { image_url: "https://sa.blob.core.windows.net/vhds/my.vhd", use_managed_disks: false },
     "managed image" => { image_id: "/subscriptions/x/images/my-image" },
-    "shared storage account" => { existing_storage_account_blob_url: "https://shared.blob.core.windows.net", use_managed_disks: false },
-    "shared storage account, no container" => { existing_storage_account_blob_url: "https://shared.blob.core.windows.net", existing_storage_account_container: "", use_managed_disks: false },
+    "gallery image" => { image_id: "/subscriptions/x/galleries/g/images/i/versions/1.0.0" },
     "marketplace plan" => { plan: { name: "n", product: "p", publisher: "pub" } },
     "vm tags" => { vm_tags: { owner: "platform", env: "ci" } },
     "key vault certificate" => { secret_url: "https://v.vault.azure.net/secrets/c", vault_name: "v", vault_resource_group: "rg" },
-    "standard public ip" => { public_ip_sku: "Standard" },
+    "extra open ports" => { open_ports: [443, 8080] },
+    "supplied security group" => { nsg_id: "/subscriptions/x/networkSecurityGroups/mine" },
+    "boot diagnostics off" => { boot_diagnostics_enabled: false },
+    "retired settings still present" => {
+      use_managed_disks: false,
+      image_url: "https://sa.blob.core.windows.net/vhds/my.vhd",
+      existing_storage_account_blob_url: "https://shared.blob.core.windows.net",
+      existing_storage_account_container: "",
+      os_type: "windows",
+    },
     "everything at once" => {
       os_disk_size_gb: 256,
       custom_data: "#cloud-config\n",
@@ -32,7 +38,7 @@ RSpec.describe "ARM deployment templates" do
       secret_url: "https://v.vault.azure.net/secrets/c",
       vault_name: "v",
       vault_resource_group: "rg",
-      public_ip_sku: "Standard",
+      open_ports: [443],
     },
   }.freeze
 
@@ -91,6 +97,23 @@ RSpec.describe "ARM deployment templates" do
           template["resources"].each do |resource|
             expect(resource).to include("type", "name", "apiVersion")
           end
+        end
+
+        # Every API version below was current as of this release; the previous
+        # ones dated back to 2015 and 2018.
+        it "pins every resource to a modern API version" do
+          template["resources"].each do |resource|
+            expect(resource["apiVersion"]).to be >= "2025-04-01"
+          end
+        end
+
+        it "creates no storage account, now that unmanaged disks are retired" do
+          expect(template["resources"].map { |r| r["type"] }).not_to include("Microsoft.Storage/storageAccounts")
+        end
+
+        it "boots every VM from a managed disk" do
+          os_disk = vm_resource(template)["properties"]["storageProfile"]["osDisk"]
+          expect(os_disk).not_to have_key("vhd")
         end
 
         it "references only parameters it declares" do

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -14,12 +14,6 @@
                 "description": "The size of the VM to be created"
             }
         },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-            }
-        },
         "adminUsername": {
             "type": "string",
             "metadata": {
@@ -40,21 +34,7 @@
                 "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
             }
         },
-        "publicIPSKU": {
-            "type": "string",
-            "defaultValue": "Basic",
-            "metadata": {
-                "description": "SKU name for the Public IP used to access the Virtual Machine."
-            }
-        },
-        "publicIPAddressType": {
-            "type": "string",
-            "defaultValue": "Dynamic",
-            "metadata": {
-                "description": "SKU name for the Public IP used to access the Virtual Machine."
-            }
-        },
-        <%- unless os_disk_size_gb.to_s.empty?  -%>
+        <%- unless os_disk_size_gb.to_s.empty? -%>
         "osDiskSizeGb": {
             "type": "int",
             "minValue": 1,
@@ -90,36 +70,15 @@
             }
         },
         <%- end -%>
-        <%- if !existing_storage_account_blob_url.empty? -%>
-        "existingStorageAccountBlobURL": {
+        <%- unless nsg_id.to_s.empty? -%>
+        "nsgId": {
             "type": "string",
             "metadata": {
-                "description": "The URL of the existing storage account (blob) (without container)"
+                "description": "Resource id of an existing network security group to attach to the network interface."
             }
         },
         <%- end -%>
-        <%- if !existing_storage_account_container.empty? -%>
-        "existingStorageAccountBlobContainer": {
-            "type": "string",
-            "metadata": {
-                "description": "The Container Name for OS Images (blob)"
-            }
-        },
-        <%- end -%>
-        <%- if !image_url.empty? -%>
-        "imageUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "An URL for a private Image (vhd)"
-            }
-        },
-        "osType": {
-            "type": "string",
-            "metadata": {
-                "description": "An OS Type (linux, windows)"
-            }
-        },
-        <%- elsif !image_id.empty? -%>
+        <%- unless image_id.empty? -%>
         "imageId": {
             "type": "string",
             "metadata": {
@@ -136,16 +95,16 @@
         },
         "imageOffer": {
             "type": "string",
-            "defaultValue": "UbuntuServer",
+            "defaultValue": "0001-com-ubuntu-server-jammy",
             "metadata": {
-                "description": "Offer for the VM, e.g. UbuntuServer, WindowsServer."
+                "description": "Offer for the VM, e.g. 0001-com-ubuntu-server-jammy, WindowsServer."
             }
         },
         "imageSku": {
             "type": "string",
-            "defaultValue": "14.04.3-LTS",
+            "defaultValue": "22_04-lts-gen2",
             "metadata": {
-                "description": "Sku for the VM, e.g. 14.04.3-LTS"
+                "description": "Sku for the VM, e.g. 22_04-lts-gen2"
             }
         },
         "imageVersion": {
@@ -156,13 +115,6 @@
             }
         },
         <%- end -%>
-        "osDiskNameSuffix": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "A disk Name Suffix to make the disk name unique in existing storage accounts."
-            }
-        },
         "vmName": {
             "type": "string",
             "defaultValue": "vm",
@@ -177,11 +129,25 @@
                 "description": "The nic name created inside of the resource group."
             }
         },
+        "publicIPSKU": {
+            "type": "string",
+            "defaultValue": "Standard",
+            "metadata": {
+                "description": "SKU name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "publicIPAddressType": {
+            "type": "string",
+            "defaultValue": "Static",
+            "metadata": {
+                "description": "Allocation method for the Public IP used to access the Virtual Machine."
+            }
+        },
         "storageAccountType": {
             "type": "string",
             "defaultValue": "<%= storage_account_type %>",
             "metadata": {
-                "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
+                "description": "The managed disk type to use (e.g. StandardSSD_LRS or Premium_LRS)."
             }
         },
         "systemAssignedIdentity": {
@@ -199,33 +165,28 @@
             }
         },
         "bootDiagnosticsEnabled": {
-            "type": "string",
-            "defaultValue": "true",
+            "type": "bool",
+            "defaultValue": true,
             "metadata": {
-                "description": "Whether to enable (true) or disable (false) boot diagnostics. Default: true (requires Standard storage)."
+                "description": "Whether to enable (true) or disable (false) managed boot diagnostics."
             }
         }
     },
     "variables": {
         "location": "[parameters('location')]",
-        "OSDiskName": "osdisk",
         "nicName": "[parameters('nicName')]",
-        "addressPrefix": "10.0.0.0/16",
+        "nsgName": "[concat(parameters('nicName'), '-nsg')]",
         "subnetName": "<%= subnet_id %>",
-        "subnetPrefix": "10.0.0.0/24",
-        "storageAccountType": "[parameters('storageAccountType')]",
         "publicIPAddressName": "publicip",
-        "vmStorageAccountContainerName": "vhds",
         "vmName": "[parameters('vmName')]",
         "vmSize": "[parameters('vmSize')]",
         "vmIdentityType": "[if(parameters('systemAssignedIdentity'), if(empty(parameters('userAssignedIdentities')), 'SystemAssigned', 'SystemAssigned, UserAssigned'), if(empty(parameters('userAssignedIdentities')), 'None', 'UserAssigned'))]",
-        "virtualNetworkName": "vnet",
         "vnetID": "<%= vnet_id %>",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
     },
     "resources": [
         {
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2025-04-01",
             "name": "pid-18d63047-6cdf-4f34-beed-62f01fc73fc2",
             "type": "Microsoft.Resources/deployments",
             "properties": {
@@ -237,53 +198,61 @@
                 }
             }
         },
-        <%- unless use_managed_disks -%>
-        <%- if existing_storage_account_blob_url.empty? -%>
+        <%- if create_nsg -%>
         {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2025-07-01",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "name": "[variables('nsgName')]",
             "location": "[variables('location')]",
             "properties": {
-                "accountType": "[variables('storageAccountType')]"
+                "securityRules": <%= nsg_rules_json %>
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>
             }
         },
         <%- end -%>
-        <%- end -%>
         <%- if public_ip -%>
         {
-            "apiVersion": "2017-08-01",
+            "apiVersion": "2025-07-01",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[variables('publicIPAddressName')]",
             "location": "[variables('location')]",
-            "sku": {
-              "name": "[parameters('publicIPSKU')]"
-            },
             "properties": {
                 "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
                 }
             },
+            "sku": {
+              "name": "[parameters('publicIPSKU')]"
+            },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>
             }
         },
         <%- end -%>
         {
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2025-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('nicName')]",
             "location": "[variables('location')]",
-            <%- if public_ip -%>
+            <%- if public_ip || create_nsg -%>
             "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+                <%- if public_ip -%>
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"<%= "," if create_nsg %>
+                <%- end -%>
+                <%- if create_nsg -%>
+                "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
+                <%- end -%>
             ],
             <%- end -%>
             "properties": {
+                <%- if attach_nsg -%>
+                "networkSecurityGroup": {
+                    "id": "<%= create_nsg ? "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]" : "[parameters('nsgId')]" %>"
+                },
+                <%- end -%>
                 "ipConfigurations": [
                     {
                         "name": "ipconfig1",
@@ -306,16 +275,11 @@
             }
         },
         {
-            "apiVersion": "2018-06-01",
+            "apiVersion": "2025-04-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('vmName')]",
             "location": "[variables('location')]",
             "dependsOn": [
-                <%- unless use_managed_disks -%>
-                <%- if existing_storage_account_blob_url.empty? -%>
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-                <%- end -%>
-                <%- end -%>
                 "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
             ],
             "properties": {
@@ -348,14 +312,14 @@
                     "adminUsername": "[parameters('adminUsername')]"
                 },
                 "storageProfile": {
-                    <%- if image_url.empty? and image_id.empty? -%>
+                    <%- if image_id.empty? -%>
                     "imageReference": {
                         "publisher": "[parameters('imagePublisher')]",
                         "offer": "[parameters('imageOffer')]",
                         "sku": "[parameters('imageSku')]",
                         "version": "[parameters('imageVersion')]"
                     },
-                    <%- elsif !image_id.empty? -%>
+                    <%- else -%>
                     "imageReference": {
                         "id": "[parameters('imageId')]"
                     },
@@ -368,41 +332,15 @@
                         "caching": "ReadOnly",
                         "createOption": "FromImage"
                     }
-                    <%- elsif use_managed_disks -%>
+                    <%- else -%>
                     "osDisk": {
-                        "name": "[concat('disk-', parameters('vmName'))]",
+                        "name": "osdisk",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
                         "diskSizeGB": "[parameters('osDiskSizeGb')]",
                         <%- end -%>
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
                         },
-                        "createOption": "FromImage"
-                    }
-                    <%- else -%>
-                    "osDisk": {
-                        "name": "[concat('disk-', parameters('vmName'))]",
-                        <%- unless os_disk_size_gb.to_s.empty? -%>
-                        "diskSizeGB": "[parameters('osDiskSizeGb')]",
-                        <%- end -%>
-                        <%- if !image_url.empty? -%>
-                        "image": {
-                            "uri": "[parameters('imageUrl')]"
-                        },
-                        "osType": "[parameters('osType')]",
-                        <%- end -%>
-                        "vhd": {
-                            <%- if existing_storage_account_blob_url.empty? -%>
-                            "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/',variables('OSDiskName'),parameters('osDiskNameSuffix'),'.vhd')]"
-                            <%- else -%>
-                            <%- if existing_storage_account_container.empty? -%>
-                            "uri": "[concat(parameters('existingStorageAccountBlobURL'), '/', variables('vmStorageAccountContainerName'), '/', variables('OSDiskName'),parameters('osDiskNameSuffix'),'.vhd')]"
-                            <%- else -%>
-                            "uri": "[concat(parameters('existingStorageAccountBlobURL'), '/', parameters('existingStorageAccountBlobContainer'), '/', variables('OSDiskName'),parameters('osDiskNameSuffix'),'.vhd')]"
-                            <%- end -%>
-                            <%- end -%>
-                        },
-                        "caching": "ReadWrite",
                         "createOption": "FromImage"
                     }
                     <%- end -%>
@@ -419,16 +357,9 @@
                     ]
                 },
                 "diagnosticsProfile": {
-                    <%- unless use_managed_disks -%>
                     "bootDiagnostics": {
-                        "enabled": "[parameters('bootDiagnosticsEnabled')]",
-                        <%- if existing_storage_account_blob_url.empty? -%>
-                        "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob]"
-                        <%- else -%>
-                        "storageUri": "[parameters('existingStorageAccountBlobURL')]"
-                        <%- end -%>
+                        "enabled": "[parameters('bootDiagnosticsEnabled')]"
                     }
-                    <%- end -%>
                 }
             },
             <%- unless plan_json.nil? -%>

--- a/templates/public.erb
+++ b/templates/public.erb
@@ -14,12 +14,6 @@
                 "description": "The size of the VM to be created"
             }
         },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-            }
-        },
         "adminUsername": {
             "type": "string",
             "metadata": {
@@ -40,7 +34,7 @@
                 "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
             }
         },
-        <%- unless os_disk_size_gb.to_s.empty?  -%>
+        <%- unless os_disk_size_gb.to_s.empty? -%>
         "osDiskSizeGb": {
             "type": "int",
             "minValue": 1,
@@ -76,36 +70,15 @@
             }
         },
         <%- end -%>
-        <%- if !existing_storage_account_blob_url.empty? -%>
-        "existingStorageAccountBlobURL": {
+        <%- unless nsg_id.to_s.empty? -%>
+        "nsgId": {
             "type": "string",
             "metadata": {
-                "description": "The URL of the existing storage account (blob) (without container)"
+                "description": "Resource id of an existing network security group to attach to the network interface."
             }
         },
         <%- end -%>
-        <%- if !existing_storage_account_container.empty? -%>
-        "existingStorageAccountBlobContainer": {
-            "type": "string",
-            "metadata": {
-                "description": "The Container Name for OS Images (blob)"
-            }
-        },
-        <%- end -%>
-        <%- if !image_url.empty? -%>
-        "imageUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "An URL for a private Image (vhd)"
-            }
-        },
-        "osType": {
-            "type": "string",
-            "metadata": {
-                "description": "An OS Type (linux, windows)"
-            }
-        },
-        <%- elsif !image_id.empty? -%>
+        <%- unless image_id.empty? -%>
         "imageId": {
             "type": "string",
             "metadata": {
@@ -122,16 +95,16 @@
         },
         "imageOffer": {
             "type": "string",
-            "defaultValue": "UbuntuServer",
+            "defaultValue": "0001-com-ubuntu-server-jammy",
             "metadata": {
-                "description": "Offer for the VM, e.g. UbuntuServer, WindowsServer."
+                "description": "Offer for the VM, e.g. 0001-com-ubuntu-server-jammy, WindowsServer."
             }
         },
         "imageSku": {
             "type": "string",
-            "defaultValue": "14.04.3-LTS",
+            "defaultValue": "22_04-lts-gen2",
             "metadata": {
-                "description": "Sku for the VM, e.g. 14.04.3-LTS"
+                "description": "Sku for the VM, e.g. 22_04-lts-gen2"
             }
         },
         "imageVersion": {
@@ -142,13 +115,6 @@
             }
         },
         <%- end -%>
-        "osDiskNameSuffix": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "A disk Name Suffix to make the disk name unique in existing storage accounts."
-            }
-        },
         "vmName": {
             "type": "string",
             "defaultValue": "vm",
@@ -165,23 +131,23 @@
         },
         "publicIPSKU": {
             "type": "string",
-            "defaultValue": "Basic",
+            "defaultValue": "Standard",
             "metadata": {
                 "description": "SKU name for the Public IP used to access the Virtual Machine."
             }
         },
         "publicIPAddressType": {
             "type": "string",
-            "defaultValue": "Dynamic",
+            "defaultValue": "Static",
             "metadata": {
-                "description": "SKU name for the Public IP used to access the Virtual Machine."
+                "description": "Allocation method for the Public IP used to access the Virtual Machine."
             }
         },
         "storageAccountType": {
             "type": "string",
             "defaultValue": "<%= storage_account_type %>",
             "metadata": {
-                "description": "The type of storage to use (e.g. Standard_LRS or Premium_LRS)."
+                "description": "The managed disk type to use (e.g. StandardSSD_LRS or Premium_LRS)."
             }
         },
         "systemAssignedIdentity": {
@@ -199,23 +165,21 @@
             }
         },
         "bootDiagnosticsEnabled": {
-            "type": "string",
-            "defaultValue": "true",
+            "type": "bool",
+            "defaultValue": true,
             "metadata": {
-                "description": "Whether to enable (true) or disable (false) boot diagnostics. Default: false."
+                "description": "Whether to enable (true) or disable (false) managed boot diagnostics."
             }
         }
     },
     "variables": {
         "location": "[parameters('location')]",
-        "OSDiskName": "osdisk",
         "nicName": "[parameters('nicName')]",
+        "nsgName": "[concat(parameters('nicName'), '-nsg')]",
         "addressPrefix": "10.0.0.0/16",
         "subnetName": "Subnet",
         "subnetPrefix": "10.0.0.0/24",
-        "storageAccountType": "[parameters('storageAccountType')]",
         "publicIPAddressName": "publicip",
-        "vmStorageAccountContainerName": "vhds",
         "vmName": "[parameters('vmName')]",
         "vmSize": "[parameters('vmSize')]",
         "vmIdentityType": "[if(parameters('systemAssignedIdentity'), if(empty(parameters('userAssignedIdentities')), 'SystemAssigned', 'SystemAssigned, UserAssigned'), if(empty(parameters('userAssignedIdentities')), 'None', 'UserAssigned'))]",
@@ -225,7 +189,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2025-04-01",
             "name": "pid-18d63047-6cdf-4f34-beed-62f01fc73fc2",
             "type": "Microsoft.Resources/deployments",
             "properties": {
@@ -237,24 +201,22 @@
                 }
             }
         },
-        <%- unless use_managed_disks -%>
-        <%- if existing_storage_account_blob_url.empty? -%>
+        <%- if create_nsg -%>
         {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2025-07-01",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "name": "[variables('nsgName')]",
             "location": "[variables('location')]",
             "properties": {
-                "accountType": "[variables('storageAccountType')]"
+                "securityRules": <%= nsg_rules_json %>
             },
             "tags": {
                 <%= vm_tags unless vm_tags.empty? %>
             }
         },
         <%- end -%>
-        <%- end -%>
         {
-            "apiVersion": "2017-08-01",
+            "apiVersion": "2025-07-01",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[variables('publicIPAddressName')]",
             "location": "[variables('location')]",
@@ -272,7 +234,7 @@
             }
         },
         {
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2025-07-01",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[variables('virtualNetworkName')]",
             "location": "[variables('location')]",
@@ -296,15 +258,23 @@
             }
         },
         {
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2025-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('nicName')]",
             "location": "[variables('location')]",
             "dependsOn": [
                 "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                <%- if create_nsg -%>
+                "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]",
+                <%- end -%>
                 "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
             ],
             "properties": {
+                <%- if attach_nsg -%>
+                "networkSecurityGroup": {
+                    "id": "<%= create_nsg ? "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]" : "[parameters('nsgId')]" %>"
+                },
+                <%- end -%>
                 "ipConfigurations": [
                     {
                         "name": "ipconfig1",
@@ -325,16 +295,11 @@
             }
         },
         {
-            "apiVersion": "2018-06-01",
+            "apiVersion": "2025-04-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('vmName')]",
             "location": "[variables('location')]",
             "dependsOn": [
-                <%- unless use_managed_disks -%>
-                <%- if existing_storage_account_blob_url.empty? -%>
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-                <%- end -%>
-                <%- end -%>
                 "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
             ],
             "properties": {
@@ -367,14 +332,14 @@
                     "adminUsername": "[parameters('adminUsername')]"
                 },
                 "storageProfile": {
-                    <%- if image_url.empty? and image_id.empty? -%>
+                    <%- if image_id.empty? -%>
                     "imageReference": {
                         "publisher": "[parameters('imagePublisher')]",
                         "offer": "[parameters('imageOffer')]",
                         "sku": "[parameters('imageSku')]",
                         "version": "[parameters('imageVersion')]"
                     },
-                    <%- elsif !image_id.empty? -%>
+                    <%- else -%>
                     "imageReference": {
                         "id": "[parameters('imageId')]"
                     },
@@ -387,7 +352,7 @@
                         "caching": "ReadOnly",
                         "createOption": "FromImage"
                     }
-                    <%- elsif use_managed_disks -%>
+                    <%- else -%>
                     "osDisk": {
                         "name": "osdisk",
                         <%- unless os_disk_size_gb.to_s.empty? -%>
@@ -396,32 +361,6 @@
                         "managedDisk": {
                             "storageAccountType": "[parameters('storageAccountType')]"
                         },
-                        "createOption": "FromImage"
-                    }
-                    <%- else -%>
-                    "osDisk": {
-                        "name": "osdisk",
-                        <%- if !image_url.empty? -%>
-                        <%- unless os_disk_size_gb.to_s.empty? -%>
-                        "diskSizeGB": "[parameters('osDiskSizeGb')]",
-                        <%- end -%>
-                        "image": {
-                            "uri": "[parameters('imageUrl')]"
-                        },
-                        "osType": "[parameters('osType')]",
-                        <%- end -%>
-                        "vhd": {
-                            <%- if existing_storage_account_blob_url.empty? -%>
-                            "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/',variables('OSDiskName'),parameters('osDiskNameSuffix'),'.vhd')]"
-                            <%- else -%>
-                            <%- if existing_storage_account_container.empty? -%>
-                            "uri": "[concat(parameters('existingStorageAccountBlobURL'), '/', variables('vmStorageAccountContainerName'), '/', variables('OSDiskName'),parameters('osDiskNameSuffix'),'.vhd')]"
-                            <%- else -%>
-                            "uri": "[concat(parameters('existingStorageAccountBlobURL'), '/', parameters('existingStorageAccountBlobContainer'), '/', variables('OSDiskName'),parameters('osDiskNameSuffix'),'.vhd')]"
-                            <%- end -%>
-                            <%- end -%>
-                        },
-                        "caching": "ReadWrite",
                         "createOption": "FromImage"
                     }
                     <%- end -%>
@@ -438,16 +377,9 @@
                     ]
                 },
                 "diagnosticsProfile": {
-                    <%- unless use_managed_disks -%>
                     "bootDiagnostics": {
-                        "enabled": "[parameters('bootDiagnosticsEnabled')]",
-                        <%- if existing_storage_account_blob_url.empty? -%>
-                        "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), '2015-06-15').primaryEndpoints.blob]"
-                        <%- else -%>
-                        "storageUri": "[parameters('existingStorageAccountBlobURL')]"
-                        <%- end -%>
+                        "enabled": "[parameters('bootDiagnosticsEnabled')]"
                     }
-                    <%- end -%>
                 }
             },
             <%- unless plan_json.nil? -%>


### PR DESCRIPTION
The driver's defaults could no longer deploy. Two Azure retirements had made them inoperable, and a third had turned a documented option into dead code.

`bundle exec rake` is green: **485 examples, 0 failures, 100% line / 96% branch coverage, 0 lint offenses**. `rake yard` reports 100% documented.

> [!WARNING]
> **Breaking.** `use_managed_disks`, `image_url`, `os_type`, `existing_storage_account_blob_url` and `existing_storage_account_container` are retired — they still parse, so an existing `kitchen.yml` keeps loading, but the driver warns and ignores them. Defaults for `public_ip_sku`, `storage_account_type` and `boot_diagnostics_enabled` have changed.

## Unbreak

**`public_ip_sku` defaulted to `Basic`.** Azure [retired Basic SKU public IPs on 30 September 2025](https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance) and blocked creation of new ones from 31 March 2025. A default `kitchen create` could not provision a public IP at all. Now defaults to `Standard`, with Static allocation.

**Flipping that alone would have made things worse.** Standard SKU public IPs are *secure by default* — closed to all inbound traffic unless a network security group opens it — and the templates created no NSG whatsoever. A Standard IP on its own would have provisioned successfully and then timed out on SSH/WinRM.

So both templates now create an NSG attached to the NIC, with rules for whichever port the transport actually uses: 22 for SSH, 5985 and 5986 for WinRM. Two new options: `nsg_id` to bring your own group, `open_ports` to add more. The generated rules allow any source address, matching the connectivity a Basic public IP used to give — so this fixes the breakage without silently changing anyone's exposure. Instances living purely inside a caller-supplied vnet get no NSG at all, leaving their subnet's own rules untouched.

**`boot_diagnostics_enabled` did nothing.** The `diagnosticsProfile` block was emitted only `unless use_managed_disks` — i.e. only on the retired path — so a documented option was inert on the default one. It now uses managed boot diagnostics, which needs no storage account. The setting used to default to the *string* `"true"`, so both spellings are accepted.

## Prune

Azure [fully retired unmanaged disks on 31 March 2026](https://learn.microsoft.com/azure/virtual-machines/unmanaged-disks-deprecation) — VMs using them can no longer be started. That made roughly a third of both ERB templates dead code. Removed: the `Microsoft.Storage/storageAccounts` resource, the VHD `osDisk` branches, `osDiskNameSuffix`, `newStorageAccountName`, and the `image_url` deployment mode.

`storage_account_type` stays, because it also drives `managedDisk.storageAccountType`, but its default moves `Standard_LRS` → `StandardSSD_LRS`, ahead of the September 2028 Standard-HDD-OS-disk retirement.

Retired options warn and are ignored rather than raising, so no existing `kitchen.yml` fails to load:

```
The 'use_managed_disks' setting is no longer supported and is being ignored.
Azure retired unmanaged disks on 31 March 2026; every deployment now uses managed disks.
```

## ARM API versions

| Resource | Before | After |
| --- | --- | --- |
| `Microsoft.Resources/deployments` | `2017-05-10` | `2025-04-01` |
| `Microsoft.Network/*` | `2015-05-01-preview` / `2017-08-01` | `2025-07-01` |
| `Microsoft.Compute/virtualMachines` | `2018-06-01` | `2025-04-01` |

Compute is **deliberately held at `2025-04-01`** rather than the newest `2026-03-01`. API version `2025-11-01`+ [enables Trusted Launch by default](https://learn.microsoft.com/azure/virtual-machines/trusted-launch#general-availability-trusted-launch-as-default), which changes behaviour for images and VM sizes that don't support it. That's a genuine improvement but it deserves its own deliberate change — left as a clean follow-up rather than a side effect of a version bump.

## Tests

The template matrix gains NSG, public IP SKU and boot-diagnostics dimensions, plus three new structural invariants: every resource is pinned to a modern API version, no storage account is created, and no VM boots from a VHD. A retired-settings suite covers the warn-and-ignore path, including that a `kitchen.yml` full of retired options still deploys.

The existing "every parameter the driver sends is declared by the template" invariant caught the pruning mismatches for free.

## Also

`yard` moves from a `:docs` group into `:development`, which CI already bundles without — so it stops being installed on every CI run.

## Follow-ups not in scope here

Trusted Launch (per above), availability zones, accelerated networking, spot instances, and replacing the ERB-string templates with Ruby Hash-to-JSON generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
