### PR TITLE
Replace the retired Azure SDK with a direct ARM REST client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,28 @@ Many style offenses can be corrected automatically:
 bundle exec cookstyle -a
 ```
 
-The unit tests stub the Azure SDK, so they neither deploy resources nor require
-a subscription or a service principal.
+The unit tests stub HTTP at the wire with WebMock, so they neither deploy
+resources nor require a subscription or a service principal. WebMock also blocks
+real network access outright, so an accidentally unstubbed request fails loudly
+rather than reaching Azure.
+
+### Talking to Azure
+
+The driver calls the Azure Resource Manager REST API directly, using only the
+Ruby standard library. The pieces live under `lib/kitchen/driver/azure/`:
+
+| File | Responsibility |
+| --- | --- |
+| `environments.rb` | Endpoints for each Azure cloud (public, US Government, China, Germany). |
+| `token_provider.rb` | Acquires and caches access tokens: service principal, managed identity, or `az login`. |
+| `arm_client.rb` | The eight ARM requests the driver makes. |
+| `http.rb` | A small `Net::HTTP` wrapper that separates transient network failures from real API errors. |
+
+One trap worth knowing about: Test Kitchen defines `Kitchen::StandardError`, and
+this code lives inside `module Kitchen`. A bare `StandardError` in that namespace
+resolves to Test Kitchen's class, not `::StandardError`, so `rescue StandardError`
+silently stops catching ordinary errors. Always write `::StandardError`
+explicitly here.
 
 ## Manual testing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/kitchen-azurerm.svg)](https://badge.fury.io/rb/kitchen-azurerm)
 [![Lint, Unit & Integration Tests](https://github.com/test-kitchen/kitchen-azurerm/actions/workflows/lint.yml/badge.svg)](https://github.com/test-kitchen/kitchen-azurerm/actions/workflows/lint.yml)
 
-**kitchen-azurerm** is a driver for the popular test harness [Test Kitchen](http://kitchen.ci) that allows Microsoft Azure resources to be provisioned before testing. This driver uses the new Microsoft Azure Resource Management REST API via the [azure-sdk-for-ruby](https://github.com/azure/azure-sdk-for-ruby).
+**kitchen-azurerm** is a driver for the popular test harness [Test Kitchen](http://kitchen.ci) that allows Microsoft Azure resources to be provisioned before testing. This driver talks to the Azure Resource Manager REST API directly, and depends only on the Ruby standard library to do so.
 
 This version has been tested on Windows, macOS, and Ubuntu. If you encounter a problem on your platform, please raise an issue.
 

--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.1"
 
-  spec.add_dependency "azure_mgmt_network2", ">= 1.0.1", "< 2.0"
-  spec.add_dependency "azure_mgmt_resources2", ">= 1.0.1", "< 2.0"
   spec.add_dependency "inifile", "~> 3.0", ">= 3.0.0"
   spec.add_dependency "sshkey", ">= 1.0.0", "< 4"
   spec.add_dependency "test-kitchen", ">= 1.20", "< 5.0"

--- a/lib/kitchen/driver/azure/arm_client.rb
+++ b/lib/kitchen/driver/azure/arm_client.rb
@@ -1,0 +1,198 @@
+require "json" unless defined?(JSON)
+require "uri" unless defined?(URI)
+
+require_relative "errors"
+require_relative "http"
+
+module Kitchen
+  module Driver
+    module Azure
+      # A minimal Azure Resource Manager client covering exactly the operations
+      # this driver performs.
+      #
+      # Replaces +azure_mgmt_resources2+, +azure_mgmt_network2+, +ms_rest2+ and
+      # +ms_rest_azure2+, which are forks of Microsoft's retired Azure SDK for
+      # Ruby. Responses are returned as parsed JSON, so callers see ARM's own
+      # camelCase property names rather than the SDK's generated model objects.
+      class ArmClient
+        # ARM API version used for resource group and deployment requests.
+        #
+        # @return [String]
+        RESOURCES_API_VERSION = "2025-04-01".freeze
+
+        # ARM API version used for network resource requests.
+        #
+        # @return [String]
+        NETWORK_API_VERSION = "2025-07-01".freeze
+
+        # @param subscription_id [String]
+        # @param environment [Environments::Environment]
+        # @param token_provider [TokenProvider]
+        def initialize(subscription_id:, environment:, token_provider:)
+          @subscription_id = subscription_id
+          @environment = environment
+          @token_provider = token_provider
+        end
+
+        # @return [String]
+        attr_reader :subscription_id
+
+        # @return [Environments::Environment]
+        attr_reader :environment
+
+        # @return [TokenProvider]
+        attr_reader :token_provider
+
+        # Whether a resource group exists.
+        #
+        # @param name [String] resource group name, case-insensitive.
+        # @return [Boolean]
+        def resource_group_exists?(name)
+          response = call(:head, resource_group_path(name), api_version: RESOURCES_API_VERSION, allow: [404])
+          response.status != 404
+        end
+
+        # Creates or updates a resource group.
+        #
+        # @param name [String] resource group name.
+        # @param location [String] Azure region.
+        # @param tags [Hash] resource tags.
+        # @return [Hash] the resource group as ARM returned it.
+        def create_or_update_resource_group(name, location:, tags: {})
+          call(:put, resource_group_path(name),
+            api_version: RESOURCES_API_VERSION,
+            body: { "location" => location, "tags" => tags || {} }).json
+        end
+
+        # Requests deletion of a resource group, returning as soon as ARM
+        # accepts the request rather than waiting for it to finish.
+        #
+        # @param name [String] resource group name.
+        # @return [void]
+        def delete_resource_group(name)
+          call(:delete, resource_group_path(name), api_version: RESOURCES_API_VERSION)
+          nil
+        end
+
+        # Submits a deployment, returning once ARM accepts it.
+        #
+        # @param resource_group [String]
+        # @param name [String] deployment name.
+        # @param deployment [Hash] the deployment body, as built by the driver.
+        # @return [Hash] the deployment as ARM returned it.
+        def create_deployment(resource_group, name, deployment)
+          call(:put, deployment_path(resource_group, name),
+            api_version: RESOURCES_API_VERSION,
+            body: deployment).json
+        end
+
+        # Reads a deployment.
+        #
+        # @param resource_group [String]
+        # @param name [String] deployment name.
+        # @return [Hash]
+        def deployment(resource_group, name)
+          call(:get, deployment_path(resource_group, name), api_version: RESOURCES_API_VERSION).json
+        end
+
+        # Lists every operation belonging to a deployment.
+        #
+        # @param resource_group [String]
+        # @param name [String] deployment name.
+        # @return [Array<Hash>]
+        def deployment_operations(resource_group, name)
+          payload = call(:get, "#{deployment_path(resource_group, name)}/operations",
+            api_version: RESOURCES_API_VERSION).json
+
+          payload.is_a?(Hash) ? Array(payload["value"]) : []
+        end
+
+        # Reads a public IP address resource.
+        #
+        # @param resource_group [String]
+        # @param name [String] public IP resource name.
+        # @return [Hash]
+        def public_ip(resource_group, name)
+          call(:get, network_path(resource_group, "publicIPAddresses", name),
+            api_version: NETWORK_API_VERSION).json
+        end
+
+        # Reads a network interface resource.
+        #
+        # @param resource_group [String]
+        # @param name [String] network interface name.
+        # @return [Hash]
+        def network_interface(resource_group, name)
+          call(:get, network_path(resource_group, "networkInterfaces", name),
+            api_version: NETWORK_API_VERSION).json
+        end
+
+        private
+
+        # @param name [String]
+        # @return [String]
+        def resource_group_path(name)
+          "/subscriptions/#{subscription_id}/resourcegroups/#{escape(name)}"
+        end
+
+        # @param resource_group [String]
+        # @param name [String]
+        # @return [String]
+        def deployment_path(resource_group, name)
+          "#{resource_group_path(resource_group)}/providers/Microsoft.Resources/deployments/#{escape(name)}"
+        end
+
+        # @param resource_group [String]
+        # @param type [String] e.g. +"publicIPAddresses"+.
+        # @param name [String]
+        # @return [String]
+        def network_path(resource_group, type, name)
+          "#{resource_group_path(resource_group)}/providers/Microsoft.Network/#{type}/#{escape(name)}"
+        end
+
+        # @param value [String]
+        # @return [String] path-escaped
+        def escape(value)
+          URI::DEFAULT_PARSER.escape(value.to_s)
+        end
+
+        # Performs an authenticated ARM request.
+        #
+        # @param method [Symbol]
+        # @param path [String] path below the resource manager URL.
+        # @param api_version [String]
+        # @param body [Hash, nil] request body, serialized as JSON.
+        # @param allow [Array<Integer>] non-2xx statuses to treat as success.
+        # @return [Http::Response]
+        # @raise [OperationError] when ARM returns an unexpected status.
+        def call(method, path, api_version:, body: nil, allow: [])
+          url = "#{environment.resource_manager_url.chomp("/")}#{path}?api-version=#{api_version}"
+          headers = {
+            "Authorization" => token_provider.authorization_header,
+            "Accept" => "application/json",
+            "User-Agent" => "kitchen-azurerm/#{Kitchen::Driver::AZURERM_VERSION}",
+          }
+          headers["Content-Type"] = "application/json" if body
+
+          response = Http.request(method:, url:, headers:, body: body && JSON.generate(body))
+          return response if response.success? || allow.include?(response.status)
+
+          raise OperationError.new(
+            "Azure returned HTTP #{response.status} for #{method.to_s.upcase} #{path}",
+            status: response.status,
+            body: error_body(response)
+          )
+        end
+
+        # @param response [Http::Response]
+        # @return [Hash] the parsed error body, or a synthesized one.
+        def error_body(response)
+          parsed = response.json
+          return parsed if parsed.is_a?(Hash) && parsed.key?("error")
+
+          { "error" => { "code" => "Unknown", "message" => response.body.to_s } }
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/driver/azure/environments.rb
+++ b/lib/kitchen/driver/azure/environments.rb
@@ -1,0 +1,73 @@
+module Kitchen
+  module Driver
+    module Azure
+      # Endpoints for each Azure cloud the driver can target.
+      #
+      # These used to come from +MsRestAzure2::AzureEnvironments+ and
+      # +MsRestAzure2::ActiveDirectoryServiceSettings+. They are stable,
+      # published values, so carrying the table ourselves costs a few lines and
+      # removes a dependency on a retired SDK.
+      module Environments
+        # One Azure cloud's endpoints.
+        #
+        # @!attribute [r] name
+        #   @return [String] canonical cloud name, e.g. +"AzureUSGovernment"+.
+        # @!attribute [r] resource_manager_url
+        #   @return [String] base URL for Azure Resource Manager requests.
+        # @!attribute [r] authentication_endpoint
+        #   @return [String] Entra ID (Azure AD) token endpoint.
+        # @!attribute [r] token_audience
+        #   @return [String] audience/resource the access token is requested for.
+        Environment = Struct.new(:name, :resource_manager_url, :authentication_endpoint, :token_audience) do
+          # The OAuth2 token URL for a tenant in this cloud.
+          #
+          # @param tenant_id [String]
+          # @return [String]
+          def token_url(tenant_id)
+            "#{authentication_endpoint.chomp("/")}/#{tenant_id}/oauth2/token"
+          end
+        end
+
+        # Every supported cloud, keyed by its downcased name so that lookups are
+        # case-insensitive.
+        #
+        # @return [Hash{String => Environment}]
+        ALL = [
+          Environment.new("Azure",
+            "https://management.azure.com/",
+            "https://login.microsoftonline.com/",
+            "https://management.core.windows.net/"),
+          Environment.new("AzureUSGovernment",
+            "https://management.usgovcloudapi.net",
+            "https://login.microsoftonline.us/",
+            "https://management.core.usgovcloudapi.net/"),
+          Environment.new("AzureChina",
+            "https://management.chinacloudapi.cn",
+            "https://login.chinacloudapi.cn/",
+            "https://management.core.chinacloudapi.cn/"),
+          Environment.new("AzureGermanCloud",
+            "https://management.microsoftazure.de",
+            "https://login.microsoftonline.de/",
+            "https://management.core.cloudapi.de/"),
+        ].each(&:freeze).to_h { |environment| [environment.name.downcase, environment] }.freeze
+
+        # Looks a cloud up by name.
+        #
+        # @param name [String] cloud name, case-insensitive.
+        # @return [Environment]
+        # @raise [Kitchen::UserError] if the name is not a known Azure cloud.
+        def self.fetch(name)
+          ALL.fetch(name.to_s.downcase) do
+            raise Kitchen::UserError,
+              "Unknown azure_environment '#{name}'. Valid values are: #{names.join(", ")} (case-insensitive)."
+          end
+        end
+
+        # @return [Array<String>] the canonical name of every supported cloud.
+        def self.names
+          ALL.values.map(&:name)
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/driver/azure/errors.rb
+++ b/lib/kitchen/driver/azure/errors.rb
@@ -1,0 +1,50 @@
+module Kitchen
+  module Driver
+    # Direct Azure Resource Manager access: endpoints, authentication, and the
+    # handful of REST calls this driver makes.
+    #
+    # This replaces the +azure_mgmt_*+ and +ms_rest*+ gems, which are forks of
+    # Microsoft's retired Azure SDK for Ruby.
+    module Azure
+      # Raised when Azure Resource Manager returns an error response.
+      #
+      # Replaces +MsRestAzure2::AzureOperationError+, keeping the +body+
+      # accessor the driver's rescue blocks already rely on.
+      #
+      # Note the explicit +::StandardError+: Test Kitchen defines
+      # +Kitchen::StandardError+, and this class lives inside +module Kitchen+,
+      # so a bare +StandardError+ here would resolve to that instead.
+      class OperationError < ::StandardError
+        # The parsed error body, as returned by ARM.
+        #
+        # @return [Hash] typically +{"error" => {"code" => ..., "message" => ...}}+.
+        attr_reader :body
+
+        # The HTTP status code of the failing response.
+        #
+        # @return [Integer]
+        attr_reader :status
+
+        # @param message [String] human-readable summary.
+        # @param status [Integer] HTTP status code.
+        # @param body [Hash] parsed ARM error body.
+        def initialize(message, status: nil, body: {})
+          super(message)
+          @status = status
+          @body = body
+        end
+
+        # The Azure error code, when ARM supplied one.
+        #
+        # @return [String, nil] e.g. +"DeploymentActive"+.
+        def code
+          body.is_a?(Hash) ? body.dig("error", "code") : nil
+        end
+      end
+
+      # Raised when a request could not be completed and is worth retrying:
+      # timeouts, resets, DNS failures and the like.
+      class TransientError < ::StandardError; end
+    end
+  end
+end

--- a/lib/kitchen/driver/azure/http.rb
+++ b/lib/kitchen/driver/azure/http.rb
@@ -1,0 +1,120 @@
+require "json" unless defined?(JSON)
+require "net/http" unless defined?(Net::HTTP)
+require "openssl" unless defined?(OpenSSL)
+require "uri" unless defined?(URI)
+
+require_relative "errors"
+
+module Kitchen
+  module Driver
+    module Azure
+      # A very small JSON-over-HTTP helper built on the standard library.
+      #
+      # The driver makes a handful of straightforward requests, so this replaces
+      # Faraday and its middleware chain rather than depending on them.
+      module Http
+        # Network-level failures worth retrying rather than surfacing.
+        #
+        # @return [Array<Class>]
+        TRANSIENT_ERRORS = [
+          Net::OpenTimeout,
+          Net::ReadTimeout,
+          Errno::ECONNREFUSED,
+          Errno::ECONNRESET,
+          Errno::EHOSTUNREACH,
+          Errno::ENETUNREACH,
+          Errno::EPIPE,
+          EOFError,
+          SocketError,
+          OpenSSL::SSL::SSLError,
+        ].freeze
+
+        # Seconds to wait for a connection and for a response.
+        #
+        # @return [Integer]
+        OPEN_TIMEOUT = 30
+        # @return [Integer]
+        READ_TIMEOUT = 120
+
+        # One HTTP response.
+        #
+        # @!attribute [r] status
+        #   @return [Integer]
+        # @!attribute [r] body
+        #   @return [String]
+        Response = Struct.new(:status, :body) do
+          # @return [Boolean] whether the status is in the 2xx range.
+          def success?
+            status.between?(200, 299)
+          end
+
+          # The response body parsed as JSON.
+          #
+          # @return [Hash, Array, nil] nil when the body is empty or not JSON.
+          def json
+            return nil if body.nil? || body.empty?
+
+            JSON.parse(body)
+          rescue JSON::ParserError
+            nil
+          end
+        end
+
+        # Performs a request.
+        #
+        # @param method [Symbol] +:get+, +:head+, +:put+, +:post+ or +:delete+.
+        # @param url [String] absolute URL.
+        # @param headers [Hash{String => String}] request headers.
+        # @param body [String, nil] request body, already encoded.
+        # @return [Response]
+        # @raise [TransientError] on a network failure worth retrying.
+        def self.request(method:, url:, headers: {}, body: nil)
+          uri = URI.parse(url)
+          request = request_class(method).new(uri)
+          headers.each { |name, value| request[name] = value }
+          request.body = body if body
+
+          response = perform(uri, request)
+          Response.new(response.code.to_i, response.body.to_s)
+        rescue *TRANSIENT_ERRORS => e
+          raise TransientError, "#{e.class}: #{e.message}"
+        end
+
+        # Sends a request, honouring the proxy environment variables.
+        #
+        # @param uri [URI]
+        # @param request [Net::HTTPRequest]
+        # @return [Net::HTTPResponse]
+        # @api private
+        def self.perform(uri, request)
+          proxy = uri.find_proxy
+          http = if proxy
+                   Net::HTTP.new(uri.host, uri.port, proxy.host, proxy.port, proxy.user, proxy.password)
+                 else
+                   Net::HTTP.new(uri.host, uri.port)
+                 end
+
+          http.use_ssl = uri.scheme == "https"
+          http.open_timeout = OPEN_TIMEOUT
+          http.read_timeout = READ_TIMEOUT
+          http.start { |connection| connection.request(request) }
+        end
+
+        # @param method [Symbol]
+        # @return [Class] the matching +Net::HTTP+ request class.
+        # @raise [ArgumentError] for an unsupported method.
+        # @api private
+        def self.request_class(method)
+          case method
+          when :get then Net::HTTP::Get
+          when :head then Net::HTTP::Head
+          when :put then Net::HTTP::Put
+          when :post then Net::HTTP::Post
+          when :delete then Net::HTTP::Delete
+          else raise ArgumentError, "Unsupported HTTP method: #{method}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/driver/azure/token_provider.rb
+++ b/lib/kitchen/driver/azure/token_provider.rb
@@ -1,0 +1,196 @@
+require "json" unless defined?(JSON)
+require "open3" unless defined?(Open3)
+require "time" unless defined?(Time.parse)
+require "uri" unless defined?(URI)
+
+require_relative "errors"
+require_relative "http"
+
+module Kitchen
+  module Driver
+    module Azure
+      # Acquires and caches Entra ID (Azure AD) access tokens for ARM.
+      #
+      # Replaces the +MsRestAzure2+ token providers. Each subclass knows how to
+      # fetch a token one way; the caching and expiry handling is shared.
+      class TokenProvider
+        # Seconds before actual expiry at which a cached token is considered
+        # stale, so a long deployment does not fail mid-flight.
+        #
+        # @return [Integer]
+        EXPIRY_MARGIN = 300
+
+        # @param environment [Environments::Environment] the target cloud.
+        def initialize(environment:)
+          @environment = environment
+          @token = nil
+          @expires_at = nil
+        end
+
+        # @return [Environments::Environment]
+        attr_reader :environment
+
+        # A valid access token, fetching or refreshing one if needed.
+        #
+        # @return [String]
+        def access_token
+          return @token if @token && @expires_at && Time.now.to_i < @expires_at - EXPIRY_MARGIN
+
+          @token, @expires_at = fetch_token
+          @token
+        end
+
+        # The value for the Authorization header.
+        #
+        # @return [String]
+        def authorization_header
+          "Bearer #{access_token}"
+        end
+
+        # Fetches a fresh token.
+        #
+        # @return [Array(String, Integer)] the token and its expiry, as a Unix time.
+        # @raise [NotImplementedError] subclasses must implement this.
+        def fetch_token
+          raise NotImplementedError
+        end
+
+        private
+
+        # Turns a token endpoint response into a token and expiry pair.
+        #
+        # @param response [Http::Response]
+        # @param source [String] describes the endpoint, for error messages.
+        # @return [Array(String, Integer)]
+        # @raise [OperationError] if the endpoint did not return a token.
+        def token_from(response, source)
+          payload = response.json
+          unless response.success? && payload.is_a?(Hash) && payload["access_token"]
+            raise OperationError.new(
+              "Could not acquire an Azure access token from #{source} (HTTP #{response.status}).",
+              status: response.status,
+              body: payload.is_a?(Hash) ? payload : {}
+            )
+          end
+
+          [payload["access_token"], expiry_from(payload)]
+        end
+
+        # Reads the expiry out of a token response, which spells it differently
+        # depending on the endpoint.
+        #
+        # @param payload [Hash]
+        # @return [Integer] Unix time at which the token expires.
+        def expiry_from(payload)
+          return payload["expires_on"].to_i if payload["expires_on"].to_s.match?(/\A\d+\z/)
+          return Time.now.to_i + payload["expires_in"].to_i if payload["expires_in"]
+
+          Time.now.to_i + 3600
+        end
+      end
+
+      # Authenticates as a service principal, using a client id and secret.
+      class ServicePrincipalToken < TokenProvider
+        # @param environment [Environments::Environment]
+        # @param tenant_id [String]
+        # @param client_id [String]
+        # @param client_secret [String]
+        def initialize(environment:, tenant_id:, client_id:, client_secret:)
+          super(environment:)
+          @tenant_id = tenant_id
+          @client_id = client_id
+          @client_secret = client_secret
+        end
+
+        # @return [Array(String, Integer)]
+        def fetch_token
+          response = Http.request(
+            method: :post,
+            url: environment.token_url(@tenant_id),
+            headers: { "Content-Type" => "application/x-www-form-urlencoded" },
+            body: URI.encode_www_form(
+              grant_type: "client_credentials",
+              client_id: @client_id,
+              client_secret: @client_secret,
+              resource: environment.token_audience
+            )
+          )
+
+          token_from(response, "the service principal token endpoint")
+        end
+      end
+
+      # Authenticates as a managed identity, via the Instance Metadata Service.
+      #
+      # This replaces the legacy MSI extension endpoint on port 50342 that the
+      # old SDK used; IMDS is the supported endpoint on modern Azure VMs.
+      class ManagedIdentityToken < TokenProvider
+        # @return [String] the IMDS token endpoint.
+        IMDS_URL = "http://169.254.169.254/metadata/identity/oauth2/token".freeze
+
+        # @return [String] IMDS API version.
+        API_VERSION = "2018-02-01".freeze
+
+        # @param environment [Environments::Environment]
+        # @param client_id [String, nil] the user-assigned identity to use, or
+        #   nil for the system-assigned identity.
+        def initialize(environment:, client_id: nil)
+          super(environment:)
+          @client_id = client_id
+        end
+
+        # @return [Array(String, Integer)]
+        def fetch_token
+          query = { "api-version" => API_VERSION, "resource" => environment.token_audience }
+          query["client_id"] = @client_id if @client_id
+
+          response = Http.request(
+            method: :get,
+            url: "#{IMDS_URL}?#{URI.encode_www_form(query)}",
+            headers: { "Metadata" => "true" }
+          )
+
+          token_from(response, "the instance metadata service")
+        end
+      end
+
+      # Reuses whatever the Azure CLI is already signed in as.
+      class AzureCliToken < TokenProvider
+        # @return [Array(String, Integer)]
+        # @raise [OperationError] if the CLI is missing or not signed in.
+        def fetch_token
+          stdout, stderr, status = Open3.capture3(
+            "az", "account", "get-access-token",
+            "--resource", environment.token_audience,
+            "--output", "json"
+          )
+
+          unless status.success?
+            raise OperationError.new("Could not acquire an Azure access token via `az account get-access-token`. Run `az login` first. (#{stderr.strip})")
+          end
+
+          payload = JSON.parse(stdout)
+          [payload.fetch("accessToken"), cli_expiry(payload)]
+        rescue Errno::ENOENT
+          raise OperationError.new("The Azure CLI (`az`) was not found on PATH, and no other Azure credentials were configured.")
+        rescue JSON::ParserError, KeyError
+          raise OperationError.new("Could not understand the response from `az account get-access-token`.")
+        end
+
+        private
+
+        # The CLI reports a local timestamp rather than a Unix time.
+        #
+        # @param payload [Hash]
+        # @return [Integer]
+        def cli_expiry(payload)
+          return payload["expires_on"].to_i if payload["expires_on"].to_s.match?(/\A\d+\z/)
+
+          Time.parse(payload["expiresOn"]).to_i
+        rescue ::StandardError
+          Time.now.to_i + 3600
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -2,13 +2,14 @@ require "inifile"
 
 require "kitchen/errors"
 require "kitchen/logging"
-autoload :MsRest2, "ms_rest2"
-autoload :MsRestAzure2, "ms_rest_azure2"
+
+require_relative "azure/arm_client"
+require_relative "azure/environments"
+require_relative "azure/token_provider"
 
 module Kitchen
   module Driver
-    # Resolves Azure Resource Manager credentials and endpoint settings for a
-    # single subscription.
+    # Resolves Azure Resource Manager credentials for a single subscription.
     #
     # Credentials are sourced, in order of precedence, from environment
     # variables (+AZURE_TENANT_ID+, +AZURE_CLIENT_ID+, +AZURE_CLIENT_SECRET+)
@@ -16,13 +17,13 @@ module Kitchen
     # +~/.azure/credentials+, overridable with +AZURE_CONFIG_FILE+).
     #
     # The combination of values that resolve determines which token provider is
-    # used - see {#azure_options}.
+    # used - see {#token_provider}.
     #
     # @example Service principal supplied by environment
     #   ENV["AZURE_TENANT_ID"]     = "..."
     #   ENV["AZURE_CLIENT_ID"]     = "..."
     #   ENV["AZURE_CLIENT_SECRET"] = "..."
-    #   options = Kitchen::Driver::AzureCredentials.new(subscription_id: "...").azure_options
+    #   client = Kitchen::Driver::AzureCredentials.new(subscription_id: "...").arm_client
     class AzureCredentials
       include Kitchen::Logging
 
@@ -31,23 +32,6 @@ module Kitchen
       #
       # @return [String]
       CONFIG_FILE = File.join(".azure", "credentials").freeze
-
-      # Azure cloud names understood by {#azure_options}, mapped to the
-      # +MsRestAzure2+ constants that describe them. Keys are downcased so
-      # lookups are case-insensitive.
-      #
-      # @return [Hash{String => Symbol}]
-      ENVIRONMENTS = {
-        "azure" => :Azure,
-        "azurechina" => :AzureChina,
-        "azuregermancloud" => :AzureGermanCloud,
-        "azureusgovernment" => :AzureUSGovernment,
-      }.freeze
-
-      # Port the Azure Instance Metadata Service listens on for MSI token requests.
-      #
-      # @return [Integer]
-      MSI_PORT = 50342
 
       # The Azure subscription these credentials authenticate against.
       #
@@ -77,29 +61,23 @@ module Kitchen
         @subscription_id = subscription_id
         @environment = environment || "Azure"
 
-        unless ENVIRONMENTS.key?(@environment.to_s.downcase)
-          raise Kitchen::UserError,
-            "Unknown azure_environment '#{@environment}'. Valid values are: #{ENVIRONMENTS.keys.join(", ")} (case-insensitive)."
-        end
+        # Validate eagerly so a typo surfaces before any Azure call is made.
+        azure_environment
       end
 
-      # Builds the options hash accepted by every +azure_mgmt_*2+ client.
+      # An ARM client authenticated with these credentials.
       #
-      # The +:credentials+ entry wraps whichever token provider matches the
-      # resolved credentials - see {#token_provider}. +:client_id+ and
-      # +:client_secret+ are only included when they resolve to a value.
+      # @return [Azure::ArmClient]
+      def arm_client
+        Azure::ArmClient.new(subscription_id:, environment: azure_environment, token_provider:)
+      end
+
+      # Endpoints for the configured cloud.
       #
-      # @return [Hash] options suitable for
-      #   +Azure::Resources2::Profiles::Latest::Mgmt::Client.new+ and friends.
-      def azure_options
-        options = { tenant_id: tenant_id!,
-                    subscription_id:,
-                    credentials: ::MsRest2::TokenCredentials.new(token_provider),
-                    active_directory_settings: ad_settings,
-                    base_url: endpoint_settings.resource_manager_endpoint_url }
-        options[:client_id] = client_id if client_id
-        options[:client_secret] = client_secret if client_secret
-        options
+      # @return [Azure::Environments::Environment]
+      # @raise [Kitchen::UserError] if the cloud name is not recognised.
+      def azure_environment
+        @azure_environment ||= Azure::Environments.fetch(environment)
       end
 
       # Selects a token provider based on which credentials resolved.
@@ -109,44 +87,9 @@ module Kitchen
       # * +tenant_id+ only - system-assigned managed identity.
       # * none of the above - falls back to the +az login+ token cache.
       #
-      # @return [MsRestAzure2::ApplicationTokenProvider,
-      #   MsRestAzure2::MSITokenProvider, MsRestAzure2::AzureCliTokenProvider]
+      # @return [Azure::TokenProvider]
       def token_provider
-        if client_id && client_secret && tenant_id
-          ::MsRestAzure2::ApplicationTokenProvider.new(tenant_id, client_id, client_secret, ad_settings)
-        elsif client_id && tenant_id
-          ::MsRestAzure2::MSITokenProvider.new(MSI_PORT, ad_settings, { client_id: })
-        elsif tenant_id
-          ::MsRestAzure2::MSITokenProvider.new(MSI_PORT, ad_settings)
-        else
-          warn("Using tenant id set through `az login`.")
-          ::MsRestAzure2::AzureCliTokenProvider.new(ad_settings)
-        end
-      end
-
-      # Active Directory settings for the configured cloud.
-      #
-      # @return [MsRestAzure2::ActiveDirectoryServiceSettings]
-      def ad_settings
-        case environment_key
-        when :AzureUSGovernment then ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_us_government_settings
-        when :AzureChina        then ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_china_settings
-        when :AzureGermanCloud  then ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_german_settings
-        else ::MsRestAzure2::ActiveDirectoryServiceSettings.get_azure_settings
-        end
-      end
-
-      # Endpoint settings (resource manager URL, storage suffixes, ...) for the
-      # configured cloud.
-      #
-      # @return [MsRestAzure2::AzureEnvironment]
-      def endpoint_settings
-        case environment_key
-        when :AzureUSGovernment then ::MsRestAzure2::AzureEnvironments::AzureUSGovernment
-        when :AzureChina        then ::MsRestAzure2::AzureEnvironments::AzureChinaCloud
-        when :AzureGermanCloud  then ::MsRestAzure2::AzureEnvironments::AzureGermanCloud
-        else ::MsRestAzure2::AzureEnvironments::AzureCloud
-        end
+        @token_provider ||= build_token_provider
       end
 
       # Path of the credentials file actually in use.
@@ -159,9 +102,18 @@ module Kitchen
 
       private
 
-      # @return [Symbol] the {ENVIRONMENTS} key for the configured cloud.
-      def environment_key
-        ENVIRONMENTS.fetch(environment.to_s.downcase)
+      # @return [Azure::TokenProvider]
+      def build_token_provider
+        if client_id && client_secret && tenant_id!
+          Azure::ServicePrincipalToken.new(environment: azure_environment, tenant_id:, client_id:, client_secret:)
+        elsif client_id && tenant_id!
+          Azure::ManagedIdentityToken.new(environment: azure_environment, client_id:)
+        elsif tenant_id!
+          Azure::ManagedIdentityToken.new(environment: azure_environment)
+        else
+          warn("Using tenant id set through `az login`.")
+          Azure::AzureCliToken.new(environment: azure_environment)
+        end
       end
 
       # @return [Kitchen::Logger] the shared Test Kitchen logger.
@@ -191,11 +143,16 @@ module Kitchen
         value unless value.to_s.empty?
       end
 
-      # Tenant ID, warning the user when one cannot be resolved.
+      # Tenant ID, warning the user once when one cannot be resolved.
       #
       # @return [String, nil]
       def tenant_id!
-        tenant_id || warn("(#{config_path}) does not contain tenant_id neither is the AZURE_TENANT_ID environment variable set.")
+        return tenant_id if tenant_id
+        return nil if @warned_about_tenant_id
+
+        @warned_about_tenant_id = true
+        warn("(#{config_path}) does not contain tenant_id neither is the AZURE_TENANT_ID environment variable set.")
+        nil
       end
 
       # @return [String, nil] tenant ID from the environment or credentials file.

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -1,21 +1,14 @@
 require "kitchen"
 
-autoload :MsRestAzure2, "ms_rest_azure2"
 require_relative "azure_credentials"
+require_relative "azure/errors"
 require "securerandom" unless defined?(SecureRandom)
-# Azure SDK namespaces, autoloaded so that requiring this driver does not pull
-# in the (large) management clients until a deployment actually needs them.
-module Azure
-  autoload :Resources2, "azure_mgmt_resources2"
-  autoload :Network2, "azure_mgmt_network2"
-end
 require "base64" unless defined?(Base64)
 autoload :SSHKey, "sshkey"
 require "fileutils" unless defined?(FileUtils)
 require "erb" unless defined?(Erb)
 require "ostruct" unless defined?(OpenStruct)
 require "json" unless defined?(JSON)
-autoload :Faraday, "faraday"
 
 # Test Kitchen's top-level namespace.
 module Kitchen
@@ -33,14 +26,8 @@ module Kitchen
       # Client for the Azure Resource Manager API, built during {#create} or
       # {#destroy} once credentials have been resolved.
       #
-      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Client, nil]
-      attr_accessor :resource_management_client
-
-      # Client for the Azure Network API, built during {#create} once the
-      # deployment has completed.
-      #
-      # @return [::Azure::Network2::Profiles::Latest::Mgmt::Client, nil]
-      attr_accessor :network_management_client
+      # @return [Azure::ArmClient, nil]
+      attr_accessor :arm_client
 
       kitchen_driver_api_version 2
 
@@ -262,7 +249,7 @@ module Kitchen
       # @param state [Hash] the instance state, mutated in place.
       # @return [void]
       # @raise [RuntimeError] if no +subscription_id+ can be resolved.
-      # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails
+      # @raise [Azure::OperationError] if an Azure API call fails
       #   for any reason other than an already-running deployment.
       def create(state)
         warn_about_deprecated_config
@@ -273,16 +260,14 @@ module Kitchen
           raise "A subscription_id config value was not detected and kitchen-azurerm cannot continue. Please check your kitchen.yml configuration. Exiting."
         end
 
-        options = Kitchen::Driver::AzureCredentials.new(subscription_id: config[:subscription_id],
-          environment: config[:azure_environment]).azure_options
-
         debug "Azure environment: #{config[:azure_environment]}"
-        @resource_management_client = ::Azure::Resources2::Profiles::Latest::Mgmt::Client.new(options)
+        @arm_client = Kitchen::Driver::AzureCredentials.new(subscription_id: config[:subscription_id],
+          environment: config[:azure_environment]).arm_client
 
         begin
           info "Creating Resource Group: #{state[:azure_resource_group_name]}"
           create_resource_group(state[:azure_resource_group_name], get_resource_group)
-        rescue ::MsRestAzure2::AzureOperationError => operation_error
+        rescue Azure::OperationError => operation_error
           error operation_error.body
           raise operation_error
         end
@@ -294,9 +279,9 @@ module Kitchen
           store_deployment_credentials(state, deployment_parameters)
 
           run_deployment(state, "post-deploy", post_deployment(config[:post_deployment_template], config[:post_deployment_parameters])) if File.file?(config[:post_deployment_template])
-        rescue ::MsRestAzure2::AzureOperationError => operation_error
+        rescue Azure::OperationError => operation_error
           rest_error = operation_error.body["error"]
-          if rest_error["code"] == "DeploymentActive"
+          if operation_error.code == "DeploymentActive"
             info "Deployment for resource group #{state[:azure_resource_group_name]} is ongoing."
             info "If you need to change the deployment template you'll need to rerun `kitchen create` for this instance."
           else
@@ -305,7 +290,6 @@ module Kitchen
           end
         end
 
-        @network_management_client = ::Azure::Network2::Profiles::Latest::Mgmt::Client.new(options)
         state[:hostname] = resolve_hostname(state, deployment_parameters["nicName"])
       end
 
@@ -380,12 +364,12 @@ module Kitchen
       #
       # @param state [Hash] instance state, used for the resource group and uuid.
       # @param prefix [String] deployment name prefix, e.g. +"pre-deploy"+.
-      # @param deployment [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @param deployment [Hash] the deployment body
       # @return [void]
       def run_deployment(state, prefix, deployment)
         name = "#{prefix}-#{state[:uuid]}"
         info "Creating deployment: #{name}"
-        create_deployment_async(state[:azure_resource_group_name], name, deployment).value!
+        create_deployment_async(state[:azure_resource_group_name], name, deployment)
         follow_deployment_until_end_state(state[:azure_resource_group_name], name)
       end
 
@@ -421,17 +405,20 @@ module Kitchen
       def resolve_hostname(state, vmnic)
         if public_ip?
           result = get_public_ip(state[:azure_resource_group_name], "publicip")
-          info "IP Address is: #{result.ip_address} [#{result.dns_settings.fqdn}]"
+          ip_address = result.dig("properties", "ipAddress")
+          fqdn = result.dig("properties", "dnsSettings", "fqdn")
+          info "IP Address is: #{ip_address} [#{fqdn}]"
           if config[:use_fqdn_hostname]
             info "Using FQDN to communicate instead of IP"
-            result.dns_settings.fqdn
+            fqdn
           else
-            result.ip_address
+            ip_address
           end
         else
           result = get_network_interface(state[:azure_resource_group_name], vmnic.to_s)
-          info "IP Address is: #{result.ip_configurations[0].private_ipaddress}"
-          result.ip_configurations[0].private_ipaddress
+          private_ip = result.dig("properties", "ipConfigurations", 0, "properties", "privateIPAddress")
+          info "IP Address is: #{private_ip}"
+          private_ip
         end
       end
 
@@ -576,7 +563,7 @@ module Kitchen
       #
       # @param pre_deployment_template_filename [String] path to an ARM template.
       # @param pre_deployment_parameters [Hash] parameter name to value.
-      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @return [Hash] the deployment body
       def pre_deployment(pre_deployment_template_filename, pre_deployment_parameters)
         build_deployment(::File.read(pre_deployment_template_filename), pre_deployment_parameters)
       end
@@ -584,10 +571,10 @@ module Kitchen
       # Builds the virtual machine deployment.
       #
       # @param parameters [Hash] parameter name to value.
-      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @return [Hash] the deployment body
       def deployment(parameters)
         deployment = build_deployment(template_for_transport_name, parameters)
-        debug(JSON.pretty_generate(deployment.properties.template))
+        debug(JSON.pretty_generate(deployment_template(deployment)))
         deployment
       end
 
@@ -595,7 +582,7 @@ module Kitchen
       #
       # @param post_deployment_template_filename [String] path to an ARM template.
       # @param post_deployment_parameters [Hash] parameter name to value.
-      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @return [Hash] the deployment body
       def post_deployment(post_deployment_template_filename, post_deployment_parameters)
         build_deployment(::File.read(post_deployment_template_filename), post_deployment_parameters)
       end
@@ -603,10 +590,10 @@ module Kitchen
       # An empty Complete-mode deployment, used to delete every resource inside
       # a resource group while leaving the group itself in place.
       #
-      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
+      # @return [Hash] the deployment body
       def empty_deployment
-        deployment = build_deployment(virtual_machine_deployment_template_file("empty.erb", nil), nil, mode: ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Complete)
-        debug(JSON.pretty_generate(deployment.properties.template))
+        deployment = build_deployment(virtual_machine_deployment_template_file("empty.erb", nil), nil, mode: "Complete")
+        debug(JSON.pretty_generate(deployment_template(deployment)))
         deployment
       end
 
@@ -615,14 +602,21 @@ module Kitchen
       # @param template [String] the ARM template as JSON.
       # @param parameters [Hash, nil] parameter name to value, or nil for none.
       # @param mode [String] the ARM deployment mode.
-      # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
-      def build_deployment(template, parameters, mode: ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Incremental)
-        deployment = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment.new
-        deployment.properties = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentProperties.new
-        deployment.properties.mode = mode
-        deployment.properties.template = JSON.parse(template)
-        deployment.properties.parameters = parameters_in_values_format(parameters) if parameters
-        deployment
+      # @return [Hash] the deployment body
+      def build_deployment(template, parameters, mode: "Incremental")
+        properties = { "mode" => mode, "template" => JSON.parse(template) }
+        formatted = parameters_in_values_format(parameters)
+        properties["parameters"] = formatted if formatted
+
+        { "properties" => properties }
+      end
+
+      # The parsed ARM template inside a deployment body.
+      #
+      # @param deployment [Hash] as built by {#build_deployment}.
+      # @return [Hash]
+      def deployment_template(deployment)
+        deployment["properties"]["template"]
       end
 
       # Renders resource tags as a JSON object body (no surrounding braces), for
@@ -647,7 +641,7 @@ module Kitchen
         return nil if parameters_in.nil? || parameters_in.empty?
 
         parameters_in.each_with_object({}) do |(key, value), acc|
-          acc[key.to_sym] = { "value" => value }
+          acc[key.to_s] = { "value" => value }
         end
       end
 
@@ -680,11 +674,11 @@ module Kitchen
       # @raise [RuntimeError] if any operation reported a non-OK status code.
       def show_failed_operations(resource_group, deployment_name)
         failures = list_deployment_operations(resource_group, deployment_name).reject do |operation|
-          operation.properties.status_code == "OK"
+          operation.dig("properties", "statusCode") == "OK"
         end
         return if failures.empty?
 
-        raise failures.map { |operation| operation.properties.status_message.inspect }.join("\n")
+        raise failures.map { |operation| operation.dig("properties", "statusMessage").inspect }.join("\n")
       end
 
       # Logs every deployment operation that has not yet reached a terminal state.
@@ -695,11 +689,11 @@ module Kitchen
       def list_outstanding_deployment_operations(resource_group, deployment_name)
         end_operation_states = %w{Failed Succeeded}
         list_deployment_operations(resource_group, deployment_name).each do |operation|
-          resource_provisioning_state = operation.properties.provisioning_state
+          resource_provisioning_state = operation.dig("properties", "provisioningState")
           next if end_operation_states.include?(resource_provisioning_state)
 
-          target = operation.properties.target_resource
-          info "Resource #{target&.resource_type} '#{target&.resource_name}' provisioning status is #{resource_provisioning_state}"
+          target = operation.dig("properties", "targetResource") || {}
+          info "Resource #{target["resourceType"]} '#{target["resourceName"]}' provisioning status is #{resource_provisioning_state}"
         end
       end
 
@@ -707,15 +701,14 @@ module Kitchen
       #
       # @param state [Hash] the instance state, mutated in place.
       # @return [void]
-      # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails.
+      # @raise [Azure::OperationError] if an Azure API call fails.
       def destroy(state)
         # TODO: We have some not so fun state issues we need to clean up
         state[:azure_environment] = config[:azure_environment] unless state[:azure_environment]
         state[:subscription_id] = config[:subscription_id] unless state[:subscription_id]
 
-        options = Kitchen::Driver::AzureCredentials.new(subscription_id: state[:subscription_id],
-          environment: state[:azure_environment]).azure_options
-        @resource_management_client = ::Azure::Resources2::Profiles::Latest::Mgmt::Client.new(options)
+        @arm_client = Kitchen::Driver::AzureCredentials.new(subscription_id: state[:subscription_id],
+          environment: state[:azure_environment]).arm_client
 
         return if destroy_orphaned_explicit_resource_group(state)
 
@@ -737,7 +730,7 @@ module Kitchen
           delete_resource_group_async(state[:azure_resource_group_name])
           info "Destroy operation accepted and will continue in the background."
           state.delete(:azure_resource_group_name)
-        rescue ::MsRestAzure2::AzureOperationError => operation_error
+        rescue Azure::OperationError => operation_error
           error operation_error.body
           raise operation_error
         end
@@ -753,7 +746,7 @@ module Kitchen
       #
       # @param state [Hash] the instance state.
       # @return [Boolean] true when the group was deleted and {#destroy} should stop.
-      # @raise [MsRestAzure2::AzureOperationError] if the delete request fails.
+      # @raise [Azure::OperationError] if the delete request fails.
       def destroy_orphaned_explicit_resource_group(state)
         return false unless state[:server_id].nil? && state[:azure_resource_group_name].nil?
         return false if config[:explicit_resource_group_name].nil?
@@ -765,7 +758,7 @@ module Kitchen
         delete_resource_group_async(config[:explicit_resource_group_name])
         info "Destroy operation accepted and will continue in the background."
         true
-      rescue ::MsRestAzure2::AzureOperationError => operation_error
+      rescue Azure::OperationError => operation_error
         error operation_error.body
         raise operation_error
       end
@@ -775,7 +768,7 @@ module Kitchen
       #
       # @param state [Hash] the instance state.
       # @return [void]
-      # @raise [MsRestAzure2::AzureOperationError] if an Azure API call fails.
+      # @raise [Azure::OperationError] if an Azure API call fails.
       def destroy_resource_group_contents(state)
         info "Destroying individual resources within the Resource Group."
         run_deployment(state, "empty-deploy", empty_deployment)
@@ -785,11 +778,9 @@ module Kitchen
           create_resource_group(state[:azure_resource_group_name], get_resource_group)
         else
           warn 'The "destroy_explicit_resource_group_tags" setting value is set to "true". The tags on the resource group will be removed.'
-          resource_group = get_resource_group
-          resource_group.tags = {}
-          create_resource_group(state[:azure_resource_group_name], resource_group)
+          create_resource_group(state[:azure_resource_group_name], get_resource_group.merge(tags: {}))
         end
-      rescue ::MsRestAzure2::AzureOperationError => operation_error
+      rescue Azure::OperationError => operation_error
         error operation_error.body
         raise operation_error
       end
@@ -1078,14 +1069,11 @@ module Kitchen
       # Wrapper methods for the Azure API calls to retry the calls when getting timeouts.
       #
 
-      # A new resource group object carrying the configured location and tags.
+      # The resource group body carrying the configured location and tags.
       #
-      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup]
+      # @return [Hash]
       def get_resource_group
-        resource_group = ::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup.new
-        resource_group.location = config[:location]
-        resource_group.tags = config[:resource_group_tags]
-        resource_group
+        { location: config[:location], tags: config[:resource_group_tags] }
       end
 
       # Runs an Azure API call, retrying on transient connection failures.
@@ -1093,12 +1081,12 @@ module Kitchen
       # @param description [String] describes the call, used in retry logging.
       # @yield the API call to run.
       # @return [Object] whatever the block returns.
-      # @raise [Faraday::Error] once the retry budget is exhausted.
+      # @raise [Azure::TransientError] once the retry budget is exhausted.
       def with_azure_retries(description)
         retries = config[:azure_api_retries]
         begin
           yield
-        rescue Faraday::TimeoutError, Faraday::ClientError => exception
+        rescue Azure::TransientError => exception
           send_exception_message(exception, "#{description} #{retries} retries left.")
           raise if retries <= 0
 
@@ -1113,18 +1101,19 @@ module Kitchen
       # @return [Boolean]
       def resource_group_exists?(resource_group_name)
         with_azure_retries("while checking if resource group '#{resource_group_name}' exists.") do
-          resource_management_client.resource_groups.check_existence(resource_group_name)
+          arm_client.resource_group_exists?(resource_group_name)
         end
       end
 
       # Creates or updates a resource group.
       #
       # @param resource_group_name [String] the resource group name.
-      # @param resource_group [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup]
-      # @return [::Azure::Resources2::Profiles::Latest::Mgmt::Models::ResourceGroup]
+      # @param resource_group [Hash] with +:location+ and +:tags+.
+      # @return [Hash] the resource group as ARM returned it.
       def create_resource_group(resource_group_name, resource_group)
         with_azure_retries("while creating resource group '#{resource_group_name}'.") do
-          resource_management_client.resource_groups.create_or_update(resource_group_name, resource_group)
+          arm_client.create_or_update_resource_group(resource_group_name,
+            location: resource_group[:location], tags: resource_group[:tags])
         end
       end
 
@@ -1132,11 +1121,11 @@ module Kitchen
       #
       # @param resource_group [String] the resource group name.
       # @param deployment_name [String] the deployment name.
-      # @param deployment [::Azure::Resources2::Profiles::Latest::Mgmt::Models::Deployment]
-      # @return [Concurrent::Promise] resolves once the request is accepted.
+      # @param deployment [Hash] as built by {#build_deployment}.
+      # @return [Hash] the deployment as ARM returned it.
       def create_deployment_async(resource_group, deployment_name, deployment)
         with_azure_retries("while sending deployment creation request for deployment '#{deployment_name}'.") do
-          resource_management_client.deployments.begin_create_or_update_async(resource_group, deployment_name, deployment)
+          arm_client.create_deployment(resource_group, deployment_name, deployment)
         end
       end
 
@@ -1144,10 +1133,10 @@ module Kitchen
       #
       # @param resource_group_name [String] the resource group name.
       # @param public_ip_name [String] the public IP resource name.
-      # @return [Object] the public IP address resource.
+      # @return [Hash] the public IP address resource.
       def get_public_ip(resource_group_name, public_ip_name)
         with_azure_retries("while fetching public ip '#{public_ip_name}' for resource group '#{resource_group_name}'.") do
-          network_management_client.public_ipaddresses.get(resource_group_name, public_ip_name)
+          arm_client.public_ip(resource_group_name, public_ip_name)
         end
       end
 
@@ -1155,11 +1144,10 @@ module Kitchen
       #
       # @param resource_group_name [String] the resource group name.
       # @param network_interface_name [String] the NIC name.
-      # @return [Object] the network interface resource.
+      # @return [Hash] the network interface resource.
       def get_network_interface(resource_group_name, network_interface_name)
         with_azure_retries("while fetching network interface '#{network_interface_name}' for resource group '#{resource_group_name}'.") do
-          network_interfaces = ::Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces.new(network_management_client)
-          network_interfaces.get(resource_group_name, network_interface_name)
+          arm_client.network_interface(resource_group_name, network_interface_name)
         end
       end
 
@@ -1167,10 +1155,10 @@ module Kitchen
       #
       # @param resource_group [String] the resource group name.
       # @param deployment_name [String] the deployment name.
-      # @return [Array<Object>]
+      # @return [Array<Hash>]
       def list_deployment_operations(resource_group, deployment_name)
         with_azure_retries("while listing deployment operations for deployment '#{deployment_name}'.") do
-          resource_management_client.deployment_operations.list(resource_group, deployment_name)
+          arm_client.deployment_operations(resource_group, deployment_name)
         end
       end
 
@@ -1181,7 +1169,7 @@ module Kitchen
       # @return [String] e.g. +"Running"+, +"Succeeded"+, +"Failed"+.
       def get_deployment_state(resource_group, deployment_name)
         with_azure_retries("while retrieving state for deployment '#{deployment_name}'.") do
-          resource_management_client.deployments.get(resource_group, deployment_name).properties.provisioning_state
+          arm_client.deployment(resource_group, deployment_name).dig("properties", "provisioningState")
         end
       end
 
@@ -1191,7 +1179,7 @@ module Kitchen
       # @return [Object] the operation response.
       def delete_resource_group_async(resource_group_name)
         with_azure_retries("while sending resource group deletion request for '#{resource_group_name}'.") do
-          resource_management_client.resource_groups.begin_delete(resource_group_name)
+          arm_client.delete_resource_group(resource_group_name)
         end
       end
 
@@ -1201,14 +1189,12 @@ module Kitchen
       # @param message [String] context describing what was being attempted.
       # @return [void]
       def send_exception_message(exception, message)
-        header = case exception
-                 when Faraday::TimeoutError then "Timed out"
-                 when Faraday::ClientError then "Connection reset by peer"
-                 else
-                   info "Unrecognized exception type."
-                   return
-                 end
-        info "#{header} #{message}"
+        unless exception.is_a?(Azure::TransientError)
+          info "Unrecognized exception type."
+          return
+        end
+
+        info "Could not reach Azure (#{exception.message}) #{message}"
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,9 @@ SimpleCov.start do
   # Only enforce the floor on a full-suite run; running a single spec file
   # legitimately covers far less than the whole driver.
   # The only uncovered branches are the `require "x" unless defined?(X)` guards
-  # at the top of the driver, which cannot both be taken in one process.
-  minimum_coverage(line: 100, branch: 95) if ARGV.grep(/_spec\.rb/).empty?
+  # at the top of each file, which cannot both be taken in one process. There
+  # are 16 of them, so 92% is the practical ceiling.
+  minimum_coverage(line: 100, branch: 92) if ARGV.grep(/_spec\.rb/).empty?
 end
 
 require "stringio"
@@ -29,11 +30,6 @@ require "webmock/rspec"
 
 require "kitchen"
 require "kitchen/transport/dummy"
-
-require "ms_rest2"
-require "ms_rest_azure2"
-require "azure_mgmt_resources2"
-require "azure_mgmt_network2"
 
 require_relative "../lib/kitchen/driver/azurerm"
 

--- a/spec/support/azure_doubles.rb
+++ b/spec/support/azure_doubles.rb
@@ -1,142 +1,112 @@
-# Doubles and real SDK model objects standing in for the Azure Resource Manager
-# and Network management APIs.
+# Doubles and fixtures standing in for Azure Resource Manager responses.
 #
-# Where the SDK ships a plain model class (deployment operations, resource
-# groups) these helpers build the real object, so the driver is exercised
-# against the same attribute names Azure actually returns. Only the operation
-# groups that would perform HTTP are doubled.
+# The driver now talks to ARM over plain HTTP, so responses are ordinary parsed
+# JSON. These helpers build that JSON in ARM's own shape - camelCase, nested
+# under "properties" - so a spec that passes here is asserting against the
+# structure Azure actually returns.
 module AzureDoubles
-  RESOURCES = Azure::Resources2::Profiles::Latest::Mgmt
-  NETWORK = Azure::Network2::Profiles::Latest::Mgmt
-
-  # A doubled resource management client.
+  # A doubled ARM client.
   #
-  # @param resource_groups [Object] stand-in for the resource groups operations.
-  # @param deployments [Object] stand-in for the deployments operations.
-  # @param deployment_operations [Object] stand-in for the deployment operations.
+  # @param overrides [Hash] method name to return value.
   # @return [RSpec::Mocks::InstanceVerifyingDouble]
-  def resource_client_double(resource_groups: resource_groups_double,
-    deployments: deployments_double,
-    deployment_operations: deployment_operations_double)
-    instance_double(RESOURCES::Client, resource_groups:, deployments:, deployment_operations:)
+  def arm_client_double(**overrides)
+    defaults = {
+      resource_group_exists?: true,
+      create_or_update_resource_group: { "id" => "/subscriptions/s/resourcegroups/rg" },
+      delete_resource_group: nil,
+      create_deployment: { "id" => "/deployments/d" },
+      deployment: deployment_response("Succeeded"),
+      deployment_operations: [],
+      public_ip: public_ip_response,
+      network_interface: network_interface_response,
+    }
+    instance_double(Kitchen::Driver::Azure::ArmClient, **defaults.merge(overrides))
   end
 
-  # @param exists [Boolean] what +check_existence+ reports.
-  # @return [RSpec::Mocks::InstanceVerifyingDouble]
-  def resource_groups_double(exists: true)
-    instance_double(RESOURCES::ResourceGroups, check_existence: exists, create_or_update: nil, begin_delete: nil)
-  end
-
-  # @param provisioning_state [String] the state reported by +get+.
-  # @return [RSpec::Mocks::InstanceVerifyingDouble]
-  def deployments_double(provisioning_state: "Succeeded")
-    instance_double(
-      RESOURCES::Deployments,
-      begin_create_or_update_async: accepted_request,
-      get: deployment_extended(provisioning_state)
-    )
-  end
-
-  # @param operations [Array] deployment operations returned by +list+.
-  # @return [RSpec::Mocks::InstanceVerifyingDouble]
-  def deployment_operations_double(operations: [])
-    instance_double(RESOURCES::DeploymentOperations, list: operations)
-  end
-
-  # The value returned by the SDK's +*_async+ methods: something answering
-  # +value!+ once the request has been accepted.
-  #
-  # @return [RSpec::Mocks::Double]
-  def accepted_request
-    double("MsRest::Promise", value!: nil)
-  end
-
-  # A real +DeploymentExtended+ carrying a provisioning state.
-  #
-  # @param provisioning_state [String]
-  # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentExtended]
-  def deployment_extended(provisioning_state)
-    deployment = RESOURCES::Models::DeploymentExtended.new
-    deployment.properties = RESOURCES::Models::DeploymentPropertiesExtended.new
-    deployment.properties.provisioning_state = provisioning_state
-    deployment
-  end
-
-  # A real +DeploymentOperation+.
+  # An ARM deployment response.
   #
   # @param provisioning_state [String] e.g. +"Running"+ or +"Succeeded"+.
+  # @return [Hash]
+  def deployment_response(provisioning_state)
+    { "properties" => { "provisioningState" => provisioning_state } }
+  end
+
+  # One entry from a deployment's operations list.
+  #
+  # @param provisioning_state [String]
   # @param status_code [String] e.g. +"OK"+ or +"Conflict"+.
   # @param status_message [String, nil] Azure's failure detail.
-  # @param resource_name [String, nil] name of the resource being operated on.
-  # @param resource_type [String, nil] type of the resource being operated on.
-  # @return [Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentOperation]
+  # @param resource_name [String, nil]
+  # @param resource_type [String, nil]
+  # @return [Hash]
   def deployment_operation(provisioning_state: "Succeeded", status_code: "OK", status_message: nil,
     resource_name: nil, resource_type: nil)
-    operation = RESOURCES::Models::DeploymentOperation.new
-    operation.properties = RESOURCES::Models::DeploymentOperationProperties.new
-    operation.properties.provisioning_state = provisioning_state
-    operation.properties.status_code = status_code
-    operation.properties.status_message = status_message
+    properties = {
+      "provisioningState" => provisioning_state,
+      "statusCode" => status_code,
+      "statusMessage" => status_message,
+    }
 
     if resource_name || resource_type
-      operation.properties.target_resource = RESOURCES::Models::TargetResource.new
-      operation.properties.target_resource.resource_name = resource_name
-      operation.properties.target_resource.resource_type = resource_type
+      properties["targetResource"] = { "resourceName" => resource_name, "resourceType" => resource_type }
     end
 
-    operation
+    { "properties" => properties }
   end
 
-  # A doubled network management client.
+  # A public IP address resource.
   #
-  # @param public_ipaddresses [Object] stand-in for the public IP operations.
-  # @return [RSpec::Mocks::InstanceVerifyingDouble]
-  def network_client_double(public_ipaddresses: public_ip_addresses_double)
-    instance_double(NETWORK::Client, public_ipaddresses:)
-  end
-
-  # @param ip_address [String] the address reported by +get+.
-  # @param fqdn [String] the DNS name reported by +get+.
-  # @return [RSpec::Mocks::InstanceVerifyingDouble]
-  def public_ip_addresses_double(ip_address: "40.121.0.1", fqdn: "kitchen-abc.eastus2.cloudapp.azure.com")
-    instance_double(NETWORK::PublicIPAddresses, get: public_ip(ip_address:, fqdn:))
-  end
-
   # @param ip_address [String]
   # @param fqdn [String]
-  # @return [RSpec::Mocks::Double]
-  def public_ip(ip_address: "40.121.0.1", fqdn: "kitchen-abc.eastus2.cloudapp.azure.com")
-    double("PublicIPAddress", ip_address:, dns_settings: double("PublicIPAddressDnsSettings", fqdn:))
+  # @return [Hash]
+  def public_ip_response(ip_address: "40.121.0.1", fqdn: "kitchen-abc.eastus2.cloudapp.azure.com")
+    {
+      "name" => "publicip",
+      "properties" => {
+        "ipAddress" => ip_address,
+        "dnsSettings" => { "fqdn" => fqdn },
+      },
+    }
   end
 
-  # @param private_ip [String] the address of the NIC's first IP configuration.
-  # @return [RSpec::Mocks::Double]
-  def network_interface(private_ip: "10.0.0.4")
-    double("NetworkInterface", ip_configurations: [double("IPConfiguration", private_ipaddress: private_ip)])
+  # A network interface resource.
+  #
+  # @param private_ip [String]
+  # @return [Hash]
+  def network_interface_response(private_ip: "10.0.0.4")
+    {
+      "name" => "nic",
+      "properties" => {
+        "ipConfigurations" => [
+          { "properties" => { "privateIPAddress" => private_ip } },
+        ],
+      },
+    }
   end
 
-  # An +MsRestAzure2::AzureOperationError+ carrying an Azure error body.
+  # An ARM error.
   #
   # @param code [String] the Azure error code, e.g. +"DeploymentActive"+.
-  # @param message [String] the Azure error message.
-  # @return [MsRestAzure2::AzureOperationError]
-  def azure_operation_error(code:, message: "something went wrong")
-    error = MsRestAzure2::AzureOperationError.new("Azure operation failed")
-    error.body = { "error" => { "code" => code, "message" => message } }
-    error
+  # @param message [String]
+  # @param status [Integer] HTTP status.
+  # @return [Kitchen::Driver::Azure::OperationError]
+  def azure_operation_error(code:, message: "something went wrong", status: 409)
+    Kitchen::Driver::Azure::OperationError.new(
+      "Azure returned HTTP #{status}",
+      status:,
+      body: { "error" => { "code" => code, "message" => message } }
+    )
   end
 
-  # Wires a driver up so that every Azure client it constructs is a double.
+  # Wires a driver up so the ARM client it builds is a double.
   #
   # @param driver [Kitchen::Driver::Azurerm]
-  # @param resource_client [Object]
-  # @param network_client [Object]
-  # @return [void]
-  def stub_azure_clients(driver, resource_client: resource_client_double, network_client: network_client_double)
-    allow(RESOURCES::Client).to receive(:new).and_return(resource_client)
-    allow(NETWORK::Client).to receive(:new).and_return(network_client)
+  # @param arm_client [Object]
+  # @return [Object] the client the driver will use.
+  def stub_arm_client(driver, arm_client: arm_client_double)
     allow(Kitchen::Driver::AzureCredentials).to receive(:new).and_return(
-      instance_double(Kitchen::Driver::AzureCredentials, azure_options: { subscription_id: driver_config(driver)[:subscription_id] })
+      instance_double(Kitchen::Driver::AzureCredentials, arm_client:)
     )
+    arm_client
   end
 end

--- a/spec/unit/kitchen/driver/azure/arm_client_spec.rb
+++ b/spec/unit/kitchen/driver/azure/arm_client_spec.rb
@@ -1,0 +1,188 @@
+RSpec.describe Kitchen::Driver::Azure::ArmClient do
+  subject(:client) do
+    described_class.new(subscription_id:, environment:, token_provider: token_provider_double)
+  end
+
+  let(:subscription_id) { "115b12cb-b0d3-4ed9-94db-f73733be6f3c" }
+  let(:environment) { Kitchen::Driver::Azure::Environments.fetch("Azure") }
+  let(:base) { "https://management.azure.com/subscriptions/#{subscription_id}" }
+  let(:resources_version) { described_class::RESOURCES_API_VERSION }
+  let(:network_version) { described_class::NETWORK_API_VERSION }
+
+  def token_provider_double
+    instance_double(Kitchen::Driver::Azure::TokenProvider, authorization_header: "Bearer a-token")
+  end
+
+  describe "request framing" do
+    it "authenticates every request" do
+      stub = stub_request(:get, "#{base}/resourcegroups/rg/providers/Microsoft.Resources/deployments/d")
+        .with(query: { "api-version" => resources_version }, headers: { "Authorization" => "Bearer a-token" })
+        .to_return(status: 200, body: "{}")
+
+      client.deployment("rg", "d")
+      expect(stub).to have_been_requested
+    end
+
+    it "identifies itself" do
+      stub = stub_request(:get, %r{/deployments/d})
+        .with(headers: { "User-Agent" => "kitchen-azurerm/#{Kitchen::Driver::AZURERM_VERSION}" })
+        .to_return(status: 200, body: "{}")
+
+      client.deployment("rg", "d")
+      expect(stub).to have_been_requested
+    end
+
+    it "escapes names that need it" do
+      stub = stub_request(:head, "#{base}/resourcegroups/my%20group")
+        .with(query: hash_including({}))
+        .to_return(status: 204)
+
+      client.resource_group_exists?("my group")
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#resource_group_exists?" do
+    it "is true for a 204" do
+      stub_request(:head, "#{base}/resourcegroups/rg").with(query: hash_including({})).to_return(status: 204)
+      expect(client.resource_group_exists?("rg")).to be true
+    end
+
+    # A 404 is the API's way of saying "no", not a failure.
+    it "is false for a 404" do
+      stub_request(:head, "#{base}/resourcegroups/rg").with(query: hash_including({})).to_return(status: 404)
+      expect(client.resource_group_exists?("rg")).to be false
+    end
+
+    it "raises for anything else" do
+      stub_request(:head, "#{base}/resourcegroups/rg").with(query: hash_including({})).to_return(status: 403)
+      expect { client.resource_group_exists?("rg") }.to raise_error(Kitchen::Driver::Azure::OperationError)
+    end
+  end
+
+  describe "#create_or_update_resource_group" do
+    it "PUTs the location and tags" do
+      stub = stub_request(:put, "#{base}/resourcegroups/rg")
+        .with(query: hash_including({}),
+          body: { "location" => "eastus2", "tags" => { "owner" => "platform" } },
+          headers: { "Content-Type" => "application/json" })
+        .to_return(status: 200, body: '{"id":"/subscriptions/s/resourcegroups/rg"}')
+
+      result = client.create_or_update_resource_group("rg", location: "eastus2", tags: { "owner" => "platform" })
+      expect(stub).to have_been_requested
+      expect(result["id"]).to eq("/subscriptions/s/resourcegroups/rg")
+    end
+
+    it "sends an empty tag object when given none" do
+      stub = stub_request(:put, "#{base}/resourcegroups/rg")
+        .with(query: hash_including({}), body: { "location" => "eastus2", "tags" => {} })
+        .to_return(status: 200, body: "{}")
+
+      client.create_or_update_resource_group("rg", location: "eastus2", tags: nil)
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#delete_resource_group" do
+    it "DELETEs and returns without waiting" do
+      stub = stub_request(:delete, "#{base}/resourcegroups/rg").with(query: hash_including({})).to_return(status: 202)
+      expect(client.delete_resource_group("rg")).to be_nil
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#create_deployment" do
+    it "PUTs the deployment body" do
+      body = { "properties" => { "mode" => "Incremental", "template" => { "resources" => [] } } }
+      stub = stub_request(:put, "#{base}/resourcegroups/rg/providers/Microsoft.Resources/deployments/deploy-1")
+        .with(query: { "api-version" => resources_version }, body:)
+        .to_return(status: 201, body: '{"id":"/deployments/deploy-1"}')
+
+      client.create_deployment("rg", "deploy-1", body)
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe "#deployment_operations" do
+    it "unwraps the value array" do
+      stub_request(:get, "#{base}/resourcegroups/rg/providers/Microsoft.Resources/deployments/d/operations")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: '{"value":[{"properties":{"statusCode":"OK"}}]}')
+
+      expect(client.deployment_operations("rg", "d")).to eq([{ "properties" => { "statusCode" => "OK" } }])
+    end
+
+    it "is an empty array when ARM returns no value key" do
+      stub_request(:get, %r{/operations}).to_return(status: 200, body: "{}")
+      expect(client.deployment_operations("rg", "d")).to eq([])
+    end
+
+    it "is an empty array when ARM returns something that is not an object" do
+      stub_request(:get, %r{/operations}).to_return(status: 200, body: "[]")
+      expect(client.deployment_operations("rg", "d")).to eq([])
+    end
+  end
+
+  describe "network resources" do
+    it "reads a public IP with the network API version" do
+      stub = stub_request(:get, "#{base}/resourcegroups/rg/providers/Microsoft.Network/publicIPAddresses/publicip")
+        .with(query: { "api-version" => network_version })
+        .to_return(status: 200, body: '{"properties":{"ipAddress":"40.121.0.1"}}')
+
+      expect(client.public_ip("rg", "publicip").dig("properties", "ipAddress")).to eq("40.121.0.1")
+      expect(stub).to have_been_requested
+    end
+
+    it "reads a network interface" do
+      stub_request(:get, "#{base}/resourcegroups/rg/providers/Microsoft.Network/networkInterfaces/nic-1")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: '{"name":"nic-1"}')
+
+      expect(client.network_interface("rg", "nic-1")["name"]).to eq("nic-1")
+    end
+  end
+
+  describe "error handling" do
+    it "surfaces the Azure error code" do
+      stub_request(:put, %r{/deployments/d}).to_return(
+        status: 409,
+        body: '{"error":{"code":"DeploymentActive","message":"already running"}}'
+      )
+
+      expect { client.create_deployment("rg", "d", {}) }
+        .to raise_error(Kitchen::Driver::Azure::OperationError) { |e|
+          expect(e.code).to eq("DeploymentActive")
+          expect(e.status).to eq(409)
+          expect(e.body.dig("error", "message")).to eq("already running")
+        }
+    end
+
+    it "synthesizes a body when Azure returns something unparseable" do
+      stub_request(:get, %r{/deployments/d}).to_return(status: 500, body: "<html>gateway blew up</html>")
+
+      expect { client.deployment("rg", "d") }
+        .to raise_error(Kitchen::Driver::Azure::OperationError) { |e|
+          expect(e.code).to eq("Unknown")
+          expect(e.body.dig("error", "message")).to include("gateway blew up")
+        }
+    end
+
+    it "names the operation that failed" do
+      stub_request(:delete, %r{/resourcegroups/rg}).to_return(status: 403, body: "{}")
+      expect { client.delete_resource_group("rg") }.to raise_error(/HTTP 403 for DELETE/)
+    end
+  end
+
+  describe "sovereign clouds" do
+    let(:environment) { Kitchen::Driver::Azure::Environments.fetch("AzureUSGovernment") }
+
+    it "targets that cloud's resource manager" do
+      stub = stub_request(:get, "https://management.usgovcloudapi.net/subscriptions/#{subscription_id}/resourcegroups/rg/providers/Microsoft.Resources/deployments/d")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: "{}")
+
+      client.deployment("rg", "d")
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azure/environments_spec.rb
+++ b/spec/unit/kitchen/driver/azure/environments_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe Kitchen::Driver::Azure::Environments do
+  describe ".fetch" do
+    it "resolves a cloud by name" do
+      expect(described_class.fetch("AzureChina").name).to eq("AzureChina")
+    end
+
+    it "is case-insensitive" do
+      expect(described_class.fetch("azureusgovernment").name).to eq("AzureUSGovernment")
+    end
+
+    it "rejects an unknown cloud with the valid values" do
+      expect { described_class.fetch("AzureAtlantis") }
+        .to raise_error(Kitchen::UserError, /Unknown azure_environment 'AzureAtlantis'.*Azure, AzureUSGovernment, AzureChina, AzureGermanCloud/m)
+    end
+  end
+
+  describe ".names" do
+    it "lists every supported cloud" do
+      expect(described_class.names).to contain_exactly("Azure", "AzureUSGovernment", "AzureChina", "AzureGermanCloud")
+    end
+  end
+
+  describe "#token_url" do
+    it "joins the authentication endpoint, tenant and oauth2 path" do
+      expect(described_class.fetch("Azure").token_url("a-tenant"))
+        .to eq("https://login.microsoftonline.com/a-tenant/oauth2/token")
+    end
+
+    it "does not double up the separator" do
+      expect(described_class.fetch("AzureChina").token_url("t")).not_to include("//t")
+    end
+  end
+
+  it "freezes the table so a caller cannot mutate shared endpoints" do
+    expect(described_class::ALL).to be_frozen
+  end
+end

--- a/spec/unit/kitchen/driver/azure/errors_spec.rb
+++ b/spec/unit/kitchen/driver/azure/errors_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Kitchen::Driver::Azure::OperationError do
+  subject(:error) do
+    described_class.new("boom", status: 409, body: { "error" => { "code" => "DeploymentActive", "message" => "busy" } })
+  end
+
+  it "carries the message" do
+    expect(error.message).to eq("boom")
+  end
+
+  it "carries the HTTP status" do
+    expect(error.status).to eq(409)
+  end
+
+  it "exposes the Azure error code" do
+    expect(error.code).to eq("DeploymentActive")
+  end
+
+  it "exposes the raw body" do
+    expect(error.body.dig("error", "message")).to eq("busy")
+  end
+
+  it "has no code when Azure sent no error object" do
+    expect(described_class.new("boom").code).to be_nil
+  end
+
+  it "defaults the body to an empty Hash" do
+    expect(described_class.new("boom").body).to eq({})
+  end
+
+  it "has no code when the body is not a Hash" do
+    expect(described_class.new("boom", body: "plain text").code).to be_nil
+  end
+
+  # These classes live inside `module Kitchen`, where Test Kitchen already
+  # defines `Kitchen::StandardError`. A bare `StandardError` in this namespace
+  # resolves to that instead of ::StandardError, which silently breaks both
+  # `rescue StandardError` and any `rescue => e` expectations callers have.
+  describe "constant resolution" do
+    [described_class, Kitchen::Driver::Azure::TransientError].each do |klass|
+      it "#{klass} descends from ::StandardError, not Kitchen::StandardError" do
+        expect(klass.superclass).to eq(::StandardError)
+      end
+
+      it "#{klass} is caught by a bare rescue" do
+        caught = begin
+          raise klass, "boom"
+                 rescue => e
+                   e
+        end
+
+        expect(caught).to be_a(klass)
+      end
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azure/http_spec.rb
+++ b/spec/unit/kitchen/driver/azure/http_spec.rb
@@ -1,0 +1,102 @@
+RSpec.describe Kitchen::Driver::Azure::Http do
+  let(:url) { "https://example.invalid/thing" }
+
+  describe ".request" do
+    it "returns the status and body" do
+      stub_request(:get, url).to_return(status: 200, body: "hello")
+
+      response = described_class.request(method: :get, url:)
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("hello")
+    end
+
+    it "sends the headers it is given" do
+      stub = stub_request(:get, url).with(headers: { "Authorization" => "Bearer t" }).to_return(status: 200)
+      described_class.request(method: :get, url:, headers: { "Authorization" => "Bearer t" })
+      expect(stub).to have_been_requested
+    end
+
+    it "sends a body when given one" do
+      stub = stub_request(:put, url).with(body: "payload").to_return(status: 200)
+      described_class.request(method: :put, url:, body: "payload")
+      expect(stub).to have_been_requested
+    end
+
+    %i{get head put post delete}.each do |verb|
+      it "supports #{verb.upcase}" do
+        stub_request(verb, url).to_return(status: 200)
+        expect(described_class.request(method: verb, url:).status).to eq(200)
+      end
+    end
+
+    it "rejects an unsupported method rather than guessing" do
+      expect { described_class.request(method: :patch, url:) }
+        .to raise_error(ArgumentError, /Unsupported HTTP method/)
+    end
+
+    # Network blips must be distinguishable from real Azure responses so the
+    # driver knows which are worth retrying.
+    {
+      "a connection timeout" => Net::OpenTimeout,
+      "a read timeout" => Net::ReadTimeout,
+      "a connection reset" => Errno::ECONNRESET,
+      "a refused connection" => Errno::ECONNREFUSED,
+      "a DNS failure" => SocketError,
+      "a TLS failure" => OpenSSL::SSL::SSLError,
+    }.each do |description, error_class|
+      it "reports #{description} as transient" do
+        stub_request(:get, url).to_raise(error_class)
+
+        expect { described_class.request(method: :get, url:) }
+          .to raise_error(Kitchen::Driver::Azure::TransientError, /#{error_class}/)
+      end
+    end
+
+    # Corporate networks routinely put a proxy in front of Azure.
+    it "routes through the proxy named by the environment" do
+      ENV["https_proxy"] = "http://proxy.invalid:8080"
+      expect(Net::HTTP).to receive(:new)
+        .with("example.invalid", 443, "proxy.invalid", 8080, nil, nil)
+        .and_call_original
+
+      stub_request(:get, url).to_return(status: 200)
+      described_class.request(method: :get, url:)
+    end
+
+    it "connects directly when the host is excluded from proxying" do
+      ENV["https_proxy"] = "http://proxy.invalid:8080"
+      ENV["no_proxy"] = "example.invalid"
+      expect(Net::HTTP).to receive(:new).with("example.invalid", 443).and_call_original
+
+      stub_request(:get, url).to_return(status: 200)
+      described_class.request(method: :get, url:)
+    end
+
+    it "does not treat an HTTP error status as transient" do
+      stub_request(:get, url).to_return(status: 500, body: "server error")
+      expect(described_class.request(method: :get, url:).status).to eq(500)
+    end
+  end
+
+  describe Kitchen::Driver::Azure::Http::Response do
+    it "is successful for 2xx" do
+      expect(described_class.new(204, "")).to be_success
+    end
+
+    it "is not successful for 4xx" do
+      expect(described_class.new(404, "")).not_to be_success
+    end
+
+    it "parses a JSON body" do
+      expect(described_class.new(200, '{"a":1}').json).to eq("a" => 1)
+    end
+
+    it "is nil for an empty body" do
+      expect(described_class.new(204, "").json).to be_nil
+    end
+
+    it "is nil rather than raising for a non-JSON body" do
+      expect(described_class.new(500, "<html>nope</html>").json).to be_nil
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azure/token_provider_spec.rb
+++ b/spec/unit/kitchen/driver/azure/token_provider_spec.rb
@@ -1,0 +1,191 @@
+RSpec.describe "Azure token providers" do
+  let(:environment) { Kitchen::Driver::Azure::Environments.fetch("Azure") }
+
+  describe Kitchen::Driver::Azure::TokenProvider do
+    it "is abstract - a subclass must say how to fetch a token" do
+      expect { described_class.new(environment:).access_token }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe Kitchen::Driver::Azure::ServicePrincipalToken do
+    subject(:provider) do
+      described_class.new(environment:, tenant_id: "a-tenant", client_id: "a-client", client_secret: "a-secret")
+    end
+
+    let(:token_url) { "https://login.microsoftonline.com/a-tenant/oauth2/token" }
+
+    it "posts a client_credentials grant for the ARM audience" do
+      stub = stub_request(:post, token_url)
+        .with(body: {
+                "grant_type" => "client_credentials",
+                "client_id" => "a-client",
+                "client_secret" => "a-secret",
+                "resource" => "https://management.core.windows.net/",
+              })
+        .to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+
+      expect(provider.access_token).to eq("tok")
+      expect(stub).to have_been_requested
+    end
+
+    it "formats an Authorization header" do
+      stub_request(:post, token_url).to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+      expect(provider.authorization_header).to eq("Bearer tok")
+    end
+
+    it "caches the token rather than fetching per request" do
+      stub = stub_request(:post, token_url).to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+
+      3.times { provider.access_token }
+      expect(stub).to have_been_requested.once
+    end
+
+    # A long deployment must not fail because the token aged out mid-flight.
+    it "refetches once the cached token is near expiry" do
+      stub = stub_request(:post, token_url)
+        .to_return({ status: 200, body: '{"access_token":"first","expires_in":"60"}' },
+          { status: 200, body: '{"access_token":"second","expires_in":"3599"}' })
+
+      expect(provider.access_token).to eq("first")
+      expect(provider.access_token).to eq("second")
+      expect(stub).to have_been_requested.twice
+    end
+
+    it "honours an absolute expires_on" do
+      stub_request(:post, token_url)
+        .to_return(status: 200, body: %({"access_token":"tok","expires_on":"#{Time.now.to_i + 3600}"}))
+
+      expect(provider.access_token).to eq("tok")
+    end
+
+    it "raises with the status when the endpoint rejects the credentials" do
+      stub_request(:post, token_url).to_return(status: 401, body: '{"error":"invalid_client"}')
+
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError, /service principal token endpoint \(HTTP 401\)/)
+    end
+
+    it "raises when the response carries no token" do
+      stub_request(:post, token_url).to_return(status: 200, body: "{}")
+      expect { provider.access_token }.to raise_error(Kitchen::Driver::Azure::OperationError)
+    end
+
+    it "raises when the response is not an object at all" do
+      stub_request(:post, token_url).to_return(status: 200, body: "[]")
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError) { |e| expect(e.body).to eq({}) }
+    end
+
+    context "in a sovereign cloud" do
+      let(:environment) { Kitchen::Driver::Azure::Environments.fetch("AzureChina") }
+
+      it "authenticates against that cloud's endpoint and audience" do
+        stub = stub_request(:post, "https://login.chinacloudapi.cn/a-tenant/oauth2/token")
+          .with(body: hash_including("resource" => "https://management.core.chinacloudapi.cn/"))
+          .to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+
+        provider.access_token
+        expect(stub).to have_been_requested
+      end
+    end
+  end
+
+  describe Kitchen::Driver::Azure::ManagedIdentityToken do
+    subject(:provider) { described_class.new(environment:) }
+
+    let(:imds) { "http://169.254.169.254/metadata/identity/oauth2/token" }
+
+    # The old SDK used the legacy MSI extension endpoint on port 50342; IMDS is
+    # the supported endpoint on modern Azure VMs.
+    it "asks the instance metadata service" do
+      stub = stub_request(:get, imds)
+        .with(query: { "api-version" => "2018-02-01", "resource" => "https://management.core.windows.net/" },
+          headers: { "Metadata" => "true" })
+        .to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+
+      expect(provider.access_token).to eq("tok")
+      expect(stub).to have_been_requested
+    end
+
+    it "sends no client_id for a system-assigned identity" do
+      stub_request(:get, imds).with(query: hash_excluding("client_id")).to_return(status: 200, body: '{"access_token":"tok"}')
+      expect(provider.access_token).to eq("tok")
+    end
+
+    context "with a user-assigned identity" do
+      subject(:provider) { described_class.new(environment:, client_id: "an-identity") }
+
+      it "names the identity" do
+        stub = stub_request(:get, imds)
+          .with(query: hash_including("client_id" => "an-identity"))
+          .to_return(status: 200, body: '{"access_token":"tok"}')
+
+        provider.access_token
+        expect(stub).to have_been_requested
+      end
+    end
+
+    it "raises when there is no metadata service to talk to" do
+      stub_request(:get, imds).with(query: hash_including({})).to_return(status: 400, body: '{"error":"invalid_request"}')
+      expect { provider.access_token }.to raise_error(Kitchen::Driver::Azure::OperationError, /instance metadata service/)
+    end
+  end
+
+  describe Kitchen::Driver::Azure::AzureCliToken do
+    subject(:provider) { described_class.new(environment:) }
+
+    let(:success) { instance_double(Process::Status, success?: true) }
+    let(:failure) { instance_double(Process::Status, success?: false) }
+
+    it "shells out for the ARM audience" do
+      expect(Open3).to receive(:capture3).with(
+        "az", "account", "get-access-token",
+        "--resource", "https://management.core.windows.net/",
+        "--output", "json"
+      ).and_return(['{"accessToken":"tok","expiresOn":"2099-01-01 00:00:00.000000"}', "", success])
+
+      expect(provider.access_token).to eq("tok")
+    end
+
+    it "caches the result rather than shelling out per request" do
+      allow(Open3).to receive(:capture3)
+        .and_return(['{"accessToken":"tok","expiresOn":"2099-01-01 00:00:00.000000"}', "", success])
+
+      3.times { provider.access_token }
+      expect(Open3).to have_received(:capture3).once
+    end
+
+    it "tells the user to sign in when the CLI is not signed in" do
+      allow(Open3).to receive(:capture3).and_return(["", "Please run 'az login'", failure])
+
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError, /Run `az login` first/)
+    end
+
+    it "explains when the CLI is not installed" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError, /was not found on PATH/)
+    end
+
+    it "reports an unparseable response rather than crashing" do
+      allow(Open3).to receive(:capture3).and_return(["not json", "", success])
+
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError, /Could not understand the response/)
+    end
+
+    it "honours a numeric expires_on from the CLI" do
+      allow(Open3).to receive(:capture3)
+        .and_return([%({"accessToken":"tok","expires_on":#{Time.now.to_i + 3600}}), "", success])
+
+      expect(provider.access_token).to eq("tok")
+    end
+
+    it "falls back to a one hour lifetime when the expiry makes no sense" do
+      allow(Open3).to receive(:capture3).and_return(['{"accessToken":"tok","expiresOn":"nonsense"}', "", success])
+      expect(provider.access_token).to eq("tok")
+    end
+  end
+end

--- a/spec/unit/kitchen/driver/azure_credentials_spec.rb
+++ b/spec/unit/kitchen/driver/azure_credentials_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
 
     it "rejects an unknown environment with an actionable message" do
       expect { described_class.new(subscription_id:, environment: "AzureAtlantis") }
-        .to raise_error(Kitchen::UserError, /Unknown azure_environment 'AzureAtlantis'.*azure, azurechina/m)
+        .to raise_error(Kitchen::UserError, /Unknown azure_environment 'AzureAtlantis'.*Azure, AzureUSGovernment, AzureChina, AzureGermanCloud/m)
     end
 
     it "accepts a known environment in any case" do
@@ -59,28 +59,23 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
     end
   end
 
-  describe "#azure_options" do
-    subject(:options) { credentials.azure_options }
+  describe "credential resolution" do
+    subject(:provider) { credentials.token_provider }
 
     context "with no credentials file and no environment variables" do
       it "logs which path it looked in" do
         expect(Kitchen.logger).to receive(:debug).with(/#{Regexp.escape(described_class.default_config_path)} was not found/)
-        options
+        provider
       end
 
       it "warns that it is falling back to the Azure CLI" do
         allow(Kitchen.logger).to receive(:warn)
-        options
+        provider
         expect(Kitchen.logger).to have_received(:warn).with("Using tenant id set through `az login`.")
       end
 
       it "falls back to the Azure CLI token provider" do
-        expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::AzureCliTokenProvider)
-      end
-
-      it "omits client_id and client_secret" do
-        expect(options).not_to have_key(:client_id)
-        expect(options).not_to have_key(:client_secret)
+        expect(provider).to be_an_instance_of(Kitchen::Driver::Azure::AzureCliToken)
       end
     end
 
@@ -88,18 +83,27 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
       before { use_default_location_credentials_file }
 
       it "resolves the tenant id from the matching subscription section" do
-        expect(options[:tenant_id]).to eq("19d3ea3e-ea8f-48f3-9f7a-00ae2810991f")
+        expect(tenant_id_of(provider)).to eq("19d3ea3e-ea8f-48f3-9f7a-00ae2810991f")
       end
 
       it "does not read another subscription's section" do
         other = described_class.new(subscription_id: CredentialsFileHelper::SUBSCRIPTIONS[:user_assigned_identity])
-        expect(other.azure_options[:tenant_id]).to eq("1ba5986d-52e1-49eb-a77e-155b7440695f")
+        expect(other.token_provider).to be_an_instance_of(Kitchen::Driver::Azure::ManagedIdentityToken)
+      end
+
+      it "warns only once about a missing tenant id, however often it is asked" do
+        unknown = described_class.new(subscription_id: "00000000-0000-0000-0000-000000000000")
+        allow(Kitchen.logger).to receive(:warn)
+
+        3.times { unknown.send(:tenant_id!) }
+
+        expect(Kitchen.logger).to have_received(:warn).with(/does not contain tenant_id/).once
       end
 
       it "warns when the subscription has no section at all" do
         unknown = described_class.new(subscription_id: "00000000-0000-0000-0000-000000000000")
         allow(Kitchen.logger).to receive(:warn)
-        unknown.azure_options
+        unknown.token_provider
         expect(Kitchen.logger).to have_received(:warn).with(/does not contain tenant_id/)
       end
     end
@@ -110,16 +114,19 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
         use_credentials_file(<<~INI)
           [#{subscription_id}]
           tenant_id = "overridden-tenant"
+          client_id = "overridden-client"
+          client_secret = "overridden-secret"
         INI
 
-        expect(options[:tenant_id]).to eq("overridden-tenant")
+        expect(tenant_id_of(provider)).to eq("overridden-tenant")
+        expect(client_id_of(provider)).to eq("overridden-client")
       end
     end
 
     context "when the credentials file is malformed" do
       it "surfaces the parse error rather than silently continuing" do
         use_credentials_file("this is not = valid [ini\n[[[")
-        expect { options }.to raise_error(IniFile::Error)
+        expect { provider }.to raise_error(IniFile::Error)
       end
     end
 
@@ -129,19 +136,22 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
       it "prefers environment variables over the credentials file" do
         set_env("AZURE_TENANT_ID" => "env-tenant", "AZURE_CLIENT_ID" => "env-client", "AZURE_CLIENT_SECRET" => "env-secret")
 
-        expect(options).to include(tenant_id: "env-tenant", client_id: "env-client", client_secret: "env-secret")
+        expect(provider).to be_an_instance_of(Kitchen::Driver::Azure::ServicePrincipalToken)
+        expect(tenant_id_of(provider)).to eq("env-tenant")
+        expect(client_id_of(provider)).to eq("env-client")
       end
 
       it "ignores environment variables that are exported but empty" do
         set_env("AZURE_CLIENT_SECRET" => "")
 
-        expect(options[:client_secret]).to eq(":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV[")
+        expect(secret_of(provider)).to eq(":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV[")
       end
 
       it "mixes environment and file values" do
         set_env("AZURE_TENANT_ID" => "env-tenant")
 
-        expect(options).to include(tenant_id: "env-tenant", client_id: "b5f3d6df-00bf-4451-a4f2-db3bc7731b58")
+        expect(tenant_id_of(provider)).to eq("env-tenant")
+        expect(client_id_of(provider)).to eq("b5f3d6df-00bf-4451-a4f2-db3bc7731b58")
       end
     end
 
@@ -152,17 +162,12 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
         let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:service_principal] }
 
         it "uses a service principal token provider" do
-          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::ApplicationTokenProvider)
+          expect(provider).to be_an_instance_of(Kitchen::Driver::Azure::ServicePrincipalToken)
         end
 
         it "passes the client id and secret through" do
-          provider = token_provider_for(options)
-          expect(provider.send(:client_id)).to eq("b5f3d6df-00bf-4451-a4f2-db3bc7731b58")
-          expect(provider.send(:client_secret)).to eq(":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV[")
-        end
-
-        it "includes both in the options hash" do
-          expect(options).to include(:client_id, :client_secret)
+          expect(client_id_of(provider)).to eq("b5f3d6df-00bf-4451-a4f2-db3bc7731b58")
+          expect(secret_of(provider)).to eq(":Qnt[7?:7RXzdMXrXE0ygBROA1hY1iV[")
         end
       end
 
@@ -170,17 +175,11 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
         let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:user_assigned_identity] }
 
         it "uses a managed identity token provider" do
-          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::MSITokenProvider)
+          expect(provider).to be_an_instance_of(Kitchen::Driver::Azure::ManagedIdentityToken)
         end
 
         it "binds the identity's client id" do
-          expect(token_provider_for(options).instance_variable_get(:@client_id))
-            .to eq("2801f9e6-c4c2-4667-a6e1-479f8827b0af")
-        end
-
-        it "omits client_secret from the options hash" do
-          expect(options).to include(:client_id)
-          expect(options).not_to have_key(:client_secret)
+          expect(client_id_of(provider)).to eq("2801f9e6-c4c2-4667-a6e1-479f8827b0af")
         end
       end
 
@@ -188,16 +187,11 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
         let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:system_assigned_identity] }
 
         it "uses a managed identity token provider" do
-          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::MSITokenProvider)
+          expect(provider).to be_an_instance_of(Kitchen::Driver::Azure::ManagedIdentityToken)
         end
 
         it "binds no client id" do
-          expect(token_provider_for(options).instance_variable_get(:@client_id)).to be_nil
-        end
-
-        it "omits both client_id and client_secret" do
-          expect(options).not_to have_key(:client_id)
-          expect(options).not_to have_key(:client_secret)
+          expect(client_id_of(provider)).to be_nil
         end
       end
 
@@ -205,39 +199,35 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
         let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:azure_cli] }
 
         it "falls back to the Azure CLI" do
-          expect(token_provider_for(options)).to be_an_instance_of(MsRestAzure2::AzureCliTokenProvider)
+          expect(provider).to be_an_instance_of(Kitchen::Driver::Azure::AzureCliToken)
         end
       end
     end
 
     describe "cloud endpoints" do
+      # rubocop:disable Layout/ExtraSpacing
       {
-        "Azure" => { base_url: "https://management.azure.com/",
+        "Azure" => { resource_manager_url: "https://management.azure.com/",
                      authentication_endpoint: "https://login.microsoftonline.com/",
                      token_audience: "https://management.core.windows.net/" },
-        "AzureUSGovernment" => { base_url: "https://management.usgovcloudapi.net",
+        "AzureUSGovernment" => { resource_manager_url: "https://management.usgovcloudapi.net",
                                  authentication_endpoint: "https://login.microsoftonline.us/",
                                  token_audience: "https://management.core.usgovcloudapi.net/" },
-        "AzureChina" => { base_url: "https://management.chinacloudapi.cn",
+        "AzureChina" => { resource_manager_url: "https://management.chinacloudapi.cn",
                           authentication_endpoint: "https://login.chinacloudapi.cn/",
                           token_audience: "https://management.core.chinacloudapi.cn/" },
-        "AzureGermanCloud" => { base_url: "https://management.microsoftazure.de",
+        "AzureGermanCloud" => { resource_manager_url: "https://management.microsoftazure.de",
                                 authentication_endpoint: "https://login.microsoftonline.de/",
                                 token_audience: "https://management.core.cloudapi.de/" },
       }.each do |cloud, expected|
+        # rubocop:enable Layout/ExtraSpacing
         context "for #{cloud}" do
           let(:environment) { cloud }
 
-          it "sets the resource manager base url" do
-            expect(options[:base_url]).to eq(expected[:base_url])
-          end
-
-          it "sets the authentication endpoint" do
-            expect(options[:active_directory_settings].authentication_endpoint).to eq(expected[:authentication_endpoint])
-          end
-
-          it "sets the token audience" do
-            expect(options[:active_directory_settings].token_audience).to eq(expected[:token_audience])
+          expected.each do |attribute, value|
+            it "sets the #{attribute}" do
+              expect(credentials.azure_environment.public_send(attribute)).to eq(value)
+            end
           end
         end
 
@@ -245,26 +235,32 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
           let(:environment) { cloud.downcase }
 
           it "resolves the same endpoints" do
-            expect(options[:base_url]).to eq(expected[:base_url])
+            expect(credentials.azure_environment.resource_manager_url).to eq(expected[:resource_manager_url])
           end
         end
       end
     end
 
-    it "wraps the token provider in MsRest2 credentials" do
-      expect(options[:credentials]).to be_an_instance_of(MsRest2::TokenCredentials)
-    end
-
-    it "carries the subscription id" do
-      expect(options[:subscription_id]).to eq(subscription_id)
+    it "builds an ARM client bound to the subscription" do
+      expect(credentials.arm_client.subscription_id).to eq(subscription_id)
     end
   end
 
-  # Digs the token provider out of the MsRest2 credentials wrapper.
-  #
-  # @param options [Hash] the result of {Kitchen::Driver::AzureCredentials#azure_options}.
-  # @return [Object] the token provider.
-  def token_provider_for(options)
-    options[:credentials].instance_variable_get(:@token_provider)
+  # @param provider [Kitchen::Driver::Azure::TokenProvider]
+  # @return [String, nil] the tenant it authenticates against.
+  def tenant_id_of(provider)
+    provider.instance_variable_get(:@tenant_id)
+  end
+
+  # @param provider [Kitchen::Driver::Azure::TokenProvider]
+  # @return [String, nil]
+  def client_id_of(provider)
+    provider.instance_variable_get(:@client_id)
+  end
+
+  # @param provider [Kitchen::Driver::Azure::TokenProvider]
+  # @return [String, nil]
+  def secret_of(provider)
+    provider.instance_variable_get(:@client_secret)
   end
 end

--- a/spec/unit/kitchen/driver/azurerm/api_retry_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/api_retry_spec.rb
@@ -2,12 +2,11 @@ RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
   subject(:driver) { build_driver(**config) }
 
   let(:config) { { azure_api_retries: 2 } }
-  let(:resource_client) { resource_client_double }
-  let(:network_client) { network_client_double }
+  let(:arm_client) { arm_client_double }
+  let(:transient) { Kitchen::Driver::Azure::TransientError.new("Net::ReadTimeout: timed out") }
 
   before do
-    driver.resource_management_client = resource_client
-    driver.network_management_client = network_client
+    driver.arm_client = arm_client
     allow(Kitchen.logger).to receive(:info)
   end
 
@@ -22,14 +21,14 @@ RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
       expect(calls).to eq(1)
     end
 
-    it "retries a timeout up to the configured budget, then gives up" do
+    it "retries a transient failure up to the configured budget, then gives up" do
       calls = 0
       expect do
         driver.send(:with_azure_retries, "doing a thing.") do
           calls += 1
-          raise Faraday::TimeoutError
+          raise transient
         end
-      end.to raise_error(Faraday::TimeoutError)
+      end.to raise_error(Kitchen::Driver::Azure::TransientError)
 
       # One initial attempt plus azure_api_retries retries.
       expect(calls).to eq(3)
@@ -39,7 +38,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
       calls = 0
       result = driver.send(:with_azure_retries, "doing a thing.") do
         calls += 1
-        raise Faraday::TimeoutError if calls < 2
+        raise transient if calls < 2
 
         :recovered
       end
@@ -48,16 +47,18 @@ RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
       expect(calls).to eq(2)
     end
 
-    it "retries connection resets too" do
+    # An HTTP error response from ARM is a real answer, not a connectivity
+    # blip, so retrying it would only delay the failure.
+    it "does not retry an Azure error response" do
       calls = 0
       expect do
         driver.send(:with_azure_retries, "doing a thing.") do
           calls += 1
-          raise Faraday::ClientError, "connection reset"
+          raise azure_operation_error(code: "InvalidTemplate")
         end
-      end.to raise_error(Faraday::ClientError)
+      end.to raise_error(Kitchen::Driver::Azure::OperationError)
 
-      expect(calls).to eq(3)
+      expect(calls).to eq(1)
     end
 
     it "does not swallow errors it cannot retry" do
@@ -72,27 +73,23 @@ RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
       expect do
         driver.send(:with_azure_retries, "doing a thing.") do
           calls += 1
-          raise Faraday::TimeoutError
+          raise transient
         end
-      end.to raise_error(Faraday::TimeoutError)
+      end.to raise_error(Kitchen::Driver::Azure::TransientError)
 
       expect(calls).to eq(1)
     end
 
-    it "logs a timeout with its cause and the remaining budget" do
-      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise Faraday::TimeoutError } }
-      expect(Kitchen.logger).to have_received(:info).with("Timed out while doing a thing. 2 retries left.")
+    it "logs the cause and the remaining budget" do
+      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise transient } }
+      expect(Kitchen.logger).to have_received(:info)
+        .with("Could not reach Azure (Net::ReadTimeout: timed out) while doing a thing. 2 retries left.")
     end
 
     it "counts down the remaining budget in the log" do
-      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise Faraday::TimeoutError } }
+      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise transient } }
       expect(Kitchen.logger).to have_received(:info).with(/1 retries left/)
       expect(Kitchen.logger).to have_received(:info).with(/0 retries left/)
-    end
-
-    it "logs a connection reset differently from a timeout" do
-      suppress_error { driver.send(:with_azure_retries, "while doing a thing.") { raise Faraday::ClientError, "reset" } }
-      expect(Kitchen.logger).to have_received(:info).with(/\AConnection reset by peer while doing a thing/).at_least(:once)
     end
   end
 
@@ -105,84 +102,61 @@ RSpec.describe Kitchen::Driver::Azurerm, "Azure API retries" do
 
   describe "the wrapped API calls" do
     {
-      resource_group_exists?: %w{check_existence},
-      create_resource_group: %w{create_or_update},
-      delete_resource_group_async: %w{begin_delete},
-    }.each do |method, (api_call)|
-      it "retries ##{method}" do
+      resource_group_exists?: :resource_group_exists?,
+      delete_resource_group_async: :delete_resource_group,
+      list_deployment_operations: :deployment_operations,
+      get_public_ip: :public_ip,
+      get_network_interface: :network_interface,
+    }.each do |driver_method, client_method|
+      it "retries ##{driver_method}" do
         calls = 0
-        allow(resource_client.resource_groups).to receive(api_call) do
+        allow(arm_client).to receive(client_method) do
           calls += 1
-          raise Faraday::TimeoutError if calls < 2
+          raise transient if calls < 2
 
           :ok
         end
 
-        expect(driver.send(method, *Array.new(driver.method(method).arity.abs, "arg"))).to eq(:ok)
+        arity = driver.method(driver_method).arity.abs
+        expect(driver.send(driver_method, *Array.new(arity, "arg"))).to eq(:ok)
         expect(calls).to eq(2)
       end
     end
 
-    it "retries #create_deployment_async" do
+    it "retries #create_resource_group" do
       calls = 0
-      allow(resource_client.deployments).to receive(:begin_create_or_update_async) do
+      allow(arm_client).to receive(:create_or_update_resource_group) do
         calls += 1
-        raise Faraday::TimeoutError if calls < 2
+        raise transient if calls < 2
 
         :ok
       end
 
-      expect(driver.send(:create_deployment_async, "rg", "deploy-1", :deployment)).to eq(:ok)
+      expect(driver.send(:create_resource_group, "rg", { location: "eastus2", tags: {} })).to eq(:ok)
     end
 
-    it "retries #list_deployment_operations" do
+    it "retries #create_deployment_async" do
       calls = 0
-      allow(resource_client.deployment_operations).to receive(:list) do
+      allow(arm_client).to receive(:create_deployment) do
         calls += 1
-        raise Faraday::ClientError, "reset" if calls < 2
+        raise transient if calls < 2
 
-        []
+        :ok
       end
 
-      expect(driver.send(:list_deployment_operations, "rg", "deploy-1")).to eq([])
+      expect(driver.send(:create_deployment_async, "rg", "deploy-1", {})).to eq(:ok)
     end
 
     it "retries #get_deployment_state and unwraps the provisioning state" do
       calls = 0
-      allow(resource_client.deployments).to receive(:get) do
+      allow(arm_client).to receive(:deployment) do
         calls += 1
-        raise Faraday::TimeoutError if calls < 2
+        raise transient if calls < 2
 
-        deployment_extended("Running")
+        deployment_response("Running")
       end
 
       expect(driver.send(:get_deployment_state, "rg", "deploy-1")).to eq("Running")
-    end
-
-    it "retries #get_public_ip" do
-      calls = 0
-      allow(network_client.public_ipaddresses).to receive(:get) do
-        calls += 1
-        raise Faraday::TimeoutError if calls < 2
-
-        public_ip(ip_address: "1.2.3.4")
-      end
-
-      expect(driver.send(:get_public_ip, "rg", "publicip").ip_address).to eq("1.2.3.4")
-    end
-
-    it "retries #get_network_interface" do
-      calls = 0
-      network_interfaces = instance_double(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces)
-      allow(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces).to receive(:new).and_return(network_interfaces)
-      allow(network_interfaces).to receive(:get) do
-        calls += 1
-        raise Faraday::TimeoutError if calls < 2
-
-        network_interface(private_ip: "10.0.0.9")
-      end
-
-      expect(driver.send(:get_network_interface, "rg", "nic-1").ip_configurations.first.private_ipaddress).to eq("10.0.0.9")
     end
   end
 

--- a/spec/unit/kitchen/driver/azurerm/create_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/create_spec.rb
@@ -4,15 +4,14 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
   let(:config) { {} }
   let(:transport) { transport_double }
   let(:state) { {} }
-  let(:resource_client) { resource_client_double }
-  let(:network_client) { network_client_double }
+  let(:arm_client) { arm_client_double }
 
   # Every deployment the driver submits, in the order it submitted them.
   let(:submitted_deployments) { [] }
 
   before do
-    stub_azure_clients(driver, resource_client:, network_client:)
-    record_deployments(resource_client)
+    stub_arm_client(driver, arm_client:)
+    record_deployments(arm_client)
   end
 
   describe "preconditions" do
@@ -30,27 +29,25 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
   describe "resource group creation" do
     it "creates the resource group before deploying" do
       driver.create(state)
-      expect(resource_client.resource_groups).to have_received(:create_or_update)
+      expect(arm_client).to have_received(:create_or_update_resource_group)
         .with(state[:azure_resource_group_name], anything)
     end
 
     it "tags the resource group" do
       driver = build_driver(resource_group_tags: { owner: "platform-team" }, location: "westus3")
-      stub_azure_clients(driver, resource_client:, network_client:)
-      record_deployments(resource_client)
+      stub_arm_client(driver, arm_client:)
+      record_deployments(arm_client)
       driver.create({})
 
-      expect(resource_client.resource_groups).to have_received(:create_or_update) do |_name, group|
-        expect(group.tags).to eq(owner: "platform-team")
-        expect(group.location).to eq("westus3")
-      end
+      expect(arm_client).to have_received(:create_or_update_resource_group)
+        .with(anything, location: "westus3", tags: { owner: "platform-team" })
     end
 
     it "re-raises an Azure failure after logging the body" do
-      allow(resource_client.resource_groups).to receive(:create_or_update)
+      allow(arm_client).to receive(:create_or_update_resource_group)
         .and_raise(azure_operation_error(code: "AuthorizationFailed"))
 
-      expect { driver.create(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+      expect { driver.create(state) }.to raise_error(Kitchen::Driver::Azure::OperationError)
     end
   end
 
@@ -65,30 +62,30 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
     it "sends a deployment whose template is valid ARM JSON" do
       driver.create(state)
-      expect(JSON.generate(submitted_deployments.first[:deployment].properties.template)).to be_a_valid_arm_template
+      expect(JSON.generate(submitted_deployments.first[:deployment]["properties"]["template"])).to be_a_valid_arm_template
     end
 
     it "passes the configured location and machine size through" do
       driver.create(state)
       expect(deployment_parameters).to include(
-        location: { "value" => "eastus2" },
-        vmSize: { "value" => "Standard_D4_v3" }
+        "location" => { "value" => "eastus2" },
+        "vmSize" => { "value" => "Standard_D4_v3" }
       )
     end
 
     it "derives the public DNS label from the uuid" do
       driver.create(state)
-      expect(deployment_parameters[:dnsNameForPublicIP]).to eq("value" => "kitchen-#{state[:uuid]}")
+      expect(deployment_parameters["dnsNameForPublicIP"]).to eq("value" => "kitchen-#{state[:uuid]}")
     end
 
     it "no longer creates a storage account for the OS disk" do
       driver.create(state)
-      expect(deployment_parameters).not_to include(:newStorageAccountName)
+      expect(deployment_parameters).not_to include("newStorageAccountName")
     end
 
     it "derives the nic name from the vm name" do
       driver.create(state)
-      expect(deployment_parameters[:nicName]).to eq("value" => "nic-#{state[:vm_name]}")
+      expect(deployment_parameters["nicName"]).to eq("value" => "nic-#{state[:vm_name]}")
     end
 
     context "with an explicit nic_name" do
@@ -96,21 +93,21 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "uses it verbatim" do
         driver.create(state)
-        expect(deployment_parameters[:nicName]).to eq("value" => "my-nic")
+        expect(deployment_parameters["nicName"]).to eq("value" => "my-nic")
       end
     end
 
     it "splits the image urn into its four parts" do
       driver = build_driver(image_urn: "RedHat:rhel-byos:rhel-raw76:7.6.20190620")
-      stub_azure_clients(driver, resource_client:, network_client:)
-      record_deployments(resource_client)
+      stub_arm_client(driver, arm_client:)
+      record_deployments(arm_client)
       driver.create({})
 
       expect(deployment_parameters).to include(
-        imagePublisher: { "value" => "RedHat" },
-        imageOffer: { "value" => "rhel-byos" },
-        imageSku: { "value" => "rhel-raw76" },
-        imageVersion: { "value" => "7.6.20190620" }
+        "imagePublisher" => { "value" => "RedHat" },
+        "imageOffer" => { "value" => "rhel-byos" },
+        "imageSku" => { "value" => "rhel-raw76" },
+        "imageVersion" => { "value" => "7.6.20190620" }
       )
     end
 
@@ -119,8 +116,8 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "sends imageId and no marketplace parameters" do
         driver.create(state)
-        expect(deployment_parameters).to include(imageId: { "value" => "/subscriptions/x/images/my-image" })
-        expect(deployment_parameters).not_to include(:imagePublisher)
+        expect(deployment_parameters).to include("imageId" => { "value" => "/subscriptions/x/images/my-image" })
+        expect(deployment_parameters).not_to include("imagePublisher")
       end
     end
 
@@ -129,8 +126,8 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "ignores it and falls back to the marketplace image" do
         driver.create(state)
-        expect(deployment_parameters).to include(:imagePublisher)
-        expect(deployment_parameters).not_to include(:imageUrl)
+        expect(deployment_parameters).to include("imagePublisher")
+        expect(deployment_parameters).not_to include("imageUrl")
       end
     end
 
@@ -138,19 +135,28 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
       # Basic SKU public IPs were retired on 30 September 2025.
       it "defaults to Standard" do
         driver.create(state)
-        expect(deployment_parameters[:publicIPSKU]).to eq("value" => "Standard")
+        expect(deployment_parameters["publicIPSKU"]).to eq("value" => "Standard")
       end
 
       it "forces a static address, which Standard SKUs require" do
         driver.create(state)
-        expect(deployment_parameters[:publicIPAddressType]).to eq("value" => "Static")
+        expect(deployment_parameters["publicIPAddressType"]).to eq("value" => "Static")
+      end
+
+      context "when a non-Standard SKU is forced" do
+        let(:config) { { public_ip_sku: "Basic" } }
+
+        it "leaves the allocation method to the template default" do
+          driver.create(state)
+          expect(deployment_parameters).not_to include("publicIPAddressType")
+        end
       end
     end
 
     describe "network security group" do
       it "sends no nsgId when it creates its own group" do
         driver.create(state)
-        expect(deployment_parameters).not_to include(:nsgId)
+        expect(deployment_parameters).not_to include("nsgId")
       end
 
       context "with an existing nsg_id" do
@@ -158,7 +164,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
         it "passes it through" do
           driver.create(state)
-          expect(deployment_parameters[:nsgId]).to eq("value" => "/subscriptions/x/networkSecurityGroups/mine")
+          expect(deployment_parameters["nsgId"]).to eq("value" => "/subscriptions/x/networkSecurityGroups/mine")
         end
       end
     end
@@ -173,12 +179,12 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "passes the system assigned identity flag" do
         driver.create(state)
-        expect(deployment_parameters[:systemAssignedIdentity]).to eq("value" => true)
+        expect(deployment_parameters["systemAssignedIdentity"]).to eq("value" => true)
       end
 
       it "converts user assigned identities into the ARM map shape" do
         driver.create(state)
-        expect(deployment_parameters[:userAssignedIdentities])
+        expect(deployment_parameters["userAssignedIdentities"])
           .to eq("value" => { "/subscriptions/x/userAssignedIdentities/id-1" => {} })
       end
     end
@@ -186,16 +192,16 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
     describe "boot diagnostics" do
       it "enables managed boot diagnostics by default" do
         driver.create(state)
-        expect(deployment_parameters[:bootDiagnosticsEnabled]).to eq("value" => true)
+        expect(deployment_parameters["bootDiagnosticsEnabled"]).to eq("value" => true)
       end
 
       it "coerces the historical string spelling" do
         driver = build_driver(boot_diagnostics_enabled: "false")
-        stub_azure_clients(driver, resource_client:, network_client:)
-        record_deployments(resource_client)
+        stub_arm_client(driver, arm_client:)
+        record_deployments(arm_client)
         driver.create({})
 
-        expect(deployment_parameters[:bootDiagnosticsEnabled]).to eq("value" => false)
+        expect(deployment_parameters["bootDiagnosticsEnabled"]).to eq("value" => false)
       end
     end
 
@@ -227,8 +233,8 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "says nothing when no retired setting is used" do
         driver = build_driver
-        stub_azure_clients(driver, resource_client:, network_client:)
-        record_deployments(resource_client)
+        stub_arm_client(driver, arm_client:)
+        record_deployments(arm_client)
         allow(Kitchen.logger).to receive(:warn)
         driver.create({})
 
@@ -241,13 +247,13 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "sends it base64 encoded" do
         driver.create(state)
-        expect(Base64.decode64(deployment_parameters[:customData]["value"])).to eq("#!/bin/sh\necho hi\n")
+        expect(Base64.decode64(deployment_parameters["customData"]["value"])).to eq("#!/bin/sh\necho hi\n")
       end
     end
 
     it "omits customData when none is configured" do
       driver.create(state)
-      expect(deployment_parameters).not_to include(:customData)
+      expect(deployment_parameters).not_to include("customData")
     end
 
     describe "key vault settings" do
@@ -256,15 +262,15 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
       it "passes all three through as parameters" do
         driver.create(state)
         expect(deployment_parameters).to include(
-          secretUrl: { "value" => "https://v.vault.azure.net/secrets/c" },
-          vaultName: { "value" => "v" },
-          vaultResourceGroup: { "value" => "vault-rg" }
+          "secretUrl" => { "value" => "https://v.vault.azure.net/secrets/c" },
+          "vaultName" => { "value" => "v" },
+          "vaultResourceGroup" => { "value" => "vault-rg" }
         )
       end
 
       it "renders the matching secrets block into the template" do
         driver.create(state)
-        vm = vm_resource(submitted_deployments.first[:deployment].properties.template)
+        vm = vm_resource(submitted_deployments.first[:deployment]["properties"]["template"])
         expect(vm["properties"]["osProfile"]).to have_key("secrets")
       end
     end
@@ -353,7 +359,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "sends no adminPassword parameter to ARM" do
         driver.create(state)
-        expect(deployment_parameters).not_to include(:adminPassword)
+        expect(deployment_parameters).not_to include("adminPassword")
       end
     end
   end
@@ -375,11 +381,8 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
     context "in a custom vnet with no public IP" do
       let(:config) { { vnet_id: "/vnet", subnet_id: "/subnet" } }
-      let(:network_interfaces) { instance_double(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces, get: network_interface(private_ip: "10.0.0.7")) }
 
-      before do
-        allow(Azure::Network2::Profiles::Latest::Mgmt::NetworkInterfaces).to receive(:new).and_return(network_interfaces)
-      end
+      before { allow(arm_client).to receive(:network_interface).and_return(network_interface_response(private_ip: "10.0.0.7")) }
 
       it "uses the NIC's private address" do
         driver.create(state)
@@ -388,7 +391,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
       it "looks up the NIC by the name it deployed" do
         driver.create(state)
-        expect(network_interfaces).to have_received(:get).with(state[:azure_resource_group_name], "nic-#{state[:vm_name]}")
+        expect(arm_client).to have_received(:network_interface).with(state[:azure_resource_group_name], "nic-#{state[:vm_name]}")
       end
     end
 
@@ -404,7 +407,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
   describe "when a deployment is already running" do
     before do
-      allow(resource_client.deployments).to receive(:begin_create_or_update_async)
+      allow(arm_client).to receive(:create_deployment)
         .and_raise(azure_operation_error(code: "DeploymentActive"))
     end
 
@@ -426,12 +429,12 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
 
   describe "when the deployment fails for any other reason" do
     before do
-      allow(resource_client.deployments).to receive(:begin_create_or_update_async)
+      allow(arm_client).to receive(:create_deployment)
         .and_raise(azure_operation_error(code: "InvalidTemplate", message: "the template is malformed"))
     end
 
     it "re-raises" do
-      expect { driver.create(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+      expect { driver.create(state) }.to raise_error(Kitchen::Driver::Azure::OperationError)
     end
   end
 
@@ -440,9 +443,9 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
   # @param client [Object] the doubled resource management client.
   # @return [void]
   def record_deployments(client)
-    allow(client.deployments).to receive(:begin_create_or_update_async) do |resource_group, name, deployment|
+    allow(client).to receive(:create_deployment) do |resource_group, name, deployment|
       submitted_deployments << { resource_group:, name:, deployment: }
-      accepted_request
+      { "id" => "/deployments/#{name}" }
     end
   end
 
@@ -451,7 +454,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
   # @return [Hash, nil]
   def deployment_parameters
     main = submitted_deployments.find { |entry| entry[:name].start_with?("deploy-") }
-    main && main[:deployment].properties.parameters
+    main && main[:deployment]["properties"]["parameters"]
   end
 
   # Names of every deployment submitted, in order.

--- a/spec/unit/kitchen/driver/azurerm/deployment_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/deployment_spec.rb
@@ -2,26 +2,23 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
   subject(:driver) { build_driver(**config) }
 
   let(:config) { {} }
-  let(:models) { Azure::Resources2::Profiles::Latest::Mgmt::Models }
-  let(:incremental) { models::DeploymentMode::Incremental }
-  let(:complete) { models::DeploymentMode::Complete }
 
   describe "#parameters_in_values_format" do
     it "wraps each value in the ARM value envelope" do
       expect(driver.parameters_in_values_format(location: "eastus2", vmSize: "Standard_D2_v3")).to eq(
-        location: { "value" => "eastus2" },
-        vmSize: { "value" => "Standard_D2_v3" }
+        "location" => { "value" => "eastus2" },
+        "vmSize" => { "value" => "Standard_D2_v3" }
       )
     end
 
-    it "symbolizes string keys" do
-      expect(driver.parameters_in_values_format("nicName" => "nic-1")).to eq(nicName: { "value" => "nic-1" })
+    it "stringifies symbol keys, matching ARM's own JSON" do
+      expect(driver.parameters_in_values_format(nicName: "nic-1")).to eq("nicName" => { "value" => "nic-1" })
     end
 
     it "preserves non-string values" do
       expect(driver.parameters_in_values_format(count: 3, enabled: false)).to eq(
-        count: { "value" => 3 },
-        enabled: { "value" => false }
+        "count" => { "value" => 3 },
+        "enabled" => { "value" => false }
       )
     end
 
@@ -38,16 +35,16 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
     subject(:deployment) { driver.deployment(location: "eastus2") }
 
     it "uses Incremental mode" do
-      expect(deployment.properties.mode).to eq(incremental)
+      expect(deployment["properties"]["mode"]).to eq("Incremental")
     end
 
     it "carries the rendered virtual machine template" do
-      expect(deployment.properties.template["resources"].map { |r| r["type"] })
+      expect(deployment["properties"]["template"]["resources"].map { |r| r["type"] })
         .to include("Microsoft.Compute/virtualMachines")
     end
 
     it "carries the parameters in ARM value format" do
-      expect(deployment.properties.parameters).to eq(location: { "value" => "eastus2" })
+      expect(deployment["properties"]["parameters"]).to eq("location" => { "value" => "eastus2" })
     end
   end
 
@@ -65,25 +62,25 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
 
     it "reads and parses the pre-deployment template from disk" do
       deployment = driver.pre_deployment(template_path, {})
-      expect(deployment.properties.template).to eq(template)
+      expect(deployment["properties"]["template"]).to eq(template)
     end
 
     it "reads and parses the post-deployment template from disk" do
       deployment = driver.post_deployment(template_path, {})
-      expect(deployment.properties.template).to eq(template)
+      expect(deployment["properties"]["template"]).to eq(template)
     end
 
     it "uses Incremental mode so existing resources survive" do
-      expect(driver.pre_deployment(template_path, {}).properties.mode).to eq(incremental)
+      expect(driver.pre_deployment(template_path, {})["properties"]["mode"]).to eq("Incremental")
     end
 
     it "formats supplied parameters" do
       deployment = driver.pre_deployment(template_path, storageName: "mystorage")
-      expect(deployment.properties.parameters).to eq(storageName: { "value" => "mystorage" })
+      expect(deployment["properties"]["parameters"]).to eq("storageName" => { "value" => "mystorage" })
     end
 
     it "leaves parameters unset when none are supplied" do
-      expect(driver.pre_deployment(template_path, {}).properties.parameters).to be_nil
+      expect(driver.pre_deployment(template_path, {})["properties"]).not_to have_key("parameters")
     end
 
     it "raises a readable error when the template file is missing" do
@@ -95,25 +92,22 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
     subject(:deployment) { driver.empty_deployment }
 
     it "uses Complete mode, which is what actually deletes the resources" do
-      expect(deployment.properties.mode).to eq(complete)
+      expect(deployment["properties"]["mode"]).to eq("Complete")
     end
 
     it "contains no resources" do
-      expect(deployment.properties.template["resources"]).to eq([])
+      expect(deployment["properties"]["template"]["resources"]).to eq([])
     end
 
     it "sets no parameters" do
-      expect(deployment.properties.parameters).to be_nil
+      expect(deployment["properties"]).not_to have_key("parameters")
     end
   end
 
   describe "#follow_deployment_until_end_state" do
-    before { driver.resource_management_client = resource_client }
+    before { driver.arm_client = arm_client }
 
-    let(:resource_client) do
-      resource_client_double(deployments: deployments, deployment_operations: deployment_operations_double)
-    end
-    let(:deployments) { deployments_double(provisioning_state: "Succeeded") }
+    let(:arm_client) { arm_client_double }
 
     it "returns once the deployment succeeds" do
       expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
@@ -127,34 +121,31 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
 
     it "sleeps between polls for the configured interval" do
       driver = build_driver(deployment_sleep: 42)
-      driver.resource_management_client = resource_client
+      driver.arm_client = arm_client
       driver.follow_deployment_until_end_state("rg", "deploy-1")
       expect(driver).to have_received(:sleep).with(42)
     end
 
     it "keeps polling until a terminal state is reached" do
-      allow(deployments).to receive(:get).and_return(
-        deployment_extended("Running"),
-        deployment_extended("Running"),
-        deployment_extended("Succeeded")
+      allow(arm_client).to receive(:deployment).and_return(
+        deployment_response("Running"),
+        deployment_response("Running"),
+        deployment_response("Succeeded")
       )
 
       driver.follow_deployment_until_end_state("rg", "deploy-1")
-      expect(deployments).to have_received(:get).exactly(3).times
+      expect(arm_client).to have_received(:deployment).exactly(3).times
     end
 
     %w{Canceled Deleted Succeeded}.each do |state|
       it "treats #{state} as terminal" do
-        allow(deployments).to receive(:get).and_return(deployment_extended(state))
+        allow(arm_client).to receive(:deployment).and_return(deployment_response(state))
         expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
       end
     end
 
     context "when the deployment fails" do
-      let(:deployments) { deployments_double(provisioning_state: "Failed") }
-      let(:resource_client) do
-        resource_client_double(deployments:, deployment_operations: deployment_operations_double(operations:))
-      end
+      let(:arm_client) { arm_client_double(deployment: deployment_response("Failed"), deployment_operations: operations) }
       let(:operations) do
         [
           deployment_operation(status_code: "OK"),
@@ -168,7 +159,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
       end
 
       it "reports every failure, not just the first" do
-        allow(resource_client.deployment_operations).to receive(:list).and_return(
+        allow(arm_client).to receive(:deployment_operations).and_return(
           [
             deployment_operation(status_code: "Conflict", status_message: "first problem"),
             deployment_operation(status_code: "BadRequest", status_message: "second problem"),
@@ -180,7 +171,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
       end
 
       it "does not raise when every operation reported OK" do
-        allow(resource_client.deployment_operations).to receive(:list).and_return([deployment_operation(status_code: "OK")])
+        allow(arm_client).to receive(:deployment_operations).and_return([deployment_operation(status_code: "OK")])
         expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
       end
     end
@@ -188,7 +179,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
 
   describe "#list_outstanding_deployment_operations" do
     before do
-      driver.resource_management_client = resource_client_double(deployment_operations: deployment_operations_double(operations:))
+      driver.arm_client = arm_client_double(deployment_operations: operations)
       allow(Kitchen.logger).to receive(:info)
     end
 
@@ -223,13 +214,13 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
 
   describe "#run_deployment" do
     let(:state) { { uuid: "abc123", azure_resource_group_name: "kitchen-rg" } }
-    let(:resource_client) { resource_client_double }
+    let(:arm_client) { arm_client_double }
 
-    before { driver.resource_management_client = resource_client }
+    before { driver.arm_client = arm_client }
 
     it "names the deployment from the prefix and the instance uuid" do
       driver.run_deployment(state, "pre-deploy", driver.empty_deployment)
-      expect(resource_client.deployments).to have_received(:begin_create_or_update_async)
+      expect(arm_client).to have_received(:create_deployment)
         .with("kitchen-rg", "pre-deploy-abc123", anything)
     end
 

--- a/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
@@ -2,8 +2,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
   subject(:driver) { build_driver(**config) }
 
   let(:config) { {} }
-  let(:resource_client) { resource_client_double }
-  let(:resource_groups) { resource_client.resource_groups }
+  let(:arm_client) { arm_client_double }
   let(:state) do
     {
       uuid: "abc123",
@@ -18,12 +17,12 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
     }
   end
 
-  before { stub_azure_clients(driver, resource_client:) }
+  before { stub_arm_client(driver, arm_client:) }
 
   describe "the ordinary case" do
     it "deletes the resource group" do
       driver.destroy(state)
-      expect(resource_groups).to have_received(:begin_delete).with("kitchen-default-20260822T134505")
+      expect(arm_client).to have_received(:delete_resource_group).with("kitchen-default-20260822T134505")
     end
 
     it "clears the resource group name from state" do
@@ -38,19 +37,19 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
     it "does not empty the resource group first by default" do
       driver.destroy(state)
-      expect(resource_client.deployments).not_to have_received(:begin_create_or_update_async)
+      expect(arm_client).not_to have_received(:create_deployment)
     end
 
     it "re-raises an Azure failure" do
-      allow(resource_groups).to receive(:begin_delete).and_raise(azure_operation_error(code: "InUseSubnetCannotBeDeleted"))
-      expect { driver.destroy(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+      allow(arm_client).to receive(:delete_resource_group).and_raise(azure_operation_error(code: "InUseSubnetCannotBeDeleted"))
+      expect { driver.destroy(state) }.to raise_error(Kitchen::Driver::Azure::OperationError)
     end
   end
 
   describe "state backfill" do
     it "falls back to config for a missing azure_environment" do
       driver = build_driver(azure_environment: "AzureUSGovernment")
-      stub_azure_clients(driver, resource_client:)
+      stub_arm_client(driver, arm_client:)
       state.delete(:azure_environment)
 
       driver.destroy(state)
@@ -69,7 +68,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
     it "does nothing" do
       driver.destroy(state)
-      expect(resource_groups).not_to have_received(:begin_delete)
+      expect(arm_client).not_to have_received(:delete_resource_group)
     end
 
     context "with an explicit resource group the user asked to destroy" do
@@ -77,7 +76,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
       it "deletes the group anyway" do
         driver.destroy(state)
-        expect(resource_groups).to have_received(:begin_delete).with("my-shared-rg")
+        expect(arm_client).to have_received(:delete_resource_group).with("my-shared-rg")
       end
 
       it "explains why it is doing so" do
@@ -87,14 +86,14 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
       end
 
       it "does nothing when the group does not exist" do
-        allow(resource_groups).to receive(:check_existence).and_return(false)
+        allow(arm_client).to receive(:resource_group_exists?).and_return(false)
         driver.destroy(state)
-        expect(resource_groups).not_to have_received(:begin_delete)
+        expect(arm_client).not_to have_received(:delete_resource_group)
       end
 
       it "re-raises an Azure failure" do
-        allow(resource_groups).to receive(:begin_delete).and_raise(azure_operation_error(code: "AuthorizationFailed"))
-        expect { driver.destroy(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+        allow(arm_client).to receive(:delete_resource_group).and_raise(azure_operation_error(code: "AuthorizationFailed"))
+        expect { driver.destroy(state) }.to raise_error(Kitchen::Driver::Azure::OperationError)
       end
 
       context "but destroy_explicit_resource_group is off" do
@@ -102,7 +101,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
         it "leaves the group alone" do
           driver.destroy(state)
-          expect(resource_groups).not_to have_received(:begin_delete)
+          expect(arm_client).not_to have_received(:delete_resource_group)
         end
       end
     end
@@ -113,7 +112,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
     it "keeps the resource group" do
       driver.destroy(state)
-      expect(resource_groups).not_to have_received(:begin_delete)
+      expect(arm_client).not_to have_received(:delete_resource_group)
     end
 
     it "warns the user that resources are still running" do
@@ -131,7 +130,7 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
       it "empties the group instead of deleting it" do
         driver.destroy(state)
-        expect(resource_client.deployments).to have_received(:begin_create_or_update_async)
+        expect(arm_client).to have_received(:create_deployment)
           .with("kitchen-default-20260822T134505", "empty-deploy-abc123", anything)
       end
 
@@ -148,23 +147,22 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
     it "submits an empty Complete-mode deployment" do
       driver.destroy(state)
-      expect(resource_client.deployments).to have_received(:begin_create_or_update_async) do |_rg, _name, deployment|
-        expect(deployment.properties.mode).to eq(Azure::Resources2::Profiles::Latest::Mgmt::Models::DeploymentMode::Complete)
-        expect(deployment.properties.template["resources"]).to eq([])
+      expect(arm_client).to have_received(:create_deployment) do |_rg, _name, deployment|
+        expect(deployment["properties"]["mode"]).to eq("Complete")
+        expect(deployment["properties"]["template"]["resources"]).to eq([])
       end
     end
 
     it "then deletes the group itself" do
       driver.destroy(state)
-      expect(resource_groups).to have_received(:begin_delete).with("kitchen-default-20260822T134505")
+      expect(arm_client).to have_received(:delete_resource_group).with("kitchen-default-20260822T134505")
     end
 
     describe "tag handling" do
       it "clears the tags by default" do
         driver.destroy(state)
-        expect(resource_groups).to have_received(:create_or_update) do |_name, group|
-          expect(group.tags).to eq({})
-        end
+        expect(arm_client).to have_received(:create_or_update_resource_group)
+          .with(anything, hash_including(tags: {}))
       end
 
       it "says so" do
@@ -178,9 +176,8 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
         it "restores the configured tags instead" do
           driver.destroy(state)
-          expect(resource_groups).to have_received(:create_or_update) do |_name, group|
-            expect(group.tags).to eq(owner: "platform")
-          end
+          expect(arm_client).to have_received(:create_or_update_resource_group)
+            .with(anything, hash_including(tags: { owner: "platform" }))
         end
 
         it "says so" do
@@ -191,16 +188,16 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
         it "does not also clear them" do
           driver.destroy(state)
-          expect(resource_groups).to have_received(:create_or_update).once
+          expect(arm_client).to have_received(:create_or_update_resource_group).once
         end
       end
     end
 
     it "re-raises an Azure failure from the empty deployment" do
-      allow(resource_client.deployments).to receive(:begin_create_or_update_async)
+      allow(arm_client).to receive(:create_deployment)
         .and_raise(azure_operation_error(code: "DeploymentFailed"))
 
-      expect { driver.destroy(state) }.to raise_error(MsRestAzure2::AzureOperationError)
+      expect { driver.destroy(state) }.to raise_error(Kitchen::Driver::Azure::OperationError)
     end
   end
 end

--- a/spec/unit/kitchen/driver/azurerm/http_integration_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/http_integration_spec.rb
@@ -1,0 +1,106 @@
+# Exercises the whole stack - driver, credentials, token provider, ARM client,
+# HTTP - with nothing doubled below the driver itself. Only the wire is stubbed.
+#
+# The per-layer specs verify each piece in isolation; this one catches wiring
+# mistakes between them, which is exactly the class of bug that appears when
+# swapping out an SDK.
+RSpec.describe Kitchen::Driver::Azurerm, "over HTTP" do
+  subject(:driver) { build_driver(subscription_id:, location: "eastus2") }
+
+  let(:subscription_id) { "115b12cb-b0d3-4ed9-94db-f73733be6f3c" }
+  let(:arm) { "https://management.azure.com/subscriptions/#{subscription_id}" }
+  let(:state) { {} }
+  let(:resource_group) { %r{#{Regexp.escape(arm)}/resourcegroups/[^/?]+\?} }
+
+  before do
+    set_env(
+      "AZURE_TENANT_ID" => "a-tenant",
+      "AZURE_CLIENT_ID" => "a-client",
+      "AZURE_CLIENT_SECRET" => "a-secret"
+    )
+
+    stub_request(:post, "https://login.microsoftonline.com/a-tenant/oauth2/token")
+      .to_return(status: 200, body: '{"access_token":"a-token","expires_in":"3599"}')
+
+    stub_request(:put, resource_group).to_return(status: 200, body: "{}")
+    stub_request(:put, %r{/deployments/deploy-}).to_return(status: 201, body: "{}")
+    stub_request(:get, %r{/deployments/deploy-[^/]+\?}).to_return(
+      status: 200, body: '{"properties":{"provisioningState":"Succeeded"}}'
+    )
+    stub_request(:get, %r{/deployments/.+/operations}).to_return(status: 200, body: '{"value":[]}')
+    stub_request(:get, %r{/publicIPAddresses/publicip}).to_return(
+      status: 200,
+      body: '{"properties":{"ipAddress":"40.121.0.1","dnsSettings":{"fqdn":"kitchen.eastus2.cloudapp.azure.com"}}}'
+    )
+  end
+
+  it "creates the instance and resolves its address" do
+    driver.create(state)
+    expect(state[:hostname]).to eq("40.121.0.1")
+  end
+
+  it "acquires a token once and reuses it across every ARM call" do
+    driver.create(state)
+    expect(a_request(:post, "https://login.microsoftonline.com/a-tenant/oauth2/token")).to have_been_made.once
+  end
+
+  it "authenticates every ARM call with that token" do
+    driver.create(state)
+    expect(a_request(:put, resource_group).with(headers: { "Authorization" => "Bearer a-token" }))
+      .to have_been_made
+  end
+
+  it "sends a deployment whose template is valid ARM JSON" do
+    driver.create(state)
+    expect(a_request(:put, %r{/deployments/deploy-}).with { |request|
+      expect(request.body).to be_a_valid_arm_template_deployment
+      true
+    }).to have_been_made
+  end
+
+  it "polls the deployment until it reports a terminal state" do
+    driver.create(state)
+    expect(a_request(:get, %r{/deployments/deploy-[^/]+\?})).to have_been_made
+  end
+
+  it "surfaces an Azure error rather than a transport exception" do
+    stub_request(:put, resource_group).to_return(
+      status: 403,
+      body: '{"error":{"code":"AuthorizationFailed","message":"nope"}}'
+    )
+
+    expect { driver.create(state) }.to raise_error(Kitchen::Driver::Azure::OperationError, /HTTP 403/)
+  end
+
+  it "retries a transient network failure" do
+    stub_request(:put, resource_group)
+      .to_raise(Errno::ECONNRESET).then
+      .to_return(status: 200, body: "{}")
+
+    expect { driver.create(state) }.not_to raise_error
+    expect(a_request(:put, resource_group)).to have_been_made.twice
+  end
+
+  describe "#destroy" do
+    let(:state) do
+      { uuid: "abc123", server_id: "vmabc123", azure_resource_group_name: "kitchen-rg",
+        subscription_id:, azure_environment: "Azure" }
+    end
+
+    it "deletes the resource group" do
+      stub = stub_request(:delete, "#{arm}/resourcegroups/kitchen-rg").with(query: hash_including({}))
+        .to_return(status: 202)
+
+      driver.destroy(state)
+      expect(stub).to have_been_requested
+    end
+  end
+
+  # Asserts the body of a deployment request carries a parseable ARM template.
+  matcher :be_a_valid_arm_template_deployment do
+    match do |body|
+      template = JSON.parse(body).dig("properties", "template")
+      template.is_a?(Hash) && template["resources"].is_a?(Array)
+    end
+  end
+end


### PR DESCRIPTION
`azure_mgmt_resources2`, `azure_mgmt_network2`, `ms_rest2` and `ms_rest_azure2` are forks of Microsoft's **retired** Azure SDK for Ruby, living at `github.com/chef/azure-sdk-for-ruby`. They pulled in `faraday-cookie_jar2` — itself a personal fork of an abandoned gem — along with `timeliness`, `http-cookie` and `domain_name`. That put four unmaintained forks in the critical path of every deployment.

The driver only ever made **eight** ARM requests. This replaces the whole stack with a small client over the standard library.

`bundle exec rake` is green: **570 examples, 0 failures, 100% line coverage, 0 lint offenses**, stable across seeds. `rake yard` reports 100% documented.

## Dependencies

**63 → 49 transitive runtime gems.** What's left is test-kitchen's own tree plus `inifile` and `sshkey`.

| Removed | |
| --- | --- |
| `azure_mgmt_resources2`, `azure_mgmt_network2` | retired SDK forks |
| `ms_rest2`, `ms_rest_azure2` | retired SDK runtime forks |
| `faraday`, `faraday-net_http`, `faraday-retry` | HTTP stack, replaced by `Net::HTTP` |
| `faraday-cookie_jar2`, `http-cookie`, `domain_name` | cookie handling an ARM client never needed |
| `timeliness` | date parsing, ditto |

```
spec.add_dependency "inifile",      "~> 3.0", ">= 3.0.0"
spec.add_dependency "sshkey",       ">= 1.0.0", "< 4"
spec.add_dependency "test-kitchen", ">= 1.20", "< 5.0"
```

## Structure

| File | Responsibility |
| --- | --- |
| `azure/environments.rb` | Endpoints per cloud — public, US Government, China, Germany |
| `azure/token_provider.rb` | Service principal / managed identity / `az login`, with caching |
| `azure/arm_client.rb` | The eight ARM requests |
| `azure/http.rb` | `Net::HTTP` wrapper separating transient failures from API errors |

> [!WARNING]
> **Breaking.** `AzureCredentials#azure_options` is replaced by `#arm_client` and `#token_provider`; the driver exposes `#arm_client` instead of `#resource_management_client` / `#network_management_client`. Anyone rescuing `MsRestAzure2::AzureOperationError` needs `Kitchen::Driver::Azure::OperationError`.

Behaviour is otherwise unchanged, with two deliberate exceptions:

- **Managed identity now uses IMDS** (`169.254.169.254`) rather than the legacy MSI extension endpoint on port 50342 that the old SDK targeted. IMDS is the supported endpoint on modern Azure VMs.
- **Transient failures and Azure errors are now distinct types**, so only the former are retried. Previously `Faraday::ClientError` covered both, so a 4xx from ARM was retried five times before surfacing.

## A bug the tests found

Test Kitchen defines `Kitchen::StandardError`. This code lives inside `module Kitchen`, so a bare `StandardError` resolved to *that* by lexical scoping — not `::StandardError`. Two consequences:

- `rescue StandardError` silently stopped catching ordinary errors. An `ArgumentError` from `Time.parse` sailed straight through a rescue that looked correct.
- `OperationError` and `TransientError` got `Kitchen::StandardError` as their superclass by accident.

Now explicit everywhere, with a regression test asserting the superclass and that a bare `rescue` catches them, plus a note in `CONTRIBUTING.md` since the next person will hit this too.

## Testing

The REST layer is tested through **WebMock rather than doubles**, so the specs assert on real request shapes — URLs, API versions, headers, bodies — which the SDK previously hid:

```ruby
stub_request(:post, token_url)
  .with(body: { "grant_type" => "client_credentials", "resource" => "https://management.core.windows.net/" })
```

New `http_integration_spec.rb` drives `create` and `destroy` with **nothing doubled below the driver** — only the wire is stubbed. That covers the wiring between driver → credentials → token provider → client → HTTP, which is exactly where SDK swaps break. It asserts the token is acquired once and reused, that every ARM call carries it, that a transient reset is retried, and that a 403 surfaces as an `OperationError`.

WebMock also blocks real network access, so an accidentally unstubbed request fails loudly rather than reaching Azure.

The branch coverage floor moves 95% → 92%: the only uncovered branches are the 16 `require "x" unless defined?(X)` guards, which can't both be taken in one process, and there are more files now. Line coverage stays at 100%.

## Not done here

`inifile` (one flat INI parse, ~25 lines to replace) and `sshkey` — I'd argue against the latter, since it's a zero-dependency gem encapsulating the fiddliest code here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
