### PR TITLE
Add workload identity federation, and fix managed identity selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,59 @@ AZURE_TENANT_ID="your-azure-tenant-id-here"
 
 Note that the environment variables, if set, take preference over the values in a configuration file.
 
+### Authentication methods
+
+The driver picks an authentication method from whatever resolves, in this order:
+
+| Method | Configure with | Use when |
+| --- | --- | --- |
+| Workload identity federation | `AZURE_FEDERATED_TOKEN_FILE` + `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` | CI — GitHub Actions, GitLab, Azure DevOps, AKS. No secret to store. |
+| Service principal | `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET` + `AZURE_TENANT_ID`, or the credentials file | A long-lived secret you manage yourself. |
+| Managed identity | `AZURE_CLIENT_ID` for a user-assigned identity, `AZURE_USE_MSI=1` for a system-assigned one | Running on an Azure VM or in AKS. |
+| Azure CLI | `az login` | Local development. |
+
+Values come from the environment first, then the matching subscription section
+of the credentials file.
+
+#### Workload identity federation
+
+This is the method to prefer in CI. Rather than storing a secret, your CI
+platform issues a short-lived signed assertion which Azure exchanges for an
+access token, so there is no credential in your repository or your CI settings
+to leak, rotate, or accidentally print.
+
+Set up a [federated credential](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)
+trusting your repository, then in GitHub Actions:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: azure/login@v2
+    with:
+      client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  - run: bundle exec kitchen test
+```
+
+`azure/login` writes the assertion to a file and exports
+`AZURE_FEDERATED_TOKEN_FILE`, `AZURE_CLIENT_ID` and `AZURE_TENANT_ID`, which is
+all this driver needs. Nothing in `kitchen.yml` changes.
+
+The assertion is re-read from disk on every token request, so a long
+`kitchen test` run keeps working when the platform rotates it.
+
+`AZURE_AUTHORITY_HOST` is honoured if your platform sets it, as AKS does.
+
+#### Managed identity
+
+On an Azure VM or in AKS, set `AZURE_CLIENT_ID` to the user-assigned identity's
+client ID, or `AZURE_USE_MSI=1` to use the system-assigned identity. Tokens come
+from the instance metadata service; no tenant is required.
+
 After adjusting your ```~/.azure/credentials``` file you will need to adjust your ```kitchen.yml``` file to leverage the azurerm driver. Use the following examples to achieve this, then check your configuration with standard kitchen commands. For example,
 
 ```bash

--- a/lib/kitchen/driver/azure/environments.rb
+++ b/lib/kitchen/driver/azure/environments.rb
@@ -19,12 +19,44 @@ module Kitchen
         # @!attribute [r] token_audience
         #   @return [String] audience/resource the access token is requested for.
         Environment = Struct.new(:name, :resource_manager_url, :authentication_endpoint, :token_audience) do
-          # The OAuth2 token URL for a tenant in this cloud.
+          # The OAuth2 v1.0 token URL for a tenant in this cloud.
           #
           # @param tenant_id [String]
           # @return [String]
           def token_url(tenant_id)
             "#{authentication_endpoint.chomp("/")}/#{tenant_id}/oauth2/token"
+          end
+
+          # The OAuth2 v2.0 token URL for a tenant in this cloud.
+          #
+          # Federated (assertion-based) client credentials are documented
+          # against v2.0, which takes a +scope+ rather than a +resource+.
+          #
+          # @param tenant_id [String]
+          # @return [String]
+          def token_url_v2(tenant_id)
+            "#{authentication_endpoint.chomp("/")}/#{tenant_id}/oauth2/v2.0/token"
+          end
+
+          # The v2.0 scope covering every permission this driver needs.
+          #
+          # @return [String] e.g. +"https://management.azure.com/.default"+
+          def default_scope
+            "#{resource_manager_url.chomp("/")}/.default"
+          end
+
+          # A copy of this cloud pointed at a different Entra ID authority.
+          #
+          # Platforms that issue federated tokens - AKS in particular - set
+          # +AZURE_AUTHORITY_HOST+ to say where those tokens should be
+          # exchanged.
+          #
+          # @param authority [String, nil] the authority URL, or nil to keep this one.
+          # @return [Environment]
+          def with_authority(authority)
+            return self if authority.to_s.empty?
+
+            self.class.new(name, resource_manager_url, authority, token_audience).freeze
           end
         end
 

--- a/lib/kitchen/driver/azure/token_provider.rb
+++ b/lib/kitchen/driver/azure/token_provider.rb
@@ -120,6 +120,67 @@ module Kitchen
         end
       end
 
+      # Authenticates with a federated token issued by another identity
+      # provider - GitHub Actions, GitLab, Azure DevOps, or a Kubernetes
+      # service account - rather than a stored secret.
+      #
+      # The platform writes a short-lived signed assertion to a file and
+      # rotates it; the file is therefore re-read on every token fetch rather
+      # than cached, or a long +kitchen test+ run would start presenting an
+      # assertion that has since expired.
+      class WorkloadIdentityToken < TokenProvider
+        # @return [String] the client assertion type required by Entra ID.
+        ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer".freeze
+
+        # @param environment [Environments::Environment]
+        # @param tenant_id [String]
+        # @param client_id [String]
+        # @param token_file [String] path to the federated token file.
+        def initialize(environment:, tenant_id:, client_id:, token_file:)
+          super(environment:)
+          @tenant_id = tenant_id
+          @client_id = client_id
+          @token_file = token_file
+        end
+
+        # @return [String] path to the federated token file.
+        attr_reader :token_file
+
+        # @return [Array(String, Integer)]
+        # @raise [OperationError] if the assertion file cannot be read.
+        def fetch_token
+          response = Http.request(
+            method: :post,
+            url: environment.token_url_v2(@tenant_id),
+            headers: { "Content-Type" => "application/x-www-form-urlencoded" },
+            body: URI.encode_www_form(
+              grant_type: "client_credentials",
+              client_id: @client_id,
+              client_assertion_type: ASSERTION_TYPE,
+              client_assertion: assertion,
+              scope: environment.default_scope
+            )
+          )
+
+          token_from(response, "the workload identity token endpoint")
+        end
+
+        private
+
+        # The current federated assertion, read fresh each time.
+        #
+        # @return [String]
+        # @raise [OperationError] if the file is missing or unreadable.
+        def assertion
+          File.read(token_file).strip
+        rescue SystemCallError => e
+          raise OperationError.new(
+            "Could not read the federated token file at #{token_file} (#{e.class}). " \
+            "AZURE_FEDERATED_TOKEN_FILE must point at a readable assertion issued by your CI platform."
+          )
+        end
+      end
+
       # Authenticates as a managed identity, via the Instance Metadata Service.
       #
       # This replaces the legacy MSI extension endpoint on port 50342 that the

--- a/lib/kitchen/driver/azure_credentials.rb
+++ b/lib/kitchen/driver/azure_credentials.rb
@@ -74,16 +74,24 @@ module Kitchen
 
       # Endpoints for the configured cloud.
       #
+      # +AZURE_AUTHORITY_HOST+ overrides the Entra ID endpoint, which is how
+      # platforms that issue federated tokens point at their own authority.
+      #
       # @return [Azure::Environments::Environment]
       # @raise [Kitchen::UserError] if the cloud name is not recognised.
       def azure_environment
-        @azure_environment ||= Azure::Environments.fetch(environment)
+        @azure_environment ||= Azure::Environments.fetch(environment).with_authority(ENV["AZURE_AUTHORITY_HOST"])
       end
 
       # Selects a token provider based on which credentials resolved.
       #
+      # In precedence order:
+      #
+      # * +AZURE_FEDERATED_TOKEN_FILE+ + +client_id+ + +tenant_id+ - workload
+      #   identity federation, the secretless option for CI.
       # * +client_id+ + +client_secret+ + +tenant_id+ - service principal.
-      # * +client_id+ + +tenant_id+ - user-assigned managed identity.
+      # * +AZURE_USE_MSI+ - managed identity, explicitly.
+      # * +client_id+ without a secret - user-assigned managed identity.
       # * +tenant_id+ only - system-assigned managed identity.
       # * none of the above - falls back to the +az login+ token cache.
       #
@@ -104,16 +112,42 @@ module Kitchen
 
       # @return [Azure::TokenProvider]
       def build_token_provider
-        if client_id && client_secret && tenant_id!
+        if federated_token_file && client_id && tenant_id!
+          debug "Authenticating with workload identity federation (#{federated_token_file})."
+          Azure::WorkloadIdentityToken.new(environment: azure_environment, tenant_id:, client_id:,
+            token_file: federated_token_file)
+        elsif client_id && client_secret && tenant_id!
           Azure::ServicePrincipalToken.new(environment: azure_environment, tenant_id:, client_id:, client_secret:)
-        elsif client_id && tenant_id!
+        elsif use_managed_identity?
           Azure::ManagedIdentityToken.new(environment: azure_environment, client_id:)
         elsif tenant_id!
+          # A tenant with no client credentials means a system-assigned identity.
           Azure::ManagedIdentityToken.new(environment: azure_environment)
         else
           warn("Using tenant id set through `az login`.")
           Azure::AzureCliToken.new(environment: azure_environment)
         end
+      end
+
+      # Whether to authenticate as a managed identity.
+      #
+      # A +client_id+ with no accompanying secret means a user-assigned managed
+      # identity, which is how the Azure SDKs read the same combination.
+      # Crucially this does not require a tenant: the instance metadata service
+      # never sees one, so demanding it only prevented the identity from being
+      # used at all.
+      #
+      # @return [Boolean]
+      def use_managed_identity?
+        return true unless ENV["AZURE_USE_MSI"].to_s.empty?
+
+        !client_id.nil? && client_secret.nil?
+      end
+
+      # @return [String, nil] path to a federated token file, if one is configured.
+      def federated_token_file
+        value = ENV["AZURE_FEDERATED_TOKEN_FILE"]
+        value unless value.to_s.empty?
       end
 
       # @return [Kitchen::Logger] the shared Test Kitchen logger.

--- a/spec/unit/kitchen/driver/azure/environments_spec.rb
+++ b/spec/unit/kitchen/driver/azure/environments_spec.rb
@@ -31,6 +31,58 @@ RSpec.describe Kitchen::Driver::Azure::Environments do
     end
   end
 
+  describe "#token_url_v2" do
+    it "targets the v2.0 endpoint, which federated credentials require" do
+      expect(described_class.fetch("Azure").token_url_v2("a-tenant"))
+        .to eq("https://login.microsoftonline.com/a-tenant/oauth2/v2.0/token")
+    end
+  end
+
+  describe "#default_scope" do
+    {
+      "Azure" => "https://management.azure.com/.default",
+      "AzureUSGovernment" => "https://management.usgovcloudapi.net/.default",
+      "AzureChina" => "https://management.chinacloudapi.cn/.default",
+      "AzureGermanCloud" => "https://management.microsoftazure.de/.default",
+    }.each do |cloud, scope|
+      it "is #{scope} for #{cloud}" do
+        expect(described_class.fetch(cloud).default_scope).to eq(scope)
+      end
+    end
+
+    it "never doubles the separator" do
+      described_class.names.each do |cloud|
+        expect(described_class.fetch(cloud).default_scope).not_to include("//.default")
+      end
+    end
+  end
+
+  describe "#with_authority" do
+    subject(:environment) { described_class.fetch("Azure") }
+
+    it "replaces the Entra ID endpoint" do
+      expect(environment.with_authority("https://login.example.invalid/").authentication_endpoint)
+        .to eq("https://login.example.invalid/")
+    end
+
+    it "leaves everything else untouched" do
+      overridden = environment.with_authority("https://login.example.invalid/")
+      expect(overridden.name).to eq("Azure")
+      expect(overridden.resource_manager_url).to eq(environment.resource_manager_url)
+      expect(overridden.token_audience).to eq(environment.token_audience)
+    end
+
+    it "returns the same object when given nothing" do
+      expect(environment.with_authority(nil)).to equal(environment)
+      expect(environment.with_authority("")).to equal(environment)
+    end
+
+    it "does not mutate the shared table" do
+      environment.with_authority("https://login.example.invalid/")
+      expect(described_class.fetch("Azure").authentication_endpoint).to eq("https://login.microsoftonline.com/")
+    end
+  end
+
   it "freezes the table so a caller cannot mutate shared endpoints" do
     expect(described_class::ALL).to be_frozen
   end

--- a/spec/unit/kitchen/driver/azure/token_provider_spec.rb
+++ b/spec/unit/kitchen/driver/azure/token_provider_spec.rb
@@ -90,6 +90,90 @@ RSpec.describe "Azure token providers" do
     end
   end
 
+  describe Kitchen::Driver::Azure::WorkloadIdentityToken do
+    subject(:provider) do
+      described_class.new(environment:, tenant_id: "a-tenant", client_id: "a-client", token_file:)
+    end
+
+    let(:token_file) { File.join(ENV.fetch("HOME"), "federated-token") }
+    let(:token_url) { "https://login.microsoftonline.com/a-tenant/oauth2/v2.0/token" }
+
+    before { File.write(token_file, "an-assertion\n") }
+
+    # Federated credentials are documented against the v2.0 endpoint, which
+    # takes a scope rather than a resource.
+    it "exchanges the assertion at the v2.0 endpoint" do
+      stub = stub_request(:post, token_url)
+        .with(body: {
+                "grant_type" => "client_credentials",
+                "client_id" => "a-client",
+                "client_assertion_type" => "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion" => "an-assertion",
+                "scope" => "https://management.azure.com/.default",
+              })
+        .to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+
+      expect(provider.access_token).to eq("tok")
+      expect(stub).to have_been_requested
+    end
+
+    it "sends no client secret" do
+      stub = stub_request(:post, token_url).with { |r| !r.body.include?("client_secret") }
+        .to_return(status: 200, body: '{"access_token":"tok"}')
+
+      provider.access_token
+      expect(stub).to have_been_requested
+    end
+
+    # CI platforms rotate the assertion file. Caching its contents would mean
+    # presenting an expired assertion partway through a long kitchen run.
+    it "re-reads the assertion file on every fetch rather than caching it" do
+      stub_request(:post, token_url)
+        .to_return({ status: 200, body: '{"access_token":"first","expires_in":"60"}' },
+          { status: 200, body: '{"access_token":"second","expires_in":"3599"}' })
+
+      provider.access_token
+      File.write(token_file, "a-rotated-assertion")
+      provider.access_token
+
+      expect(a_request(:post, token_url).with(body: hash_including("client_assertion" => "a-rotated-assertion")))
+        .to have_been_made
+    end
+
+    it "still caches the access token itself" do
+      stub = stub_request(:post, token_url).to_return(status: 200, body: '{"access_token":"tok","expires_in":"3599"}')
+      3.times { provider.access_token }
+      expect(stub).to have_been_requested.once
+    end
+
+    it "explains what to fix when the assertion file is missing" do
+      File.delete(token_file)
+
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError, /AZURE_FEDERATED_TOKEN_FILE must point at a readable assertion/)
+    end
+
+    it "surfaces a rejected assertion" do
+      stub_request(:post, token_url).to_return(status: 400, body: '{"error":"invalid_client"}')
+
+      expect { provider.access_token }
+        .to raise_error(Kitchen::Driver::Azure::OperationError, /workload identity token endpoint \(HTTP 400\)/)
+    end
+
+    context "in a sovereign cloud" do
+      let(:environment) { Kitchen::Driver::Azure::Environments.fetch("AzureUSGovernment") }
+
+      it "uses that cloud's scope" do
+        stub = stub_request(:post, "https://login.microsoftonline.us/a-tenant/oauth2/v2.0/token")
+          .with(body: hash_including("scope" => "https://management.usgovcloudapi.net/.default"))
+          .to_return(status: 200, body: '{"access_token":"tok"}')
+
+        provider.access_token
+        expect(stub).to have_been_requested
+      end
+    end
+  end
+
   describe Kitchen::Driver::Azure::ManagedIdentityToken do
     subject(:provider) { described_class.new(environment:) }
 

--- a/spec/unit/kitchen/driver/azure_credentials_spec.rb
+++ b/spec/unit/kitchen/driver/azure_credentials_spec.rb
@@ -158,6 +158,58 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
     describe "token provider selection" do
       before { use_fixture_credentials_file }
 
+      # Each row is the combination a user actually configures, and the
+      # provider it must resolve to. Getting this table wrong is how an
+      # instance silently authenticates as the wrong thing - or, worse, falls
+      # through to a credential that is not present in CI at all.
+      describe "the full matrix" do
+        let(:token_file) { File.join(ENV.fetch("HOME"), "federated-token").tap { |f| File.write(f, "assertion") } }
+
+        before { ENV.delete("AZURE_CONFIG_FILE") }
+
+        {
+          "nothing configured" => [{}, Kitchen::Driver::Azure::AzureCliToken],
+          "a tenant alone" => [{ "AZURE_TENANT_ID" => "t" }, Kitchen::Driver::Azure::ManagedIdentityToken],
+          "a client id alone" => [{ "AZURE_CLIENT_ID" => "c" }, Kitchen::Driver::Azure::ManagedIdentityToken],
+          "a client id and tenant" => [{ "AZURE_CLIENT_ID" => "c", "AZURE_TENANT_ID" => "t" }, Kitchen::Driver::Azure::ManagedIdentityToken],
+          "an explicit AZURE_USE_MSI" => [{ "AZURE_USE_MSI" => "1" }, Kitchen::Driver::Azure::ManagedIdentityToken],
+          "a full service principal" => [{ "AZURE_CLIENT_ID" => "c", "AZURE_CLIENT_SECRET" => "s", "AZURE_TENANT_ID" => "t" }, Kitchen::Driver::Azure::ServicePrincipalToken],
+        }.each do |label, (env, expected)|
+          it "resolves #{label} to #{expected.to_s.split("::").last}" do
+            set_env(env)
+            expect(described_class.new(subscription_id: "s").token_provider).to be_an_instance_of(expected)
+          end
+        end
+
+        it "resolves a federated token file to WorkloadIdentityToken" do
+          set_env("AZURE_FEDERATED_TOKEN_FILE" => token_file, "AZURE_CLIENT_ID" => "c", "AZURE_TENANT_ID" => "t")
+          expect(described_class.new(subscription_id: "s").token_provider)
+            .to be_an_instance_of(Kitchen::Driver::Azure::WorkloadIdentityToken)
+        end
+
+        it "prefers federation over a service principal secret" do
+          set_env("AZURE_FEDERATED_TOKEN_FILE" => token_file, "AZURE_CLIENT_ID" => "c",
+            "AZURE_CLIENT_SECRET" => "s", "AZURE_TENANT_ID" => "t")
+          expect(described_class.new(subscription_id: "s").token_provider)
+            .to be_an_instance_of(Kitchen::Driver::Azure::WorkloadIdentityToken)
+        end
+
+        it "ignores an empty AZURE_FEDERATED_TOKEN_FILE" do
+          set_env("AZURE_FEDERATED_TOKEN_FILE" => "", "AZURE_CLIENT_ID" => "c",
+            "AZURE_CLIENT_SECRET" => "s", "AZURE_TENANT_ID" => "t")
+          expect(described_class.new(subscription_id: "s").token_provider)
+            .to be_an_instance_of(Kitchen::Driver::Azure::ServicePrincipalToken)
+        end
+
+        # The instance metadata service never sees a tenant, so requiring one
+        # only stopped the identity from being usable.
+        it "needs no tenant for a user-assigned managed identity" do
+          set_env("AZURE_CLIENT_ID" => "c")
+          provider = described_class.new(subscription_id: "s").token_provider
+          expect(client_id_of(provider)).to eq("c")
+        end
+      end
+
       context "with client_id, client_secret and tenant_id" do
         let(:subscription_id) { CredentialsFileHelper::SUBSCRIPTIONS[:service_principal] }
 
@@ -238,6 +290,23 @@ RSpec.describe Kitchen::Driver::AzureCredentials do
             expect(credentials.azure_environment.resource_manager_url).to eq(expected[:resource_manager_url])
           end
         end
+      end
+    end
+
+    describe "AZURE_AUTHORITY_HOST" do
+      it "redirects token exchange at the authority the platform names" do
+        set_env("AZURE_AUTHORITY_HOST" => "https://login.example.invalid/")
+        expect(credentials.azure_environment.authentication_endpoint).to eq("https://login.example.invalid/")
+      end
+
+      it "leaves the resource manager endpoint alone" do
+        set_env("AZURE_AUTHORITY_HOST" => "https://login.example.invalid/")
+        expect(credentials.azure_environment.resource_manager_url).to eq("https://management.azure.com/")
+      end
+
+      it "is ignored when empty" do
+        set_env("AZURE_AUTHORITY_HOST" => "")
+        expect(credentials.azure_environment.authentication_endpoint).to eq("https://login.microsoftonline.com/")
       end
     end
 


### PR DESCRIPTION
Adds the secretless authentication method Microsoft recommends for CI, and repairs managed identity selection, which couldn't be used in the way it's normally configured.

`bundle exec rake` is green: **600 examples, 0 failures, 100% line coverage, 0 lint offenses**, stable across seeds.

## Why workload identity federation is worth having

Right now, running kitchen-azurerm in CI means putting a service principal secret somewhere. That secret is long-lived, has to be rotated by somebody who remembers to, and lives in your CI provider's settings where any step careless with `set -x` can print it into a log. If it leaks, it stays valid until someone revokes it.

Workload identity federation removes it entirely. Your CI platform issues a short-lived, cryptographically signed assertion scoped to *this specific repository and workflow*, and Azure exchanges it for an access token. There's nothing to store, nothing to rotate, and nothing to leak. If someone forks the repository, their workflow's assertion doesn't match the federated credential's subject, so Azure rejects it.

It's Microsoft's recommended method — the Azure docs describe OIDC as "the recommended authentication method" for GitHub Actions and note that it stores no secrets — and it's supported by GitHub Actions, GitLab, Azure DevOps and AKS. For a driver whose entire job is provisioning test infrastructure from CI, this was the notable gap in what we support.

**It needs no `kitchen.yml` change.** `azure/login` already exports exactly the variables the driver now reads:

```yaml
permissions:
  id-token: write

steps:
  - uses: azure/login@v2
    with:
      client-id: ${{ secrets.AZURE_CLIENT_ID }}
      tenant-id: ${{ secrets.AZURE_TENANT_ID }}
      subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
  - run: bundle exec kitchen test
```

Those are `secrets` only because they're identifiers people prefer not to publish — none of them is a credential.

Two implementation details worth reviewing:

- Federated credentials are documented against the **v2.0** token endpoint, which takes a `scope` rather than a `resource`. I checked this rather than assuming, because the existing service-principal flow uses v1.0 and copying it would have been wrong. The scope is derived per cloud from the resource manager URL, so sovereign clouds work.
- **The assertion file is re-read on every token fetch, not cached.** Platforms rotate it — AKS hourly, GitHub's is short-lived — so caching would mean presenting an expired assertion partway through a long `kitchen test`. There's a test pinning this.

`AZURE_AUTHORITY_HOST` is honoured for platforms that set it, as AKS does.

## The managed identity fix

Selection required a `tenant_id` that IMDS **never sees** — the driver didn't even pass it to the provider. The practical effect:

```
                                     before   after
client_id only (user-assigned MSI)   CLI   →  ManagedIdentityToken
tenant only (system-assigned MSI)    MSI   →  ManagedIdentityToken
```

`AZURE_CLIENT_ID` alone is the normal way to name a user-assigned identity, and it's how the Azure SDKs read the same combination. Under the old logic it silently fell through to the Azure CLI and then failed wherever `az` wasn't installed — which is most Azure VMs and every AKS pod.

A client id with no accompanying secret now means managed identity, with no tenant required. `AZURE_USE_MSI=1` selects a system-assigned identity explicitly, which previously meant setting a tenant that was then thrown away.

This is inherited behaviour, not something the REST rewrite introduced — but I carried it over faithfully and it was wrong.

## Compatibility

Every combination that already worked resolves the same way. The only behaviour change is that `AZURE_CLIENT_ID` with no secret now selects managed identity instead of the Azure CLI. That combination previously couldn't authenticate as a managed identity at all, so anyone relying on the CLI fallback in that state was relying on the bug.

## Testing

Selection is now pinned by a table covering every combination a user actually configures:

| Configured | Resolves to |
| --- | --- |
| nothing | `AzureCliToken` |
| tenant alone | `ManagedIdentityToken` |
| client id alone | `ManagedIdentityToken` |
| client id + tenant | `ManagedIdentityToken` |
| `AZURE_USE_MSI` | `ManagedIdentityToken` |
| client id + secret + tenant | `ServicePrincipalToken` |
| federated token file + client id + tenant | `WorkloadIdentityToken` |

Getting this table wrong means silently authenticating as the wrong thing, or falling through to a credential that isn't present in CI — which is exactly the failure this PR fixes, so it seemed worth nailing down explicitly.

The provider itself is tested through WebMock against the real request shape: endpoint, grant type, assertion type, scope, and the absence of any `client_secret`.

## Still not supported

Certificate-based service principals (`AZURE_CLIENT_CERTIFICATE_PATH`), device code, Azure PowerShell, `azd`, and VS Code credentials. Happy to add the certificate flow if there's demand; the rest matter much less for a CI tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
