### PR TITLE
docs: restructure the README around the new user journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,181 @@
 # kitchen-azurerm
 
-[![Gem Version](https://badge.fury.io/rb/kitchen-azurerm.svg)](https://badge.fury.io/rb/kitchen-azurerm)
+[![Gem Version](https://img.shields.io/gem/v/kitchen-azurerm.svg)](https://rubygems.org/gems/kitchen-azurerm)
 [![Lint, Unit & Integration Tests](https://github.com/test-kitchen/kitchen-azurerm/actions/workflows/lint.yml/badge.svg)](https://github.com/test-kitchen/kitchen-azurerm/actions/workflows/lint.yml)
 
-**kitchen-azurerm** is a driver for the popular test harness [Test Kitchen](http://kitchen.ci) that allows Microsoft Azure resources to be provisioned before testing. This driver talks to the Azure Resource Manager REST API directly, and depends only on the Ruby standard library to do so.
+A [Test Kitchen](https://kitchen.ci/) driver for Microsoft Azure.
 
-This version has been tested on Windows, macOS, and Ubuntu. If you encounter a problem on your platform, please raise an issue.
+Test Kitchen builds a throwaway machine, converges your configuration code on
+it, runs your tests, and destroys it. This driver makes that throwaway machine
+an Azure virtual machine, so you can test against the same platform you deploy
+to. It talks to the Azure Resource Manager REST API directly and depends only
+on the Ruby standard library to do so.
 
-## Quick-start
+Tested on Windows, macOS, and Linux. If you hit a problem on your platform,
+please raise an issue.
 
-### Installation
+> This documentation uses [Cinc Workstation](https://cinc.sh/) and the `cinc`
+> commands throughout. Everything here works identically with Chef Workstation —
+> see [Using with Chef](#using-with-chef).
 
-This plugin ships in [Cinc Workstation](https://cinc.sh/start/workstation/) out of the box, so there is no need to
-install it if you are using Cinc Workstation. The examples below use the `cinc` commands; everything works identically
-with Chef Workstation, which also bundles this plugin — see [Using with Chef](#using-with-chef).
+---
 
-If you're not using a Workstation build and need to install the plugin as a gem, run:
+## Contents
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Quick start](#quick-start)
+- [Authentication](#authentication)
+- [Configuration reference](#configuration-reference)
+- [Common setups](#common-setups)
+- [Finding an image URN](#finding-an-image-urn)
+- [Troubleshooting](#troubleshooting)
+- [Using with Chef](#using-with-chef)
+- [Contributing](#contributing)
+- [License and Copyright](#license-and-copyright)
+
+---
+
+## Requirements
+
+- Ruby 3.1 or newer (already satisfied if you use Cinc Workstation)
+- An active Azure subscription — you can [start for free](https://azure.microsoft.com/en-us/free/)
+  or use an [MSDN subscription](https://azure.microsoft.com/en-us/pricing/member-offers/msdn-benefits/)
+- A way to authenticate to it, with rights to create resources. A service
+  principal with the Contributor role is the usual choice; see
+  [Authentication](#authentication) for the alternatives.
+
+The [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) is not
+required at run time, but the quick start uses it to create the service
+principal and to look up images.
+
+## Installation
+
+This driver ships with [Cinc
+Workstation](https://cinc.sh/start/workstation/), which is the simplest way to
+get Test Kitchen and its plugins in one package. It also ships with [Chef
+Workstation](https://www.chef.io/downloads/tools/workstation).
+
+To install it yourself, add it to your `Gemfile`:
+
+```ruby
+gem "kitchen-azurerm"
+```
+
+then `bundle install`. Or install the gem directly:
 
 ```shell
 gem install kitchen-azurerm
 ```
 
-### Configuration
+## Quick start
 
-For the driver to interact with the Microsoft Azure Resource Management REST API, you need to configure a Service Principal with Contributor rights for a specific subscription. Using an Organizational (AAD) account and related password is no longer supported. To create a Service Principal and apply the correct permissions, see the [create an Azure service principal with the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest#create-a-service-principal) and the [Azure CLI](https://azure.microsoft.com/en-us/documentation/articles/xplat-cli-install/) documentation. Make sure you stay within the section titled 'Password-based authentication'.
+### 1. Create a service principal
 
-If the above is TLDR then try this after `az login` using your target subscription ID and the desired SP name:
+The driver needs an identity with Contributor rights on the subscription you
+want to deploy into. After `az login`:
 
 ```bash
-# Create a Service Principal using the desired subscription id from the command above
-az ad sp create-for-rbac --name="kitchen-azurerm" --role="Contributor" --scopes="/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-#Output
-#
-#{
-#  "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",    <- Also known as the Client ID
-#  "displayName": "azure-cli-2018-12-12-14-15-39",
-#  "name": "http://azure-cli-2018-12-12-14-15-39",
-#  "password": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-#  "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-#}
+az ad sp create-for-rbac --name "kitchen-azurerm" \
+  --role "Contributor" \
+  --scopes "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 ```
 
-NOTE: Don't forget to save the values from the output -- most importantly the `password`.
+which prints:
 
-You will also need to ensure you have an active Azure subscription (you can get started [for free](https://azure.microsoft.com/en-us/free/) or use your [MSDN Subscription](https://azure.microsoft.com/en-us/pricing/member-offers/msdn-benefits/)).
+```json
+{
+  "appId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "displayName": "kitchen-azurerm",
+  "password": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "tenant": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+```
 
-You are now ready to configure kitchen-azurerm to use the credentials from the service principal you created above. You will use four elements from the output:
+**Save the `password` now** — Azure will not show it again. You need four
+values: the subscription ID, `appId` (the client ID), `password` (the client
+secret), and `tenant`.
 
-1. **Subscription ID**: available from the Azure portal
-2. **Client ID**: the appId value from the output.
-3. **Client Secret/Password**: the password from the output.
-4. **Tenant ID**: the tenant from the output.
+> Organizational (Entra ID) account and password authentication is no longer
+> supported. If you are setting this up for CI, prefer [workload identity
+> federation](#workload-identity-federation) and skip the secret entirely.
 
-Using a text editor, open or create the file ```~/.azure/credentials``` and add the following section, noting there is one section per Subscription ID. **Make sure you save the file with UTF-8 encoding**
+### 2. Store the credentials
 
-```ruby
-[ADD-YOUR-AZURE-SUBSCRIPTION-ID-HERE-IN-SQUARE-BRACKET]
+Create `~/.azure/credentials`, with one section per subscription ID. **Save it
+as UTF-8.**
+
+```ini
+[your-azure-subscription-id-here]
 client_id = "your-azure-client-id-here"
 client_secret = "your-client-secret-here"
 tenant_id = "your-azure-tenant-id-here"
 ```
 
-If preferred, you may also set the following environment variables, however this would be incompatible with supporting multiple Azure subscriptions.
+Or use environment variables, which take precedence over the file but cannot
+describe more than one subscription:
 
-```ruby
-AZURE_CLIENT_ID="your-azure-client-id-here"
-AZURE_CLIENT_SECRET="your-client-secret-here"
-AZURE_TENANT_ID="your-azure-tenant-id-here"
+```bash
+export AZURE_CLIENT_ID="your-azure-client-id-here"
+export AZURE_CLIENT_SECRET="your-client-secret-here"
+export AZURE_TENANT_ID="your-azure-tenant-id-here"
 ```
 
-Note that the environment variables, if set, take preference over the values in a configuration file.
+### 3. Write your `kitchen.yml`
 
-### Authentication methods
+```yaml
+---
+driver:
+  name: azurerm
+  subscription_id: <%= ENV["AZURE_SUBSCRIPTION_ID"] %>
+  location: westeurope
+  machine_size: Standard_D2s_v3
 
-The driver picks an authentication method from whatever resolves, in this order:
+transport:
+  ssh_key: ~/.ssh/id_kitchen-azurerm
+
+provisioner:
+  name: cinc_infra
+
+verifier:
+  name: cinc_auditor
+
+platforms:
+  - name: ubuntu-22.04
+
+suites:
+  - name: default
+```
+
+If the SSH key does not exist at the path you give, Test Kitchen creates it.
+When `ssh_key` is set, Test Kitchen uses it in preference to any password.
+
+### 4. Run it
+
+```bash
+cinc kitchen test
+```
+
+Or step through it:
+
+```bash
+cinc kitchen create    # deploy the resource group and VM
+cinc kitchen converge  # apply your configuration
+cinc kitchen verify    # run your tests
+cinc kitchen destroy   # delete the resource group
+```
+
+`cinc kitchen list` shows what is configured and what state it is in:
+
+```text
+Instance            Driver   Provisioner  Verifier     Transport  Last Action    Last Error
+default-ubuntu-2204 Azurerm  CincInfra    CincAuditor  Ssh        <Not Created>  <None>
+```
+
+## Authentication
+
+The driver picks an authentication method from whatever resolves, in this
+order:
 
 | Method | Configure with | Use when |
 | --- | --- | --- |
@@ -86,7 +187,7 @@ The driver picks an authentication method from whatever resolves, in this order:
 Values come from the environment first, then the matching subscription section
 of the credentials file.
 
-#### Workload identity federation
+### Workload identity federation
 
 This is the method to prefer in CI. Rather than storing a secret, your CI
 platform issues a short-lived signed assertion which Azure exchanges for an
@@ -119,26 +220,17 @@ The assertion is re-read from disk on every token request, so a long
 
 `AZURE_AUTHORITY_HOST` is honoured if your platform sets it, as AKS does.
 
-#### Managed identity
+### Managed identity
 
 On an Azure VM or in AKS, set `AZURE_CLIENT_ID` to the user-assigned identity's
 client ID, or `AZURE_USE_MSI=1` to use the system-assigned identity. Tokens come
 from the instance metadata service; no tenant is required.
 
-After adjusting your ```~/.azure/credentials``` file you will need to adjust your ```kitchen.yml``` file to leverage the azurerm driver. Use the following examples to achieve this, then check your configuration with standard kitchen commands. For example,
-
-```bash
-% kitchen list
-Instance            Driver   Provisioner  Verifier  Transport  Last Action    Last Error
-wsus-windows-2019   Azurerm  ChefZero     Inspec    Winrm      <Not Created>  <None>
-wsus-windows-2016   Azurerm  ChefZero     Inspec    Winrm      <Not Created>  <None>
-```
-
-### Driver Properties
+## Configuration reference
 
 All options below are set under the `driver:` key in `kitchen.yml`, or per platform under `platforms[].driver:`.
 
-#### Required
+### Required
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -146,17 +238,17 @@ All options below are set under the `driver:` key in `kitchen.yml`, or per platf
 | `location` | *none* | Azure region, e.g. `westeurope`. Required. |
 | `machine_size` | *none* | VM size, e.g. `Standard_D2s_v3`. Required. |
 
-#### Image
+### Image
 
 Set one of `image_urn` or `image_id`.
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `image_urn` | `Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest` | Marketplace image, as `Publisher:Offer:Sku:Version`. See [How to retrieve the image_urn](#how-to-retrieve-the-image_urn). |
+| `image_urn` | `Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest` | Marketplace image, as `Publisher:Offer:Sku:Version`. See [Finding an image URN](#finding-an-image-urn). |
 | `image_id` | `""` | Resource ID of a private managed image or an Azure Compute Gallery image version. |
 | `plan` | *unset* | Purchase plan for a Marketplace image that requires one. A hash accepting `name`, `product`, `publisher`, and `promotion_code`. |
 
-#### Virtual machine
+### Virtual machine
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -169,7 +261,7 @@ Set one of `image_urn` or `image_id`.
 | `use_fqdn_hostname` | `false` | Connect using the FQDN rather than the IP address. |
 | `store_deployment_credentials_in_state` | `true` | Persist the generated credentials in the Test Kitchen state file. |
 
-#### Disks
+### Disks
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -182,7 +274,7 @@ Set one of `image_urn` or `image_id`.
 
 All deployments use managed disks. Azure retired unmanaged disks on 31 March 2026.
 
-#### Networking
+### Networking
 
 | Option | Default | Description |
 | --- | --- | --- |
@@ -202,7 +294,54 @@ transport uses - 22 for SSH, 5985 and 5986 for WinRM - plus anything in
 Basic SKU public IP used to provide. To restrict the source, create your own
 security group and pass it as `nsg_id`.
 
-#### Retired settings
+### Resource group
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `azure_resource_group_name` | derived | Name of the resource group created for the run. |
+| `azure_resource_group_prefix` | `"kitchen-"` | Prefix for the generated resource group name. |
+| `azure_resource_group_suffix` | `""` | Suffix for the generated resource group name. |
+| `explicit_resource_group_name` | `nil` | Deploy into an existing resource group instead of creating one. |
+| `resource_group_tags` | `{}` | Tags applied to a resource group the driver creates. |
+| `destroy_explicit_resource_group` | `true` | Delete the explicit resource group on destroy. Set to `false` when deploying into a shared group. |
+| `destroy_explicit_resource_group_tags` | `true` | Remove the tags the driver added to an explicit resource group on destroy. |
+| `destroy_resource_group_contents` | `false` | Delete the resource group's contents rather than the group itself. |
+
+### Identity
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `system_assigned_identity` | `false` | Enable a system-assigned managed identity on the VM. |
+| `user_assigned_identities` | `[]` | Array of user-assigned managed identity resource IDs. |
+
+### Key Vault
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `secret_url` | `""` | URL of a Key Vault certificate to install on the VM. |
+| `vault_name` | `""` | Name of the Key Vault holding it. |
+| `vault_resource_group` | `""` | Resource group containing the vault. |
+
+### ARM templates
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `pre_deployment_template` | `""` | Path to an ARM template deployed before the VM. |
+| `pre_deployment_parameters` | `{}` | Parameters for the pre-deployment template. |
+| `post_deployment_template` | `""` | Path to an ARM template deployed after the VM. |
+| `post_deployment_parameters` | `{}` | Parameters for the post-deployment template. |
+
+### Environment and behaviour
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `azure_environment` | `"Azure"` | Cloud to target: `Azure`, `AzureUSGovernment`, `AzureChina`, `AzureGermanCloud`. See [Government and sovereign clouds](#government-and-sovereign-clouds). |
+| `boot_diagnostics_enabled` | `true` | Enable managed boot diagnostics on the VM. |
+| `winrm_powershell_script` | `false` | Custom PowerShell script used to configure WinRM. Windows only. |
+| `deployment_sleep` | `10` | Seconds to wait between polls of the deployment status. |
+| `azure_api_retries` | `5` | Number of times to retry a failed Azure API call. |
+
+### Retired settings
 
 These settings are still accepted so that an existing `kitchen.yml` keeps
 loading, but Azure retirements have made them inoperable. The driver logs a
@@ -216,631 +355,354 @@ warning and ignores them.
 | `existing_storage_account_blob_url` | OS disks are no longer placed in a storage account you supply. |
 | `existing_storage_account_container` | As above. |
 
-#### Resource group
+## Common setups
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `azure_resource_group_name` | derived | Name of the resource group created for the run. |
-| `azure_resource_group_prefix` | `"kitchen-"` | Prefix for the generated resource group name. |
-| `azure_resource_group_suffix` | `""` | Suffix for the generated resource group name. |
-| `explicit_resource_group_name` | `nil` | Deploy into an existing resource group instead of creating one. |
-| `resource_group_tags` | `{}` | Tags applied to a resource group the driver creates. |
-| `destroy_explicit_resource_group` | `true` | Delete the explicit resource group on destroy. Set to `false` when deploying into a shared group. |
-| `destroy_explicit_resource_group_tags` | `true` | Remove the tags the driver added to an explicit resource group on destroy. |
-| `destroy_resource_group_contents` | `false` | Delete the resource group's contents rather than the group itself. |
+Each of these shows only the parts that matter — combine them with the quick
+start's `kitchen.yml` as needed. Any `driver:` setting can be given at the top
+level or per platform under `platforms[].driver:`.
 
-#### Identity
+### Windows over WinRM
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `system_assigned_identity` | `false` | Enable a system-assigned managed identity on the VM. |
-| `user_assigned_identities` | `[]` | Array of user-assigned managed identity resource IDs. |
-
-#### Key Vault
-
-| Option | Default | Description |
-| --- | --- | --- |
-| `secret_url` | `""` | URL of a Key Vault certificate to install on the VM. |
-| `vault_name` | `""` | Name of the Key Vault holding it. |
-| `vault_resource_group` | `""` | Resource group containing the vault. |
-
-#### ARM templates
-
-| Option | Default | Description |
-| --- | --- | --- |
-| `pre_deployment_template` | `""` | Path to an ARM template deployed before the VM. |
-| `pre_deployment_parameters` | `{}` | Parameters for the pre-deployment template. |
-| `post_deployment_template` | `""` | Path to an ARM template deployed after the VM. |
-| `post_deployment_parameters` | `{}` | Parameters for the post-deployment template. |
-
-#### Environment and behaviour
-
-| Option | Default | Description |
-| --- | --- | --- |
-| `azure_environment` | `"Azure"` | Cloud to target: `Azure`, `AzureUSGovernment`, `AzureChina`, `AzureGermanCloud`. See [Support for Government and Sovereign Clouds](#support-for-government-and-sovereign-clouds-china-and-germany). |
-| `boot_diagnostics_enabled` | `true` | Enable managed boot diagnostics on the VM. |
-| `winrm_powershell_script` | `false` | Custom PowerShell script used to configure WinRM. Windows only. |
-| `deployment_sleep` | `10` | Seconds to wait between polls of the deployment status. |
-| `azure_api_retries` | `5` | Number of times to retry a failed Azure API call. |
-
-### kitchen.yml example 1 - Linux/Ubuntu
-
-Here's an example ```kitchen.yml``` file that provisions an Ubuntu Server, using Chef Zero as the provisioner and SSH as the transport. Note that if the key does not exist at the specified location, it will be created. Also note that if ```ssh_key``` is supplied, Test Kitchen will use this in preference to any default/configured passwords that are supplied.
+The VM enables itself for remote access at deployment time. This example also
+uses an [ephemeral OS
+disk](https://learn.microsoft.com/azure/virtual-machines/ephemeral-os-disks),
+which is faster and cheaper but lost when the VM is deallocated, and tags both
+the VM and its resource group.
 
 ```yaml
 ---
 driver:
   name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
+  subscription_id: <%= ENV["AZURE_SUBSCRIPTION_ID"] %>
+  location: westeurope
+  machine_size: Standard_DS2_v2
 
 provisioner:
-  name: chef_zero
+  name: cinc_infra
+
+verifier:
+  name: cinc_auditor
 
 platforms:
-  - name: ubuntu-14.04
+  - name: windows-2022
     driver:
-      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
-      vm_name: trusty-vm
-
-suites:
-  - name: default
-    attributes:
-```
-
-### Concurrent execution
-
-Concurrent execution of create/converge/destroy is supported via the --concurrency parameter. Each machine is created in its own Azure Resource Group so it has no shared lifecycle with the other machines in the test run. To take advantage of parallel execution use the following command:
-
-```kitchen test --concurrency <n>```
-
-Where n is the number of threads to create. Note that any failure (e.g. an AzureOperationError) will cause the whole test to fail, though resources already in creation will continue to be created.
-
-### kitchen.yml example 2 - Windows
-
-Here's a further example ```kitchen.yml``` file that will provision a Windows Server 2019 [smalldisk] instance, using WinRM as the transport. An [ephemeral os disk](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks) is used. The resource created in Azure will enable itself for remote access at deployment time (it does this by customizing the machine at provisioning time) and tags the Azure Resource Group with metadata using the ```resource_group_tags``` property. Notice that the ```vm_tags``` and ```resource_group_tags``` properties use a simple ```key : value``` structure per line:
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_DS2_v2'
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: windows2019
-    driver:
-      image_urn: MicrosoftWindowsServer:WindowsServer:2019-Datacenter-smalldisk:latest
+      image_urn: MicrosoftWindowsServer:WindowsServer:2022-Datacenter-smalldisk:latest
       use_ephemeral_osdisk: true
       resource_group_tags:
-        project: 'My Cool Project'
-        contact: 'me@somewhere.com'
+        project: My Cool Project
+        contact: me@somewhere.com
       vm_tags:
         my_tag: its value
         another_tag: its awesome value
     transport:
       name: winrm
+
 suites:
   - name: default
-    attributes:
 ```
 
-### kitchen.yml example 3 - "pre-deployment" ARM template
+### Running instances concurrently
 
-The following example introduces the ```pre_deployment_template``` and ```pre_deployment_parameters``` properties in the configuration file.
-You can use this capability to execute an ARM template containing Azure resources to provision before the system under test is created.
+Each machine is created in its own Azure resource group, so instances share no
+lifecycle and can be built in parallel:
 
-In the example the ARM template in the file ```predeploy.json``` would be executed with the parameters that are specified under ```pre_deployment_parameters```.
-These resources will be created in the same Azure Resource Group as the VM under test, and therefore will be destroyed when you type ```kitchen destroy```.
+```bash
+cinc kitchen test --concurrency 4
+```
+
+Any failure fails the whole run, though resources already being created will
+finish being created.
+
+### Deploying into an existing virtual network
+
+Set `vnet_id` and `subnet_id` to place the VM on a network that already exists,
+possibly in a different resource group. This is the usual setup when you reach
+the VM over ExpressRoute or a VPN rather than a public address.
 
 ```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-  pre_deployment_template: predeploy.json
-  pre_deployment_parameters:
-    test_parameter: 'This is a test.'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
 platforms:
-  - name: ubuntu-1404
+  - name: ubuntu-22.04
     driver:
       image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
+      vnet_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/my-infrastructure/providers/Microsoft.Network/virtualNetworks/my-vnet
+      subnet_id: my-subnet
+```
+
+No public IP address is assigned unless you also set `public_ip: true`. When
+the subnet sits behind a NAT gateway, or otherwise needs a Standard SKU
+address, add:
+
+```yaml
+      public_ip: true
+      public_ip_sku: Standard
+```
+
+Standard SKU public IPs are closed to inbound traffic unless a network security
+group allows it — see the note under [Networking](#networking).
+
+### Using a private image
+
+Set `image_id` to the resource ID of a managed image or an Azure Compute
+Gallery image version, in place of `image_urn`. The image must already exist.
+
+```yaml
+platforms:
+  - name: my-custom-image
+    driver:
+      image_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/my-images/providers/Microsoft.Compute/images/my-image
+```
+
+Everything created for the run, including the OS disk, is removed on
+`kitchen destroy`.
+
+> Deploying from a VHD URL in a storage account is no longer supported. Azure
+> retired unmanaged disks on 31 March 2026 — see [Retired
+> settings](#retired-settings).
+
+### Custom data and a larger OS disk
+
+`custom_data` takes either a string or a path to a file, and `os_disk_size_gb`
+grows the OS disk beyond the image's own size.
+
+```yaml
+platforms:
+  - name: ubuntu-22.04
+    driver:
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
+      custom_data: cloud-init.txt
+      os_disk_size_gb: 128
+```
+
+> Custom data is how WinRM gets enabled on non-Nano Windows images, so setting
+> `custom_data` yourself is not supported when using the WinRM transport.
+
+### Attaching data disks
+
+Each entry needs a `lun` and a `disk_size_gb`:
+
+```yaml
+platforms:
+  - name: windows-2022
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2022-Datacenter:latest
+      data_disks:
+        - lun: 0
+          disk_size_gb: 128
+        - lun: 1
+          disk_size_gb: 128
+        - lun: 2
+          disk_size_gb: 128
+      format_data_disks: true
+```
+
+`format_data_disks` runs a PowerShell script at first boot to initialize and
+format the disks as NTFS. It has no effect on Linux.
+
+### Managed identities
+
+Any combination of system-assigned and user-assigned identities can be enabled,
+and multiple user-assigned identities can be supplied. See the [managed
+identities
+documentation](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview).
+
+```yaml
+platforms:
+  - name: ubuntu-22.04
+    driver:
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
+      system_assigned_identity: true
+      user_assigned_identities:
+        - /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/test-kitchen-user/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-kitchen-user
+```
+
+### Installing a Key Vault certificate
+
+```yaml
+driver:
+  name: azurerm
+  subscription_id: <%= ENV["AZURE_SUBSCRIPTION_ID"] %>
+  location: centralus
+  machine_size: Standard_D2s_v3
+  secret_url: https://YOUR-VAULT.vault.azure.net/secrets/YOUR-SECRET/YOUR-VERSION
+  vault_name: YOUR-VAULT-NAME
+  vault_resource_group: YOUR-VAULT-RESOURCE-GROUP
+
+transport:
+  name: winrm
+  elevated: true
+
+provisioner:
+  name: cinc_infra
+
+platforms:
+  - name: windows-2022
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2022-Datacenter:latest
 
 suites:
   - name: default
-    run_list:
-      - recipe[kitchen-azurerm-demo::default]
-    attributes:
 ```
 
-Example predeploy.json:
+### ARM templates before and after the VM
+
+`pre_deployment_template` runs an ARM template before the system under test is
+created; `post_deployment_template` runs one after. Both deploy into the same
+resource group as the VM, so both are torn down by `kitchen destroy`.
+
+```yaml
+driver:
+  name: azurerm
+  subscription_id: <%= ENV["AZURE_SUBSCRIPTION_ID"] %>
+  location: westeurope
+  machine_size: Standard_D2s_v3
+  pre_deployment_template: predeploy.json
+  pre_deployment_parameters:
+    test_parameter: This is a test.
+  post_deployment_template: postdeploy.json
+  post_deployment_parameters:
+    test_parameter: This is a test.
+```
+
+A minimal `predeploy.json`:
 
 ```json
 {
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-      "test_parameter": {
-        "type": "string",
-        "defaultValue": ""
-      }
+    "test_parameter": {
+      "type": "string",
+      "defaultValue": ""
+    }
   },
-  "variables": {
-
-  },
-  "resources": [
-      {
-        "name": "uniqueinstancenamehere01",
-        "type": "Microsoft.Sql/servers",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "2014-04-01-preview",
-        "properties": {
-          "version": "12.0",
-          "administratorLogin": "azure",
-          "administratorLoginPassword": "P2ssw0rd"
-        }
-      }
-  ],
+  "variables": {},
+  "resources": [],
   "outputs": {
-      "parameter testing": {
-        "type": "string",
-        "value": "[parameters('test_parameter')]"
-      }
+    "parameter testing": {
+      "type": "string",
+      "value": "[parameters('test_parameter')]"
+    }
   }
 }
 ```
 
-### kitchen.yml example 4 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios)
-
-The following example introduces the ```vnet_id``` and ```subnet_id``` properties under "driver" in the configuration file. This can be applied at the top level, or per platform.
-You can use this capability to create the VM on an existing virtual network and subnet created in a different resource group.
-
-In this case, the public IP address is not used unless ```public_ip``` is set to ```true```
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
-      vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
-      subnet_id: subnet-10.1.0
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 5 - deploy VM to existing virtual network/subnet with a Standard SKU public IP (use for ExpressRoute/VPN scenarios)
-
-The following example introduces the ```vnet_id``` and ```subnet_id``` properties under "driver" in the configuration file. This can be applied at the top level, or per platform.
-You can use this capability to create the VM on an existing virtual network and subnet created in a different resource group.
-
-This enables scenarios that require a Standard SKU public IP resource, for example when a NAT gateway is present on the target subnet.
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
-      vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
-      subnet_id: subnet-10.1.0
-      public_ip: true
-      public_ip_sku: Standard
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 6 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with Private Managed Image
-
-This example is the same as above, but uses a private managed image to provision the vm.
-
-Note: The image must be available first. On deletion the disk and everything is removed.
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/RESGROUP/providers/Microsoft.Compute/images/IMAGENAME
-      vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
-      subnet_id: subnet-10.1.0
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 7 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with a private managed image
-
-This example a classic Custom VM Image (aka a VHD file) is used. As the Image VHD must be in the same storage account then the disk of the instance, the os disk is created in an existing image account.
-
-Note: When the resource group ís deleted, the os disk is left in the existing storage account blob. You must clean up manually.
-
-This example will:
-
-* use the customized image <https://yourstorageaccount.blob.core.windows.net/system/Microsoft.Compute/Images/images/Cent7_P4-osDisk.170dd1b7-7dc3-4496-b248-f47c49f63965.vhd> (can be built with packer)
-* set the disk url of the vm to <https://yourstorageaccount.blob.core.windows.net/vhds/osdisk-kitchen-XXXXX.vhd>
-* set the os type to linux
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Compute/images/Cent7_P4
-      vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
-      subnet_id: subnet-10.1.0
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 8 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with a private managed image, custom data and an extra large os disk
-
-This is the same as above, but uses custom data to customize the instance.
-
-Note: Custom data can be custom data or a file to custom data. Please also note that if you use winrm communication to non-nano windows servers custom data is not supported, as winrm is enabled via custom data.
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Compute/images/Cent7_P4
-      vnet_id: /subscriptions/b6e7eee9-YOUR-GUID-HERE-03ab624df016/resourceGroups/pendrica-infrastructure/providers/Microsoft.Network/virtualNetworks/pendrica-arm-vnet
-      subnet_id: subnet-10.1.0
-      os_disk_size_gb: 100
-      #custom_data: /tmp/customdata.txt
-      custom_data: |
-        #cloud-config
-        fqdn: myhostname
-        preserve_hostname: false
-        runcmd:
-          - yum install -y telnet
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 9 - Windows 2016 VM with additional data disks
-
-This example demonstrates how to add 3 additional Managed data disks to a Windows Server 2016 VM. Not supported with legacy (pre-managed disk) storage accounts.
-
-Note the availability of a `format_data_disks` option (default: `false`). When set to true, a PowerShell script will execute at first boot to initialize and format the disks with an NTFS filesystem. This option does not affect Linux machines.
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_F2s'
-
-provisioner:
-  name: chef_zero
-
-platforms:
-- name: windows2016-noformat
-  driver:
-    image_urn: MicrosoftWindowsServer:WindowsServer:2016-Datacenter:latest
-    data_disks:
-      - lun: 0
-        disk_size_gb: 128
-      - lun: 1
-        disk_size_gb: 128
-      - lun: 2
-        disk_size_gb: 128
-    # format_data_disks: false
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 10 - "post-deployment" ARM template with MSI authentication
-
-The following example introduces the ```post_deployment_template``` and ```post_deployment_parameters``` properties in the configuration file.
-You can use this capability to execute an ARM template containing Azure resources to provision after the system under test is created.
-
-In the example the ARM template in the file ```postdeploy.json``` would be executed with the parameters that are specified under ```post_deployment_parameters```.
-These resources will be created in the same Azure Resource Group as the VM under test, and therefore will be destroyed when you type ```kitchen destroy```.
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-  post_deployment_template: postdeploy.json
-  post_deployment_parameters:
-    test_parameter: 'This is a test.'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
-
-provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
-
-suites:
-  - name: default
-    attributes:
-```
-
-Example postdeploy.json to enable MSI extension on VM:
+A post-deployment template runs against the VM that was just created, so it can
+reference it — for example to attach an extension. Use the `vmName` the driver
+reports, and declare the dependency:
 
 ```json
-{
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vmName": {
-            "type": "String"
-        },
-        "location": {
-            "type": "String"
-        },
-        "msiExtensionName": {
-            "type": "String"
-        }
-    },
-    "resources": [
-        {
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[parameters('vmName')]",
-            "apiVersion": "2017-12-01",
-            "location": "[parameters('location')]",
-            "identity": {
-                "type": "systemAssigned"
-            }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat( parameters('vmName'), '/' , parameters('msiExtensionName') )]",
-            "apiVersion": "2017-12-01",
-            "location": "[parameters('location')]",
-            "properties": {
-                "publisher": "Microsoft.ManagedIdentity",
-                "type": "[parameters('msiExtensionName')]",
-                "typeHandlerVersion": "1.0",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                    "port": 50342
-                }
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
-            ]
-        }
-    ]
-}
+"dependsOn": [
+  "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+]
 ```
 
-### kitchen.yml example 11 - Enabling Managed Service Identities
+### Government and sovereign clouds
 
-This example demonstrates how to enable a System Assigned Identity and User Assigned Identities on a Kitchen VM.
-Any combination of System and User assigned identities may be enabled, and multiple User Assigned Identities can be supplied.
-
-See the [Managed identities for Azure resources](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) documentation for more information on using Managed Service Identities.
+Set `azure_environment` to target a cloud other than global Azure. Valid values
+are `Azure`, `AzureUSGovernment`, `AzureChina`, and `AzureGermanCloud`.
 
 ```yaml
 ---
 driver:
   name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'West Europe'
-  machine_size: 'Standard_D1'
-
-transport:
-  ssh_key: ~/.ssh/id_kitchen-azurerm
+  subscription_id: <%= ENV["AZURE_SUBSCRIPTION_ID"] %>
+  azure_environment: AzureUSGovernment
+  location: usgoviowa
+  machine_size: Standard_D2_v2
 
 provisioner:
-  name: chef_zero
-
-platforms:
-  - name: ubuntu-1404
-    driver:
-      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
-      system_assigned_identity: true
-      user_assigned_identities:
-        - /subscriptions/4801fa9d-YOUR-GUID-HERE-b265ff49ce21/resourcegroups/test-kitchen-user/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-kitchen-user
-
-suites:
-  - name: default
-    attributes:
-```
-
-### kitchen.yml example 12 - deploy VM with key vault certificate
-
-This following example introduces ```secret_url```, ```vault_name```, and ```vault_resource_group``` properties under "driver" in the configuration file. You can use this capability to create a VM with a specified key vault certificate.
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  location: 'CentralUS'
-  machine_size: 'Standard_D2s_v3'
-  secret_url: 'https://YOUR-SECRET-PATH'
-  vault_name: 'YOUR-VAULT-NAME'
-  vault_group_name: 'YOUR-VAULT-GROUP-NAME'
-transport:
-  name: winrm
-  elevated: true
-provisioner:
-  name: chef_zero
-platforms:
-  - name: win2012R2-sql2016
-    driver:
-      image_urn: MicrosoftSQLServer:SQL2016SP2-WS2012R2:SQLDEV:latest
-
-suites:
-  - name: default
-    attributes:
-```
-
-## Support for Government and Sovereign Clouds (China and Germany)
-
-Starting with v0.9.0 this driver has support for Azure Government and Sovereign Clouds via the use of the ```azure_environment``` setting. Valid Azure environments are ```Azure```, ```AzureUSGovernment```, ```AzureChina``` and ```AzureGermanCloud```
-
-### Example kitchen.yml for Azure US Government cloud
-
-```yaml
----
-driver:
-  name: azurerm
-  subscription_id: 'your-azure-subscription-id-here'
-  azure_environment: 'AzureUSGovernment'
-  location: 'US Gov Iowa'
-  machine_size: 'Standard_D2_v2_Promo'
-
-provisioner:
-  name: chef_zero
+  name: cinc_infra
 
 verifier:
-  name: inspec
+  name: cinc_auditor
 
 platforms:
-- name: ubuntu1604
-  driver:
-    image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
-  transport:
-    ssh_key: ~/.ssh/id_kitchen-azurerm
+  - name: ubuntu-22.04
+    driver:
+      image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
+    transport:
+      ssh_key: ~/.ssh/id_kitchen-azurerm
 
 suites:
   - name: default
 ```
 
-### How to retrieve the image_urn
+## Finding an image URN
 
-You can use the azure (azure-cli) command line tools to interrogate for the Urn. All 4 parts of the Urn must be specified, though the last part can be changed to "latest" to indicate you always wish to provision the latest operating system and patches.
+An `image_urn` has four parts — `Publisher:Offer:Sku:Version`. All four must be
+given, though the last can be `latest` to always take the newest version.
 
-```$ azure vm image list "West Europe" Canonical UbuntuServer```
-
-This will return a list like the following, from which you can derive the Urn.
-*this list has been shortened for readability*
+List the offers a publisher has in your region:
 
 ```bash
-data:    Publisher  Offer         Sku                Version          Location    Urn
-data:    ---------  ------------  -----------------  ---------------  ----------  --------------------------------------------------------
-data:    Canonical  UbuntuServer  12.04.5-LTS        12.04.201507301  westeurope  Canonical:UbuntuServer:12.04.5-LTS:12.04.201507301
-data:    Canonical  UbuntuServer  12.04.5-LTS        12.04.201507311  westeurope  Canonical:UbuntuServer:12.04.5-LTS:12.04.201507311
-data:    Canonical  UbuntuServer  12.04.5-LTS        12.04.201508190  westeurope  Canonical:UbuntuServer:12.04.5-LTS:12.04.201508190
-data:    Canonical  UbuntuServer  12.04.5-LTS        12.04.201509060  westeurope  Canonical:UbuntuServer:12.04.5-LTS:12.04.201509060
-data:    Canonical  UbuntuServer  12.04.5-LTS        12.04.201509090  westeurope  Canonical:UbuntuServer:12.04.5-LTS:12.04.201509090
-data:    Canonical  UbuntuServer  12.10              12.10.201212180  westeurope  Canonical:UbuntuServer:12.10:12.10.201212180
-data:    Canonical  UbuntuServer  14.04.3-DAILY-LTS  14.04.201509110  westeurope  Canonical:UbuntuServer:14.04.3-DAILY-LTS:14.04.201509110
-data:    Canonical  UbuntuServer  14.04.3-DAILY-LTS  14.04.201509160  westeurope  Canonical:UbuntuServer:14.04.3-DAILY-LTS:14.04.201509160
-data:    Canonical  UbuntuServer  14.04.3-DAILY-LTS  14.04.201509220  westeurope  Canonical:UbuntuServer:14.04.3-DAILY-LTS:14.04.201509220
-data:    Canonical  UbuntuServer  14.04.3-LTS        14.04.201508050  westeurope  Canonical:UbuntuServer:14.04.3-LTS:14.04.201508050
-data:    Canonical  UbuntuServer  14.04.3-LTS        14.04.201509080  westeurope  Canonical:UbuntuServer:14.04.3-LTS:14.04.201509080
-data:    Canonical  UbuntuServer  15.04              15.04.201506161  westeurope  Canonical:UbuntuServer:15.04:15.04.201506161
-data:    Canonical  UbuntuServer  15.04              15.04.201507070  westeurope  Canonical:UbuntuServer:15.04:15.04.201507070
-data:    Canonical  UbuntuServer  15.04              15.04.201507220  westeurope  Canonical:UbuntuServer:15.04:15.04.201507220
-data:    Canonical  UbuntuServer  15.04              15.04.201507280  westeurope  Canonical:UbuntuServer:15.04:15.04.201507280
-data:    Canonical  UbuntuServer  15.10-DAILY        15.10.201509170  westeurope  Canonical:UbuntuServer:15.10-DAILY:15.10.201509170
-data:    Canonical  UbuntuServer  15.10-DAILY        15.10.201509180  westeurope  Canonical:UbuntuServer:15.10-DAILY:15.10.201509180
-data:    Canonical  UbuntuServer  15.10-DAILY        15.10.201509190  westeurope  Canonical:UbuntuServer:15.10-DAILY:15.10.201509190
-data:    Canonical  UbuntuServer  15.10-DAILY        15.10.201509210  westeurope  Canonical:UbuntuServer:15.10-DAILY:15.10.201509210
-data:    Canonical  UbuntuServer  15.10-DAILY        15.10.201509220  westeurope  Canonical:UbuntuServer:15.10-DAILY:15.10.201509220
-info:    vm image list command OK
+az vm image list --location westeurope --publisher Canonical \
+  --all --output table
 ```
+
+```text
+Architecture  Offer                            Publisher  Sku               Version         Urn
+------------  -------------------------------  ---------  ----------------  --------------  ----------------------------------------------------------------------------
+x64           0001-com-ubuntu-server-jammy     Canonical  22_04-lts-gen2    22.04.202401161 Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202401161
+x64           0001-com-ubuntu-server-noble     Canonical  24_04-lts-gen2    24.04.202404230 Canonical:0001-com-ubuntu-server-noble:24_04-lts-gen2:24.04.202404230
+```
+
+Take the `Urn` column and replace the version with `latest` if you want the
+newest each run. Drop `--all` for a much shorter list of current images, and
+add `--offer` to narrow further.
+
+## Troubleshooting
+
+**`kitchen create` fails immediately with an authentication error.**
+Check which method is actually being picked — see [Authentication](#authentication).
+The environment wins over `~/.azure/credentials`, so a stale `AZURE_CLIENT_ID`
+exported in your shell will silently override the file. Confirm the service
+principal still has Contributor on the subscription in `subscription_id`.
+
+**The credentials file is ignored.**
+It must be saved as UTF-8, and the section header is the bare subscription ID
+in square brackets, with no quotes.
+
+**The deployment succeeds but Test Kitchen cannot connect.**
+Almost always the network. If you set `public_ip: false`, you need
+ExpressRoute, a VPN, or a jump host to reach the VM at all. If you have a
+public IP, remember Standard SKU addresses are closed by default: the driver
+creates a security group opening your transport's port only when it creates the
+public IP *and* you have not supplied `nsg_id`. Supply `open_ports` for anything
+extra.
+
+**`The requested size for resource is currently not available in location`.**
+The `machine_size` is not offered in that region, or your subscription has no
+quota for it. `az vm list-skus --location westeurope --size Standard_D --output table`
+shows what is available.
+
+**A Key Vault certificate is not installed and no error is raised.**
+Check the option name. It is `vault_resource_group` — `vault_group_name` is not
+a real setting and is silently ignored.
+
+**An option in my `kitchen.yml` has no effect.**
+Check it against [Retired settings](#retired-settings). Those are still accepted
+so old configuration keeps loading, but the driver logs a warning and ignores
+them.
+
+**Resources are left behind after a failed run.**
+A `kitchen test` that fails partway can leave the resource group in place.
+`cinc kitchen destroy` removes it. If you deployed into an existing group with
+`explicit_resource_group_name` and `destroy_explicit_resource_group: false`,
+nothing is deleted by design — clean up in the portal.
 
 ## Using with Chef
 
 This driver is not tied to Cinc. It provisions Azure resources and does not
-itself install either distribution — that is the provisioner's job. The examples
-above use Cinc Workstation and the `cinc_infra` provisioner; with
-[Chef Workstation](https://www.chef.io/downloads/tools/workstation) run `kitchen`
-instead of `cinc kitchen` and use `chef_infra` instead of `cinc_infra`:
+itself install either distribution — that is the provisioner's job. The
+examples above use Cinc Workstation and the `cinc_infra` provisioner; with
+[Chef Workstation](https://www.chef.io/downloads/tools/workstation) run
+`kitchen` instead of `cinc kitchen`, and substitute the plugin names:
+
+| Cinc | Chef |
+| --- | --- |
+| `cinc kitchen test` | `kitchen test` |
+| `cinc_infra` provisioner | `chef_infra` provisioner |
+| `cinc_auditor` verifier | `inspec` verifier |
 
 ```yaml
 provisioner:


### PR DESCRIPTION
## Why

The option reference here is genuinely good — every one of the 47 driver options is documented with a default and a description. The *structure* around it was the problem:

- no `## Requirements` section and no Contents nav
- "Quick-start" was installation and service-principal setup, not a quick start
- **twelve** numbered examples, several near-identical, with titles like *"kitchen.yml example 6 - deploy VM to existing virtual network/subnet (use for ExpressRoute/VPN scenarios) with Private Managed Image"*
- no troubleshooting
- it claimed to be Cinc-first while every example used `chef_zero`

## What changed

Restructured to the path a new user actually takes: **Requirements → Installation → Quick start (4 steps) → Authentication → Configuration reference → Common setups → Finding an image URN → Troubleshooting → Using with Chef**.

**The option tables are preserved verbatim.** Only their heading level changed, and `Retired settings` moved to the end of the reference instead of sitting between Networking and Resource group. The twelve numbered examples become ten task-named sections ("Windows over WinRM", "Attaching data disks", "Installing a Key Vault certificate"), which is why the file shrinks by ~140 lines while *gaining* Requirements, Contents, and Troubleshooting.

## Bugs fixed

**Example 12 had the wrong option name.** It used `vault_group_name`; the real setting is `vault_resource_group`:

```
$ grep -n 'vault' lib/kitchen/driver/azurerm.rb
204:      default_config(:vault_name) do |_config|
208:      default_config(:vault_resource_group) do |_config|
```

Anyone copying that example got a silently ignored key and no certificate on the VM. Fixed, and added to troubleshooting since the failure is invisible.

**"Using with Chef" contradicted every example.** It read "The examples above use Cinc Workstation and the `cinc_infra` provisioner" — but there were 13 uses of `chef_zero` and 2 of `cinc_infra`, both inside that section. Examples now use `cinc_infra`/`cinc_auditor`, so the claim is true, and the section gained a command-mapping table.

**Example 7's prose described a retired workflow.** It talked about VHD files, storage accounts, `os_type`, and manual blob cleanup — all things the README's own *Retired settings* table says are ignored. Its YAML had already been quietly updated to `image_id`, leaving prose and code disagreeing, and duplicating example 6. Merged into one "Using a private image" section that points at Retired settings.

**The image URN instructions used a dead CLI.** `azure vm image list` is the pre-2017 Azure CLI, with Ubuntu 12.04/15.04 sample output. Now `az vm image list` with current output and an explanation of the four URN parts.

**Stale example values.** Platform names `ubuntu-14.04`/`ubuntu-1404`/`trusty-vm` paired with a Jammy image URN, and the retired `Standard_D1` machine size.

## Verification

```
declared options: 47   missing from README: none
broken anchors: none
chef_zero remaining: 0   cinc_infra: 6
```

```
$ npx markdownlint-cli2 README.md
Summary: 0 issues in 0 files
```

Docs-only — no `lib/` or `spec/` files touched. The one remaining `vault_group_name` occurrence is the troubleshooting entry explaining that it is *not* a real setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)