### PR TITLE
fix: accept a full resource id for subnet_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ All deployments use managed disks. Azure retired unmanaged disks on 31 March 202
 | Option | Default | Description |
 | --- | --- | --- |
 | `vnet_id` | `""` | Resource ID of an existing virtual network. Leave unset to create one. |
-| `subnet_id` | `""` | Name of the subnet within `vnet_id`. |
+| `subnet_id` | `""` | Subnet to attach to: either its name within `vnet_id`, or its full resource ID. |
 | `nic_name` | `""` | Name of an existing network interface to attach. |
 | `public_ip` | `false` | Assign a public IP address. Required unless you reach the VM over ExpressRoute or a VPN. |
 | `public_ip_sku` | `"Standard"` | Public IP SKU. Azure retired the `Basic` SKU on 30 September 2025. |
@@ -426,6 +426,13 @@ platforms:
       image_urn: Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest
       vnet_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/my-infrastructure/providers/Microsoft.Network/virtualNetworks/my-vnet
       subnet_id: my-subnet
+```
+
+`subnet_id` also accepts a full subnet resource ID, which is useful when the
+subnet lives somewhere other than `vnet_id`:
+
+```yaml
+      subnet_id: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/my-infrastructure/providers/Microsoft.Network/virtualNetworks/my-vnet/subnets/my-subnet
 ```
 
 No public IP address is assigned unless you also set `public_ip: true`. When

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -921,11 +921,28 @@ module Kitchen
           info "Using custom vnet: #{config[:vnet_id]}"
           virtual_machine_deployment_template_file("internal.erb", data.merge(
             vnet_id: config[:vnet_id],
-            subnet_id: config[:subnet_id],
+            subnet_ref: subnet_reference,
             public_ip: config[:public_ip],
             public_ip_sku: config[:public_ip_sku]
           ))
         end
+      end
+
+      # Resource id of the subnet the network interface attaches to.
+      #
+      # +subnet_id+ has always held the subnet's *name*, resolved against
+      # +vnet_id+. The setting is named like a resource id and sits directly
+      # beside +vnet_id+, which really is one, so supplying a full subnet
+      # resource id is an easy mistake to make - and it used to be appended to
+      # the vnet id, leaving ARM to reject a path that appears nowhere in the
+      # user's kitchen.yml. Both spellings are accepted.
+      #
+      # @return [String]
+      def subnet_reference
+        subnet = config[:subnet_id].to_s
+        return subnet if subnet.start_with?("/subscriptions/")
+
+        "#{config[:vnet_id]}/subnets/#{subnet}"
       end
 
       # Warns about settings that Azure retirements have made inoperable.

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -37,6 +37,41 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
         expect(driver.virtual_machine_deployment_template).to include("subnet-1")
       end
 
+      it "resolves a subnet name against the configured vnet" do
+        expect(subnet_ref_of(driver))
+          .to eq("/subscriptions/x/resourceGroups/y/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet-1")
+      end
+
+      # `subnet_id` is named like a resource id and sits next to `vnet_id`,
+      # which is one. Supplying a full subnet resource id used to be appended
+      # to the vnet id, and ARM answered with an opaque
+      # "InvalidJsonReferenceFormat" naming a path that appeared nowhere in
+      # the user's configuration.
+      context "when subnet_id is a full resource id" do
+        let(:subnet_resource_id) do
+          "/subscriptions/x/resourceGroups/y/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet-1"
+        end
+        let(:config) { super().merge(subnet_id: subnet_resource_id) }
+
+        it "uses it as-is rather than appending it to the vnet id" do
+          expect(subnet_ref_of(driver)).to eq(subnet_resource_id)
+        end
+
+        it "does not produce a doubled subnets path" do
+          expect(driver.virtual_machine_deployment_template).not_to include("subnets//subscriptions")
+        end
+
+        it "still renders valid JSON" do
+          expect(driver.virtual_machine_deployment_template).to be_a_valid_arm_template
+        end
+
+        it "resolves a subnet in a different resource group than the vnet" do
+          elsewhere = "/subscriptions/x/resourceGroups/other/providers/Microsoft.Network/virtualNetworks/v2/subnets/s2"
+          other = build_driver(transport:, platform_name:, **config.merge(subnet_id: elsewhere))
+          expect(subnet_ref_of(other)).to eq(elsewhere)
+        end
+      end
+
       it "creates no public IP resource by default" do
         expect(resource_types(rendered_template(driver))).not_to include("Microsoft.Network/publicIPAddresses")
       end
@@ -624,5 +659,14 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
   # @return [Array<String>] the type of every resource in the template.
   def resource_types(template)
     template["resources"].map { |resource| resource["type"] }
+  end
+
+  # The subnet the network interface is wired to, read out of the rendered
+  # template rather than from the driver's internals.
+  #
+  # @param driver [Kitchen::Driver::Azurerm]
+  # @return [String]
+  def subnet_ref_of(driver)
+    rendered_template(driver).dig("variables", "subnetRef")
   end
 end

--- a/templates/internal.erb
+++ b/templates/internal.erb
@@ -176,13 +176,12 @@
         "location": "[parameters('location')]",
         "nicName": "[parameters('nicName')]",
         "nsgName": "[concat(parameters('nicName'), '-nsg')]",
-        "subnetName": "<%= subnet_id %>",
         "publicIPAddressName": "publicip",
         "vmName": "[parameters('vmName')]",
         "vmSize": "[parameters('vmSize')]",
         "vmIdentityType": "[if(parameters('systemAssignedIdentity'), if(empty(parameters('userAssignedIdentities')), 'SystemAssigned', 'SystemAssigned, UserAssigned'), if(empty(parameters('userAssignedIdentities')), 'None', 'UserAssigned'))]",
         "vnetID": "<%= vnet_id %>",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+        "subnetRef": "<%= subnet_ref %>"
     },
     "resources": [
         {


### PR DESCRIPTION
## The problem

`subnet_id` holds the subnet's **name**, resolved against `vnet_id`. But it is *named* like a resource id, sits directly beside `vnet_id` — which really is one — and every other id-shaped setting in the driver (`vnet_id`, `nsg_id`, `image_id`) takes a full resource id.

So supplying a full subnet resource id is an easy mistake to make. I made it myself while integration-testing the driver against a real subscription. It was appended to the vnet id, and ARM rejected a path that appears nowhere in the user's `kitchen.yml`:

```
InvalidJsonReferenceFormat: Reference Id /subscriptions/.../virtualNetworks/itest-vnet/subnets//subscriptions/.../virtualNetworks/itest-vnet/subnets/itest-subnet
is not formatted correctly. The Id is expected to reference resources of type virtualNetworks/subnets.
Path properties.ipConfigurations[0].properties.subnet.
```

Nothing in that message points back at the setting that caused it.

## The fix

Accept either spelling:

- a value starting with `/subscriptions/` is used as the subnet reference as-is
- anything else is resolved against `vnet_id`, exactly as before

Using a full id also allows a subnet in a **different resource group** to the vnet, which the concatenation could never express.

The reference is now resolved in Ruby rather than by an ARM `concat()` over two template variables, so the rendered template names the subnet it will actually use rather than an expression that only resolves inside Azure.

## Testing

- `bundle exec rspec` — **605 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- Verified end to end against a **real Azure subscription**, deploying Ubuntu 22.04 into a pre-existing vnet in `eastus`, with two suites that differ only in how the subnet is named:

  | `subnet_id` | before | after |
  | --- | --- | --- |
  | `itest-subnet` (name) | converges | converges |
  | `/subscriptions/.../subnets/itest-subnet` (id) | **`InvalidJsonReferenceFormat`** | converges |

Backwards compatible: the documented spelling is unchanged and still takes the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)