### PR TITLE
fix: wait for an in-flight deployment instead of abandoning create

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -280,14 +280,8 @@ module Kitchen
 
           run_deployment(state, "post-deploy", post_deployment(config[:post_deployment_template], config[:post_deployment_parameters])) if File.file?(config[:post_deployment_template])
         rescue Azure::OperationError => operation_error
-          rest_error = operation_error.body["error"]
-          if operation_error.code == "DeploymentActive"
-            info "Deployment for resource group #{state[:azure_resource_group_name]} is ongoing."
-            info "If you need to change the deployment template you'll need to rerun `kitchen create` for this instance."
-          else
-            info rest_error
-            raise operation_error
-          end
+          info operation_error.body["error"]
+          raise operation_error
         end
 
         state[:hostname] = resolve_hostname(state, deployment_parameters["nicName"])
@@ -369,7 +363,18 @@ module Kitchen
       def run_deployment(state, prefix, deployment)
         name = "#{prefix}-#{state[:uuid]}"
         info "Creating deployment: #{name}"
-        create_deployment_async(state[:azure_resource_group_name], name, deployment)
+        begin
+          create_deployment_async(state[:azure_resource_group_name], name, deployment)
+        rescue Azure::OperationError => operation_error
+          raise unless operation_error.code == "DeploymentActive"
+
+          # An interrupted `kitchen create` leaves its deployment running in
+          # Azure. Wait for that one instead of abandoning the rest of create:
+          # the deployment already in flight is the one we wanted, and the
+          # steps after this still have to run for the instance to be usable.
+          info "Deployment #{name} is already running; waiting for it rather than submitting it again."
+          info "To deploy a changed template, run `kitchen destroy` for this instance first."
+        end
         follow_deployment_until_end_state(state[:azure_resource_group_name], name)
       end
 

--- a/spec/unit/kitchen/driver/azurerm/create_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/create_spec.rb
@@ -405,25 +405,64 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
     end
   end
 
+  # An interrupted `kitchen create` leaves its deployment running in Azure.
+  # Re-running it gets DeploymentActive back from ARM, which used to abandon
+  # the rest of create: the credentials were never written to state, and the
+  # instance was reported as created anyway. The transport then failed with a
+  # bare "SSH session could not be established" naming nothing that led to it.
   describe "when a deployment is already running" do
     before do
       allow(arm_client).to receive(:create_deployment)
         .and_raise(azure_operation_error(code: "DeploymentActive"))
     end
 
-    it "does not raise, because the existing deployment will finish on its own" do
+    it "does not raise, because the existing deployment is the one we wanted" do
       expect { driver.create(state) }.not_to raise_error
     end
 
-    it "tells the user what happened" do
+    it "says it is waiting rather than that it gave up" do
       allow(Kitchen.logger).to receive(:info)
       driver.create(state)
-      expect(Kitchen.logger).to have_received(:info).with(/Deployment for resource group .* is ongoing/)
+      expect(Kitchen.logger).to have_received(:info).with(/already running.*waiting for it/i)
+    end
+
+    it "waits for the running deployment to reach an end state" do
+      driver.create(state)
+      expect(arm_client).to have_received(:deployment).with(anything, /\Adeploy-/)
     end
 
     it "still resolves a hostname" do
       driver.create(state)
       expect(state[:hostname]).to eq("40.121.0.1")
+    end
+
+    # The whole point. Without this the instance is unreachable, and for a
+    # password-authenticated instance the generated password is lost for good:
+    # the next run generates a different one that was never applied to the VM.
+    it "stores the deployment credentials" do
+      driver.create(state)
+      expect(state[:username]).to eq("azure")
+    end
+
+    it "stores the generated password when there is no ssh key" do
+      driver = build_driver(transport: transport_double(ssh_key: nil))
+      stub_arm_client(driver, arm_client:)
+      record_deployments(arm_client)
+      allow(arm_client).to receive(:create_deployment)
+        .and_raise(azure_operation_error(code: "DeploymentActive"))
+
+      driver.create(state)
+
+      expect(state[:password]).not_to be_nil
+    end
+
+    it "surfaces a failure in the deployment it waited for" do
+      allow(arm_client).to receive(:deployment).and_return(deployment_response("Failed"))
+      allow(arm_client).to receive(:deployment_operations)
+        .and_return([deployment_operation(provisioning_state: "Failed", status_code: "Conflict",
+          status_message: "quota exceeded")])
+
+      expect { driver.create(state) }.to raise_error(/quota exceeded/)
     end
   end
 


### PR DESCRIPTION
## The problem

An interrupted `kitchen create` leaves its ARM deployment running in Azure. Re-running it gets `DeploymentActive` back from ARM, which was rescued at the top of `create`:

```ruby
begin
  run_deployment(state, "deploy", deployment(deployment_parameters))
  store_deployment_credentials(state, deployment_parameters)   # <- never reached
  ...
rescue Azure::OperationError => operation_error
  if operation_error.code == "DeploymentActive"
    info "Deployment for resource group ... is ongoing."
```

The rescue skips the rest of the `begin` block — **including `store_deployment_credentials`** — and then execution falls through to `state[:hostname] = resolve_hostname(...)` and returns normally.

So `create` reports success:

```
Deployment for resource group kitchen-itest-explicit is ongoing.
If you need to change the deployment template you'll need to rerun `kitchen create` for this instance.
IP Address is: 40.117.251.130 [...]
Finished creating <explicitrg-ubuntu2204> (0m1.95s).
```

…having written **no `username` and no `password`** into state. The transport has nothing to authenticate with, and the very next action fails with:

```
Converge failed on instance <explicitrg-ubuntu2204>.
Message: SSH session could not be established
```

which names nothing that led to it. The log line even tells the user to rerun `kitchen create`, but the action was marked successful, so `kitchen test` walks straight into that error instead.

For a **password-authenticated** instance it is worse than confusing. The generated password is lost, and the next run generates a *different* random password that was never applied to the VM — the instance can never be reached again.

It also resolves the hostname of a VM that may not exist yet: note the 1.95s "Finished creating" above, while the deployment was still running.

## The fix

Handle `DeploymentActive` where the deployment is actually submitted, in `run_deployment`:

```ruby
begin
  create_deployment_async(state[:azure_resource_group_name], name, deployment)
rescue Azure::OperationError => operation_error
  raise unless operation_error.code == "DeploymentActive"

  info "Deployment #{name} is already running; waiting for it rather than submitting it again."
  info "To deploy a changed template, run `kitchen destroy` for this instance first."
end
follow_deployment_until_end_state(state[:azure_resource_group_name], name)
```

The deployment already in flight *is* the one we wanted, so wait for it and let the rest of `create` run normally. Credentials get stored, and the hostname is resolved after the VM really exists. A failure in the deployment we waited for is now reported like any other rather than silently swallowed.

## Testing

- `bundle exec rspec` — **604 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: waiting for the running deployment, storing the username, storing the generated password when there is no SSH key, and surfacing a failure in the deployment that was waited for.

Reproduced and verified against a **real Azure subscription**. A `kitchen create` was killed mid-deployment, leaving `deploy-c2f4caf1d4d79d25` in state `Running` in Azure, then re-run:

**Before** — create "succeeds" in 1.95s, state has no `username`, converge dies with `SSH session could not be established`.

**After:**
```
Creating deployment: deploy-c2f4caf1d4d79d25
Deployment deploy-c2f4caf1d4d79d25 is already running; waiting for it rather than submitting it again.
To deploy a changed template, run `kitchen destroy` for this instance first.
Resource Microsoft.Compute/virtualMachines 'tk-c2f4caf1d4d7' provisioning status is Running
Resource Template deployment reached end state of 'Succeeded'.
IP Address is: 20.51.193.88
Finished creating <explicitrg-ubuntu2204> (0m12.23s).
```

State now contains `username: azure`, and `kitchen converge` against the same instance succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)