### PR TITLE
fix: fail the run when a deployment does not succeed

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -663,10 +663,18 @@ module Kitchen
         end
 
         info "Resource Template deployment reached end state of '#{deployment_provisioning_state}'."
-        show_failed_operations(resource_group, deployment_name) if deployment_provisioning_state == "Failed"
+        return if deployment_provisioning_state == "Succeeded"
+
+        show_failed_operations(resource_group, deployment_name)
+        raise "Deployment '#{deployment_name}' in resource group '#{resource_group}' " \
+              "ended in state '#{deployment_provisioning_state}'."
       end
 
       # Raises with the status messages of every failed operation in a deployment.
+      #
+      # Returns quietly when no single operation reported a failure, leaving
+      # the caller to raise: a deployment can fail without one, and its own
+      # provisioning state is the authority on whether it worked.
       #
       # @param resource_group [String] the resource group name.
       # @param deployment_name [String] the deployment name.

--- a/spec/unit/kitchen/driver/azurerm/deployment_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/deployment_spec.rb
@@ -138,9 +138,27 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
     end
 
     %w{Canceled Deleted Succeeded}.each do |state|
-      it "treats #{state} as terminal" do
+      it "treats #{state} as terminal, rather than polling forever" do
         allow(arm_client).to receive(:deployment).and_return(deployment_response(state))
-        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
+        driver.follow_deployment_until_end_state("rg", "deploy-1")
+      rescue RuntimeError
+        # Terminal but unsuccessful states raise; the point here is that the
+        # poll loop ends at all.
+      end
+    end
+
+    # Azure has four terminal states and only one of them means the machine
+    # exists. Canceled and Deleted were treated exactly like Succeeded, so
+    # create carried on and handed the transport a hostname for a VM that was
+    # never built.
+    %w{Canceled Deleted}.each do |state|
+      context "when the deployment ends as #{state}" do
+        let(:arm_client) { arm_client_double(deployment: deployment_response(state), deployment_operations: []) }
+
+        it "raises rather than reporting success" do
+          expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }
+            .to raise_error(/deploy-1.*#{state}/)
+        end
       end
     end
 
@@ -170,9 +188,19 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployments" do
           .to raise_error(/first problem.*second problem/m)
       end
 
-      it "does not raise when every operation reported OK" do
+      # A deployment can fail without any single operation reporting a
+      # non-OK status - a preflight rejection, or a failure Azure records
+      # against the deployment rather than an operation. Returning quietly
+      # here reported the failed deployment as a successful create.
+      it "still raises when no individual operation reported a failure" do
         allow(arm_client).to receive(:deployment_operations).and_return([deployment_operation(status_code: "OK")])
-        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.not_to raise_error
+        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }
+          .to raise_error(/deploy-1.*Failed/)
+      end
+
+      it "names the resource group it was deploying into" do
+        allow(arm_client).to receive(:deployment_operations).and_return([])
+        expect { driver.follow_deployment_until_end_state("rg", "deploy-1") }.to raise_error(/rg/)
       end
     end
   end


### PR DESCRIPTION
## The problem

Azure has four terminal deployment states and **only one of them means the machine exists**:

```ruby
end_provisioning_states = %w{Canceled Failed Deleted Succeeded}
...
info "Resource Template deployment reached end state of '#{deployment_provisioning_state}'."
show_failed_operations(resource_group, deployment_name) if deployment_provisioning_state == "Failed"
```

`Canceled` and `Deleted` were treated exactly like `Succeeded`. And `Failed` only raised if some *individual operation* reported a non-OK status code — `show_failed_operations` returns quietly when `failures.empty?` — but a deployment can fail without one (a preflight rejection, or a failure Azure records against the deployment itself).

In each of those cases `create` carried straight on to `state[:hostname] = resolve_hostname(...)` and reported the instance as created.

### Reproduced against a real subscription

Cancelling a deployment mid-flight is enough:

```
Creating deployment: deploy-9f48e8eec16f0a92
Resource Template deployment reached end state of 'Canceled'.
IP Address is: 20.42.46.181 [kitchen-9f48e8eec16f0a92.eastus.cloudapp.azure.com]
Finished creating <tags-ubuntu2204> (0m14.08s).
KITCHEN_EXIT=0
```

Exit status **0**. And there is no virtual machine:

```
$ az vm list -g kitchen-tags-ubuntu2204-20260823T062335 --query "length(@)"
0
$ az resource list -g ... --query "[].type" -o tsv
Microsoft.Network/networkSecurityGroups
Microsoft.Network/publicIPAddresses
Microsoft.Network/virtualNetworks
```

Only the network scaffolding was built, yet Test Kitchen reported a created instance and handed the transport a public IP that nothing is listening on. In CI this turns an infrastructure failure into a confusing transport timeout much later in the run — or, if a later step tolerates it, into a green build that tested nothing.

## The fix

Treat the deployment's own provisioning state as the authority on whether it worked:

```ruby
return if deployment_provisioning_state == "Succeeded"

show_failed_operations(resource_group, deployment_name)
raise "Deployment '#{deployment_name}' in resource group '#{resource_group}' " \
      "ended in state '#{deployment_provisioning_state}'."
```

Failing operations are still reported when Azure attributed the failure to any — that message is the more useful one, so it wins. The generic raise is the backstop for when there is no per-operation detail, and names the deployment, its resource group, and the state it ended in.

## Testing

- `bundle exec rspec` — **603 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover `Canceled`, `Deleted`, and a `Failed` deployment whose operations all report OK. The existing "treats X as terminal" specs are kept — they pin down that the poll loop *ends* — but no longer assert that an unsuccessful state passes silently.

Re-ran the identical cancellation experiment against the fix:

```
Resource Template deployment reached end state of 'Canceled'.
>>>>>> Failed to complete #create action: [{"status" => "Failed", "error" => {"code" => "DeploymentCanceled",
       "target" => ".../publicIPAddresses/publicip", "message" => "The deployment was canceled. ..."}}
...
KITCHEN_EXIT=20
```

Fails loudly, with Azure's own reason, instead of silently succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)