### PR TITLE
fix: keep a generated vm_name from ending on its prefix separator

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -458,20 +458,23 @@ module Kitchen
       # The VM name to use, either the configured one or one generated from
       # +vm_prefix+ plus part of the instance uuid.
       #
-      # The generated name is truncated to {MAX_VM_NAME_LENGTH} so that a
-      # +vm_prefix+ longer than the documented three characters still yields a
-      # name Azure will accept.
+      # The prefix is capped one character short of {MAX_VM_NAME_LENGTH} so
+      # that a +vm_prefix+ longer than the documented three characters still
+      # yields a name Azure will accept. Leaving room for at least one uuid
+      # character does two things: it keeps some entropy in every generated
+      # name, and it guarantees the name ends with one, because a prefix that
+      # filled the whole budget could end on the separator it was written
+      # with. Azure rejects that outright - both for the VM and for the
+      # network interface named after it, which must end with a word
+      # character.
       #
       # @param state [Hash] instance state, must already have a +:uuid+.
       # @return [String]
       def generated_vm_name(state)
         return config[:vm_name] if config[:vm_name]
 
-        prefix = config[:vm_prefix].to_s
-        remaining = MAX_VM_NAME_LENGTH - prefix.length
-        return prefix[0, MAX_VM_NAME_LENGTH] if remaining <= 0
-
-        "#{prefix}#{state[:uuid][0, remaining]}"
+        prefix = config[:vm_prefix].to_s[0, MAX_VM_NAME_LENGTH - 1]
+        "#{prefix}#{state[:uuid][0, MAX_VM_NAME_LENGTH - prefix.length]}"
       end
 
       # Name of the resource group this instance deploys into.

--- a/spec/unit/kitchen/driver/azurerm/state_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/state_spec.rb
@@ -91,6 +91,37 @@ RSpec.describe Kitchen::Driver::Azurerm, "state management" do
         expect(name.length).to eq(15)
       end
 
+      # The network interface name is derived from the VM name, and Azure
+      # requires both to end with a word character. Truncating the prefix to
+      # exactly 15 characters could leave a trailing separator, which ARM
+      # rejected at preflight:
+      #
+      #   Resource name nic-verylongprefix- is invalid. [...] it must end with
+      #   a word character or with '_'.
+      it "does not end with a separator when the prefix fills the whole name" do
+        driver = build_driver(vm_prefix: "verylongprefix-")
+        expect(driver.validate_state({})[:vm_name]).to match(/\w\z/)
+      end
+
+      it "derives a network interface name Azure will accept" do
+        driver = build_driver(vm_prefix: "verylongprefix-")
+        state = driver.validate_state({})
+        expect(driver.nic_name(state)).to match(/\A\w[\w.-]*\w\z/)
+      end
+
+      it "keeps uuid entropy even when the prefix fills the whole name" do
+        driver = build_driver(vm_prefix: "verylongprefix-")
+        names = Array.new(5) { driver.validate_state({})[:vm_name] }
+        expect(names.uniq.length).to be > 1
+      end
+
+      it "still caps a prefix that is longer than the whole budget" do
+        driver = build_driver(vm_prefix: "an-absurdly-long-prefix-indeed-")
+        name = driver.validate_state({})[:vm_name]
+        expect(name.length).to eq(15)
+        expect(name).to match(/\w\z/)
+      end
+
       it "keeps an existing vm_name" do
         expect(driver.validate_state(vm_name: "from-state")[:vm_name]).to eq("from-state")
       end


### PR DESCRIPTION
## The problem

`generated_vm_name` truncates to `MAX_VM_NAME_LENGTH` so that a `vm_prefix` longer than the documented three characters — quoting the existing comment — "still yields a name Azure will accept":

```ruby
prefix = config[:vm_prefix].to_s
remaining = MAX_VM_NAME_LENGTH - prefix.length
return prefix[0, MAX_VM_NAME_LENGTH] if remaining <= 0
```

It does not, quite. A prefix that fills the whole 15-character budget is used verbatim — and prefixes are conventionally written with a **trailing separator** (the driver's own default is `tk-`).

`vm_prefix: verylongprefix-` is exactly 15 characters, so the generated VM name is `verylongprefix-`, and the network interface named after it (`nic-#{vm_name}`) is rejected by ARM at preflight:

```
InvalidTemplateDeployment: ... reported preflight validation errors.
InvalidResourceName: Resource name nic-verylongprefix- is invalid. The name can be up to 80
characters long. It must begin with a word character, and it must end with a word character
or with '_'.
```

Nothing in that message points back at `vm_prefix`, and the failure comes from a resource name the user never wrote.

The existing spec for this ("never exceeds 15 characters, whatever the prefix") uses `a-very-long-prefix-`, which truncates to `a-very-long-pre` — ending on a word character by luck, so it passed.

A second, quieter consequence: when the prefix fills the budget the uuid is squeezed out entirely, so **every** instance using that prefix gets the same VM name.

## The fix

Cap the prefix one character short of the limit:

```ruby
prefix = config[:vm_prefix].to_s[0, MAX_VM_NAME_LENGTH - 1]
"#{prefix}#{state[:uuid][0, MAX_VM_NAME_LENGTH - prefix.length]}"
```

Reserving room for at least one uuid character guarantees the name ends with one (uuids are hex), keeps entropy in every generated name, and removes the special case for an overflowing prefix entirely.

## Testing

- `bundle exec rspec` — **604 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: the name not ending in a separator, the derived NIC name matching Azure's rule, entropy being retained, and a prefix longer than the whole budget still being capped.

Verified against a **real Azure subscription** with the config that failed:

```yaml
driver:
  vm_prefix: verylongprefix-
```

**Before:** `InvalidResourceName: Resource name nic-verylongprefix- is invalid.`

**After:** deploys and converges. Azure created:

```
verylongprefix7          # the VM, 15 chars, ends with uuid entropy
nic-verylongprefix7      # the NIC
nic-verylongprefix7-nsg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)