### PR TITLE
fix: stop discarding custom_data on Windows instances

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -838,11 +838,20 @@ module Kitchen
 
       # The full first-boot script handed to a Windows VM as custom data.
       #
+      # A Windows VM has exactly one custom data slot, and the driver needs it
+      # for the WinRM bootstrap. Any +custom_data+ the user configured has to
+      # travel in the same slot, so it is appended here rather than assigned
+      # over the top - which is what used to happen, silently discarding it.
+      #
+      # It runs after WinRM is listening and the data disks are formatted, and
+      # before the logoff that ends the first-logon session.
+      #
       # @return [String]
       def custom_data_script_windows
         <<-EOH
   #{enable_winrm_powershell_script}
   #{format_data_disks_powershell_script}
+  #{custom_data_content}
   logoff
         EOH
       end
@@ -1034,18 +1043,25 @@ module Kitchen
 
       # Base64-encoded custom data for the VM.
       #
-      # +custom_data+ may be either the literal content or a path to a file
-      # holding it.
-      #
       # @return [String, nil] nil when no +custom_data+ is configured.
       def prepared_custom_data
         return nil if config[:custom_data].nil?
 
-        @prepared_custom_data ||= if readable_file?(config[:custom_data])
-                                    Base64.strict_encode64(File.read(config[:custom_data]))
-                                  else
-                                    Base64.strict_encode64(config[:custom_data])
-                                  end
+        @prepared_custom_data ||= Base64.strict_encode64(custom_data_content)
+      end
+
+      # The configured custom data, as content.
+      #
+      # +custom_data+ may be either the literal content or a path to a file
+      # holding it, so this resolves whichever was given.
+      #
+      # @return [String] empty when no +custom_data+ is configured.
+      def custom_data_content
+        @custom_data_content ||= if readable_file?(config[:custom_data])
+                                   File.read(config[:custom_data])
+                                 else
+                                   config[:custom_data].to_s
+                                 end
       end
 
       private

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -576,6 +576,57 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
     end
   end
 
+  # A Windows instance carries its WinRM bootstrap in custom data, which is the
+  # same single slot the user's own custom_data has to travel in. The bootstrap
+  # used to be assigned over the top of it, so configuring custom_data on
+  # Windows silently did nothing at all.
+  describe "custom_data on Windows" do
+    subject(:driver) do
+      build_driver(transport: transport_double(name: "Winrm"), platform_name: "windows-2022",
+        custom_data: user_script)
+    end
+
+    let(:user_script) { "New-Item -Path C:\\kitchen-marker.txt -ItemType File\n" }
+
+    # @return [String] the decoded custom data the VM will actually receive.
+    def custom_data_of(driver)
+      template = JSON.parse(driver.template_for_transport_name)
+      resource = template["resources"].find { |r| r["type"] == "Microsoft.Compute/virtualMachines" }
+      Base64.decode64(resource["properties"]["osProfile"]["customData"])
+    end
+
+    it "keeps the user's custom_data" do
+      expect(custom_data_of(driver)).to include("kitchen-marker.txt")
+    end
+
+    it "still installs the WinRM listeners" do
+      expect(custom_data_of(driver)).to include("winrm create")
+    end
+
+    it "runs the user's script after WinRM is configured" do
+      decoded = custom_data_of(driver)
+      expect(decoded.index("winrm create")).to be < decoded.index("kitchen-marker.txt")
+    end
+
+    it "logs off last, so the script has run before the session ends" do
+      expect(custom_data_of(driver).strip).to end_with("logoff")
+    end
+
+    it "reads custom_data from a file when it names one" do
+      path = File.join(ENV.fetch("HOME"), "bootstrap.ps1")
+      File.write(path, "Write-Host 'from a file'\n")
+      from_file = build_driver(transport: transport_double(name: "Winrm"),
+        platform_name: "windows-2022", custom_data: path)
+
+      expect(custom_data_of(from_file)).to include("from a file")
+    end
+
+    it "is unchanged when no custom_data is configured" do
+      without = build_driver(transport: transport_double(name: "Winrm"), platform_name: "windows-2022")
+      expect(custom_data_of(without)).to include("winrm create")
+    end
+  end
+
   describe "#prepared_custom_data" do
     it "is nil when custom_data is not configured" do
       expect(build_driver(custom_data: nil).prepared_custom_data).to be_nil


### PR DESCRIPTION
## The problem

A Windows VM has exactly **one** custom data slot, and the driver needs it for the WinRM bootstrap script. Any `custom_data` the user configured travels in that same slot — and the bootstrap was assigned straight over the top of it:

```ruby
virtual_machine_resources(template).each do |resource|
  resource["properties"]["osProfile"]["customData"] = encoded_command   # <- overwrites
  resource["properties"]["osProfile"]["windowsConfiguration"] = windows_unattend_content
end
```

The value was still *sent*: `build_deployment_parameters` base64-encodes it into the `customData` ARM parameter. But the template's `"customData": "[parameters('customData')]"` had just been replaced with a literal, so nothing ever read it.

**Configuring `custom_data` on Windows did nothing at all, with no warning.**

### Confirmed on a real Windows Server 2022 instance

A `custom_data` script that creates a marker file:

```yaml
driver:
  custom_data: |
    New-Item -Path C:\kitchen-custom-data.txt -ItemType File -Force
    Set-Content -Path C:\kitchen-custom-data.txt -Value "custom_data ran"
```

Result on the box:

```
MARKER ABSENT
RESULT: custom_data WAS DISCARDED
--- first 200 chars of C:\AzureData\CustomData.bin ---
    $cert = New-SelfSignedCertificate -DnsName $env:COMPUTERNAME ...
  winrm create winrm/config/
```

`CustomData.bin` on the instance holds the WinRM bootstrap, and the user's script is nowhere.

## The fix

Append the user's script to the bootstrap rather than replacing it:

```ruby
def custom_data_script_windows
  <<-EOH
#{enable_winrm_powershell_script}
#{format_data_disks_powershell_script}
#{custom_data_content}
logoff
  EOH
end
```

It runs after WinRM is listening and the data disks are formatted, and before the `logoff` that ends the first-logon session. That is the same mechanism `format_data_disks` already uses, so the ordering is one the driver already depends on — and it matches how custom data behaves on Windows anyway, where it is executed as PowerShell via `C:\Config.ps1`.

Resolving "literal content or a path to a file" moves into `custom_data_content`, now shared by the Windows script and `prepared_custom_data` instead of being written twice.

## Testing

- `bundle exec rspec` — **606 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: the user's script surviving, the WinRM listeners still being installed, the ordering between them, `logoff` staying last, and `custom_data` given as a file path.

Re-deployed the identical suite against a **real subscription** with the fix:

```
MARKER PRESENT: custom_data ran
RESULT: custom_data RAN
Finished converging <wincustomdata-windows2022> (1m27.76s).
```

Linux is unaffected — it has no bootstrap competing for the slot, so `custom_data` continues to flow through the ARM parameter as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)