### PR TITLE
fix: open the port the transport actually connects on

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -975,9 +975,33 @@ module Kitchen
 
       # The port(s) the configured transport connects on.
       #
-      # @return [Array<Integer>] 5985 and 5986 for WinRM, otherwise 22.
+      # The transport already knows which port it will dial, so a +port+ set on
+      # it is authoritative: assuming the default instead produced an instance
+      # nothing could reach, and left the user repeating the port in
+      # +open_ports+ to get in.
+      #
+      # WinRM keeps both standard ports regardless, because
+      # {#enable_winrm_powershell_script} creates both listeners whatever the
+      # transport was pointed at.
+      #
+      # @return [Array<Integer>]
       def transport_ports
-        instance.transport.name.to_s.casecmp("winrm") == 0 ? [5985, 5986] : [22]
+        configured = instance.transport[:port].to_i
+
+        if winrm_transport?
+          ([5985, 5986] + [configured]).reject(&:zero?).uniq
+        elsif configured == 0
+          [22]
+        else
+          [configured]
+        end
+      end
+
+      # Whether the instance is driven over WinRM.
+      #
+      # @return [Boolean]
+      def winrm_transport?
+        instance.transport.name.to_s.casecmp("winrm") == 0
       end
 
       # ARM security rules for the generated network security group.

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -301,6 +301,41 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
       end
     end
 
+    # The transport knows which port it will dial; the security group used to
+    # assume the default. Setting `port:` on the transport therefore produced
+    # an instance nothing could reach, and the only way out was to repeat the
+    # port in open_ports.
+    context "with a transport on a non-default port" do
+      let(:transport) { transport_double(name: "Ssh", port: 2222) }
+
+      it "opens the port the transport will actually connect on" do
+        expect(rule_ports(nsg)).to include("2222")
+      end
+
+      it "does not open the default port instead" do
+        expect(rule_ports(nsg)).to eq(["2222"])
+      end
+    end
+
+    context "with a WinRM transport on a non-default port" do
+      let(:transport) { transport_double(name: "Winrm", port: 5999) }
+      let(:platform_name) { "windows-2022" }
+
+      # Both standard listeners are still created by the bootstrap script, so
+      # they stay open alongside whatever the transport was pointed at.
+      it "opens the configured port as well as the standard pair" do
+        expect(rule_ports(nsg)).to contain_exactly("5985", "5986", "5999")
+      end
+    end
+
+    context "with a transport that reports no port" do
+      let(:transport) { transport_double(name: "Ssh") }
+
+      it "falls back to the default" do
+        expect(rule_ports(nsg)).to eq(["22"])
+      end
+    end
+
     context "with extra open_ports" do
       let(:config) { { open_ports: [443, 8080] } }
 


### PR DESCRIPTION
## The problem

`transport_ports` hardcoded the defaults and ignored the `port` the transport was configured with:

```ruby
def transport_ports
  instance.transport.name.to_s.casecmp("winrm") == 0 ? [5985, 5986] : [22]
end
```

So with `port: 2222` on the transport, the generated security group opens **22** — a port nothing is listening on — and Azure silently drops the traffic to 2222, which is where Test Kitchen is actually dialling.

The instance can never be reached. The only way in is to repeat the port in `open_ports`, duplicating something the transport already knows:

```yaml
transport:
  port: 2222
driver:
  open_ports: [2222]   # <- otherwise unreachable
```

### Confirmed on real instances

Two otherwise identical Ubuntu 22.04 instances, both running sshd on 2222, differing only in the generated security group:

| Security group | Result on port 2222 |
| --- | --- |
| `allow-tcp-22` only | **Operation timed out** |
| `allow-tcp-22`, `allow-tcp-2222` | **REACHABLE** |

A **dropped** packet rather than a **refused** one is what distinguishes the security group from a listener that simply is not up yet — a refused connection means the packet reached the host. Test Kitchen shows the same split:

```
sshport      (22 only)    -> Net::SSH::ConnectionTimeout
sshportopen  (22 + 2222)  -> Errno::ECONNREFUSED
```

## The fix

Take the transport's port when it reports one:

```ruby
configured = instance.transport[:port].to_i

if winrm_transport?
  ([5985, 5986] + [configured]).reject(&:zero?).uniq
elsif configured == 0
  [22]
else
  [configured]
end
```

WinRM keeps 5985 and 5986 regardless, because `enable_winrm_powershell_script` creates **both** listeners whatever the transport was pointed at — so closing them would break the bootstrap it just ran. A custom WinRM port is opened alongside them.

SSH gets exactly the port it will dial, because sshd listens on one.

## Testing

- `bundle exec rspec` — **604 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: a non-default SSH port being opened (and the default *not* being opened instead), a custom WinRM port opening alongside the standard pair, and falling back to 22 when the transport reports no port.

Verified against a **real subscription**. Same suite that previously timed out forever, now with only `port: 2222` set and no `open_ports`:

```
$ ssh -p 2222 azure@40.121.1.170
REACHABLE on 2222
tk-7b479fa3dce6
```

The Test Kitchen failure mode also changed from `ConnectionTimeout` (dropped at the security group) to `ECONNREFUSED` (delivered to the host, sshd not yet restarted by cloud-init) — the packets are now getting through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)