### PR TITLE
fix: never send instance metadata requests through a proxy

### DIFF
--- a/lib/kitchen/driver/azure/http.rb
+++ b/lib/kitchen/driver/azure/http.rb
@@ -1,3 +1,4 @@
+require "ipaddr" unless defined?(IPAddr)
 require "json" unless defined?(JSON)
 require "net/http" unless defined?(Net::HTTP)
 require "openssl" unless defined?(OpenSSL)
@@ -28,6 +29,11 @@ module Kitchen
           SocketError,
           OpenSSL::SSL::SSLError,
         ].freeze
+
+        # The link-local range, which holds Azure's instance metadata service.
+        #
+        # @return [IPAddr]
+        LINK_LOCAL = IPAddr.new("169.254.0.0/16").freeze
 
         # Seconds to wait for a connection and for a response.
         #
@@ -87,17 +93,48 @@ module Kitchen
         # @return [Net::HTTPResponse]
         # @api private
         def self.perform(uri, request)
-          proxy = uri.find_proxy
+          proxy = proxy_for(uri)
           http = if proxy
                    Net::HTTP.new(uri.host, uri.port, proxy.host, proxy.port, proxy.user, proxy.password)
                  else
-                   Net::HTTP.new(uri.host, uri.port)
+                   # Explicitly nil rather than Net::HTTP's default of :ENV,
+                   # which would send it back to the environment to pick a
+                   # proxy we have just decided against.
+                   Net::HTTP.new(uri.host, uri.port, nil)
                  end
 
           http.use_ssl = uri.scheme == "https"
           http.open_timeout = OPEN_TIMEOUT
           http.read_timeout = READ_TIMEOUT
           http.start { |connection| connection.request(request) }
+        end
+
+        # The proxy to reach a URL through, if any.
+        #
+        # Azure's instance metadata service answers on a link-local address,
+        # which exists only on the local link and which no proxy can route to.
+        # Sending it through one breaks managed identity authentication
+        # outright: the connection hangs until the open timeout, surfaces as a
+        # {TransientError}, and is then retried. Every Azure SDK carves the
+        # same exception out.
+        #
+        # @param uri [URI]
+        # @return [URI, nil]
+        # @api private
+        def self.proxy_for(uri)
+          return nil if link_local?(uri.host)
+
+          uri.find_proxy
+        end
+
+        # @param host [String]
+        # @return [Boolean] whether the host is a link-local address.
+        # @api private
+        def self.link_local?(host)
+          LINK_LOCAL.include?(IPAddr.new(host.to_s))
+        rescue IPAddr::Error
+          # Not an IP address at all, so not the metadata service.
+          false
         end
 
         # @param method [Symbol]

--- a/spec/unit/kitchen/driver/azure/http_spec.rb
+++ b/spec/unit/kitchen/driver/azure/http_spec.rb
@@ -63,13 +63,60 @@ RSpec.describe Kitchen::Driver::Azure::Http do
       described_class.request(method: :get, url:)
     end
 
+    # The nil is not incidental: Net::HTTP's default p_addr is :ENV, which
+    # makes it consult the proxy environment again for itself. Deciding not to
+    # proxy has to be stated, not merely left unsaid.
     it "connects directly when the host is excluded from proxying" do
       ENV["https_proxy"] = "http://proxy.invalid:8080"
       ENV["no_proxy"] = "example.invalid"
-      expect(Net::HTTP).to receive(:new).with("example.invalid", 443).and_call_original
+      expect(Net::HTTP).to receive(:new).with("example.invalid", 443, nil).and_call_original
 
       stub_request(:get, url).to_return(status: 200)
       described_class.request(method: :get, url:)
+    end
+
+    # Azure's instance metadata service answers on a link-local address that
+    # exists only on the local link. A proxy cannot route to it, so sending
+    # IMDS through one breaks managed identity authentication outright - on a
+    # real VM it hangs until the connect timeout and then surfaces as a
+    # TransientError, which the driver dutifully retries.
+    describe "the instance metadata service" do
+      let(:imds) do
+        "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01"
+      end
+
+      before { stub_request(:get, imds).to_return(status: 200, body: "{}") }
+
+      it "is never sent through a proxy" do
+        ENV["http_proxy"] = "http://proxy.invalid:8080"
+        expect(Net::HTTP).to receive(:new).with("169.254.169.254", 80, nil).and_call_original
+
+        described_class.request(method: :get, url: imds)
+      end
+
+      it "is not proxied even when no_proxy names something else" do
+        ENV["http_proxy"] = "http://proxy.invalid:8080"
+        ENV["no_proxy"] = "example.invalid"
+        expect(Net::HTTP).to receive(:new).with("169.254.169.254", 80, nil).and_call_original
+
+        described_class.request(method: :get, url: imds)
+      end
+
+      it "still reaches it when no proxy is configured at all" do
+        expect(described_class.request(method: :get, url: imds).status).to eq(200)
+      end
+    end
+
+    # Everything else must keep honouring the proxy: this is not a licence to
+    # ignore it, only a carve-out for an address a proxy cannot reach.
+    it "keeps proxying an ordinary host that happens to be plain HTTP" do
+      ENV["http_proxy"] = "http://proxy.invalid:8080"
+      plain = "http://example.invalid/x"
+      stub_request(:get, plain).to_return(status: 200)
+      expect(Net::HTTP).to receive(:new)
+        .with("example.invalid", 80, "proxy.invalid", 8080, nil, nil).and_call_original
+
+      described_class.request(method: :get, url: plain)
     end
 
     it "does not treat an HTTP error status as transient" do


### PR DESCRIPTION
## The problem

Azure's instance metadata service answers on **169.254.169.254**, a link-local address that exists only on the local link. `Http.perform` handed every URL to `URI#find_proxy`:

```ruby
proxy = uri.find_proxy
```

So an `http_proxy` set for the internet — routine in a corporate network, and common on CI runners — is applied to IMDS too. No proxy can route to a link-local address, so **managed identity authentication breaks outright**.

It does not fail quickly, either. The connection hangs until the 30-second open timeout, surfaces as a `TransientError`, and `with_azure_retries` then retries it five more times — so a `kitchen create` on a VM using managed identity stalls for minutes before giving up with a timeout that says nothing about proxies.

### Confirmed on a real Azure VM

An Ubuntu 22.04 instance with a system-assigned identity, driving **this same `Http` layer** against the real metadata service — uploaded to the box and required directly, so it is the driver's own code path, not a re-implementation:

```
--- no proxy in the environment ---
  http_proxy=nil -> HTTP 200, access_token=true
--- http_proxy set to an unroutable address (as in a corporate network) ---
  http_proxy="http://10.255.255.1:3128" -> Kitchen::Driver::Azure::TransientError: Net::OpenTimeout: execution expired
```

## The fix

Skip the proxy for link-local addresses — the same carve-out every Azure SDK makes:

```ruby
def self.proxy_for(uri)
  return nil if link_local?(uri.host)

  uri.find_proxy
end
```

Everything else keeps honouring the environment. This is a carve-out for an address a proxy cannot reach, not a licence to ignore proxy configuration.

### One subtlety worth calling out

The no-proxy branch now passes an **explicit `nil`**:

```ruby
Net::HTTP.new(uri.host, uri.port, nil)
```

`Net::HTTP.new`'s default `p_addr` is `:ENV`, which makes it consult the proxy environment *again on its own*. Deciding not to proxy has to be stated, not merely left unsaid — otherwise the fix above would be undone one layer down.

## Testing

- `bundle exec rspec` — **604 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: IMDS not proxied when `http_proxy` is set, not proxied when `no_proxy` names something else, still reachable with no proxy at all, and — importantly — an ordinary plain-HTTP host **still being proxied**, so the carve-out cannot quietly widen.

Re-ran the identical probe on a real VM with the fix:

```
  http_proxy=nil                          -> HTTP 200, access_token=true
  http_proxy="http://10.255.255.1:3128"   -> HTTP 200, access_token=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)