### PR TITLE
fix: keep generated resource group names within Azure's limit

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -474,7 +474,18 @@ module Kitchen
         "#{prefix}#{state[:uuid][0, remaining]}"
       end
 
+      # Maximum length of an Azure resource group name.
+      #
+      # @return [Integer]
+      MAX_RESOURCE_GROUP_NAME_LENGTH = 90
+
       # Name of the resource group this instance deploys into.
+      #
+      # The instance name is the suite and platform joined together, so a
+      # descriptive suite on a long platform overruns Azure's limit and
+      # +kitchen create+ fails on its very first call - over a name the user
+      # never chose. Only that part is shortened: the prefix and suffix were
+      # asked for explicitly, and the timestamp is what keeps the name unique.
       #
       # @return [String] +explicit_resource_group_name+ when set, otherwise
       #   prefix + instance name + UTC timestamp + suffix.
@@ -482,7 +493,12 @@ module Kitchen
         return config[:explicit_resource_group_name] if config[:explicit_resource_group_name]
 
         formatted_time = Time.now.utc.strftime "%Y%m%dT%H%M%S"
-        "#{config[:azure_resource_group_prefix]}#{config[:azure_resource_group_name]}-#{formatted_time}#{config[:azure_resource_group_suffix]}"
+        prefix = config[:azure_resource_group_prefix].to_s
+        suffix = config[:azure_resource_group_suffix].to_s
+        room = MAX_RESOURCE_GROUP_NAME_LENGTH - prefix.length - suffix.length - formatted_time.length - 1
+        name = config[:azure_resource_group_name].to_s[0, [room, 0].max]
+
+        "#{prefix}#{name}-#{formatted_time}#{suffix}"
       end
 
       # JSON fragment describing the data disks to attach to the VM.

--- a/spec/unit/kitchen/driver/azurerm/state_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/state_spec.rb
@@ -106,6 +106,50 @@ RSpec.describe Kitchen::Driver::Azurerm, "state management" do
         expect(driver.validate_state(azure_resource_group_name: "kitchen-existing")[:azure_resource_group_name])
           .to eq("kitchen-existing")
       end
+
+      # The name is generated from the instance name, which is the suite and
+      # platform joined together, so a descriptive suite on a long platform
+      # overruns Azure's limit and `kitchen create` fails on its first call:
+      #
+      #   InvalidResourceGroup: The provided resource group name '...' has a
+      #   length of '107' which exceeds the maximum length of '90'.
+      context "when the instance name is long" do
+        let(:long_instance) { "install-and-configure-monitoring-agent-windows-server-2022-datacenter-azure-edition" }
+
+        subject(:name) { build_driver(instance_name: long_instance).azure_resource_group_name }
+
+        it "stays within Azure's 90 character limit" do
+          expect(name.length).to be <= 90
+        end
+
+        it "keeps the timestamp, which is what makes it unique" do
+          expect(name).to match(/-\d{8}T\d{6}\z/)
+        end
+
+        it "keeps the configured prefix" do
+          expect(name).to start_with("kitchen-")
+        end
+
+        it "keeps a configured suffix" do
+          suffixed = build_driver(instance_name: long_instance, azure_resource_group_suffix: "-ci")
+          expect(suffixed.azure_resource_group_name).to end_with("-ci")
+          expect(suffixed.azure_resource_group_name.length).to be <= 90
+        end
+
+        it "still identifies the instance it belongs to" do
+          expect(name).to include("install-and-configure")
+        end
+      end
+
+      it "does not truncate a name that already fits" do
+        expect(build_driver(instance_name: "default-ubuntu-2204").azure_resource_group_name)
+          .to start_with("kitchen-default-ubuntu-2204-")
+      end
+
+      it "copes with a prefix that consumes the whole budget" do
+        driver = build_driver(azure_resource_group_prefix: "p" * 95)
+        expect(driver.azure_resource_group_name).to start_with("p" * 90)
+      end
     end
 
     describe "config values copied into state" do


### PR DESCRIPTION
## The problem

The resource group name is generated, not chosen:

```ruby
"#{config[:azure_resource_group_prefix]}#{config[:azure_resource_group_name]}-#{formatted_time}#{config[:azure_resource_group_suffix]}"
```

`azure_resource_group_name` defaults to `config.instance.name` — the **suite and platform joined together**. A descriptive suite on a long platform overruns Azure's 90-character limit, and `kitchen create` fails on its very first API call:

```
InvalidResourceGroup: The provided resource group name
'kitchen-install-and-configure-monitoring-agent-windows-server-2022-datacenter-azure-edition-20260823T080000'
has a length of '107' which exceeds the maximum length of '90'.
```

Verified directly against Azure — that is the real error, from a real `az group create`.

Nothing in the user's `kitchen.yml` contains that string. They wrote a suite name and a platform name, both perfectly reasonable, and got an API error about a 107-character identifier they never typed. The suite/platform pair above is 83 characters, which is not exotic for a descriptive suite on a fully-spelled-out platform.

## The fix

Shorten the instance-name portion so the whole name fits:

```ruby
room = MAX_RESOURCE_GROUP_NAME_LENGTH - prefix.length - suffix.length - formatted_time.length - 1
name = config[:azure_resource_group_name].to_s[0, [room, 0].max]
```

Only that part is trimmed, deliberately:

- the **prefix** and **suffix** were asked for explicitly, so they are honoured in full
- the **timestamp** is what makes the name unique, so dropping it would risk collisions between runs

The instance name is the only part that is both generated and redundant — enough of it survives to identify the instance.

## Testing

- `bundle exec rspec` — **607 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: staying within 90 characters, keeping the timestamp, keeping the prefix, keeping a configured suffix, still identifying the instance, not truncating a name that already fits, and a prefix that consumes the entire budget.

Verified against a **real subscription** with an 88-character instance name, which would previously have generated a 112-character group name:

```
Creating Resource Group: kitchen-install-and-configure-monitoring-agent-ubuntu-2204-lts-gen2-harden-20260823T074631
login_user=azure
OK: baseline
Finished converging <install-and-configure-monitoring-agent-ubuntu-2204-lts-gen2-hardened-cis-level-1-baseline> (0m11.71s)
```

The created group is exactly 90 characters — at the limit, and accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)