### PR TITLE
fix: accept settings written with no value, and a lone identity

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -308,7 +308,7 @@ module Kitchen
           dnsNameForPublicIP: "kitchen-#{state[:uuid]}",
           vmName: state[:vm_name],
           systemAssignedIdentity: config[:system_assigned_identity],
-          userAssignedIdentities: config[:user_assigned_identities].to_h { |identity| [identity, {}] },
+          userAssignedIdentities: Array(config[:user_assigned_identities]).to_h { |identity| [identity, {}] },
           secretUrl: config[:secret_url],
           vaultName: config[:vault_name],
           vaultResourceGroup: config[:vault_resource_group],
@@ -899,8 +899,11 @@ module Kitchen
         data = {
           vm_tags: vm_tag_string(config[:vm_tags]),
           storage_account_type: config[:storage_account_type],
-          image_id: config[:image_id],
-          custom_data: config[:custom_data],
+          # A setting written with no value is nil, not "". The templates ask
+          # these two whether they are empty, so give them something that can
+          # answer.
+          image_id: config[:image_id].to_s,
+          custom_data: config[:custom_data].to_s,
           os_disk_size_gb: config[:os_disk_size_gb],
           data_disks_for_vm_json:,
           use_ephemeral_osdisk: config[:use_ephemeral_osdisk],

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -576,6 +576,54 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
     end
   end
 
+  # `custom_data:` or `image_id:` written with no value is nil in YAML, not "".
+  # The templates guard with .empty? while the rest of the driver uses
+  # .to_s.empty?, so a nil arrived as `undefined method 'empty?' for nil` -
+  # a Ruby error naming neither the setting nor the file it came from.
+  describe "settings written with no value" do
+    it "treats a nil custom_data as unset" do
+      expect { build_driver(custom_data: nil).virtual_machine_deployment_template }.not_to raise_error
+    end
+
+    it "treats a nil image_id as unset, falling back to the image_urn" do
+      driver = build_driver(image_id: nil)
+      expect(driver.virtual_machine_deployment_template).to include("imagePublisher")
+    end
+
+    it "treats a nil vm_tags as unset" do
+      expect { build_driver(vm_tags: nil).virtual_machine_deployment_template }.not_to raise_error
+    end
+
+    it "treats a nil open_ports as unset" do
+      expect(build_driver(open_ports: nil).send(:nsg_ports)).to eq([22])
+    end
+  end
+
+  # `user_assigned_identities` takes a list, but a single identity written as
+  # a plain string is an easy mistake, and produced `undefined method 'to_h'
+  # for an instance of String`.
+  describe "user_assigned_identities given as a single string" do
+    let(:identity) { "/subscriptions/x/resourcegroups/y/providers/Microsoft.ManagedIdentity/userAssignedIdentities/z" }
+
+    it "is accepted as a list of one" do
+      driver = build_driver(user_assigned_identities: identity)
+      parameters = driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a")
+      expect(parameters[:userAssignedIdentities]).to eq(identity => {})
+    end
+
+    it "still accepts a list" do
+      driver = build_driver(user_assigned_identities: [identity])
+      parameters = driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a")
+      expect(parameters[:userAssignedIdentities]).to eq(identity => {})
+    end
+
+    it "still accepts none" do
+      driver = build_driver
+      parameters = driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a")
+      expect(parameters[:userAssignedIdentities]).to eq({})
+    end
+  end
+
   describe "#prepared_custom_data" do
     it "is nil when custom_data is not configured" do
       expect(build_driver(custom_data: nil).prepared_custom_data).to be_nil

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -576,6 +576,44 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
     end
   end
 
+  describe "#prepared_custom_data" do
+    it "is nil when custom_data is not configured" do
+      expect(build_driver(custom_data: nil).prepared_custom_data).to be_nil
+    end
+
+    context "with inline content" do
+      let(:config) { { custom_data: "#!/bin/sh\necho hello\n" } }
+
+      it "base64 encodes it" do
+        expect(Base64.decode64(driver.prepared_custom_data)).to eq("#!/bin/sh\necho hello\n")
+      end
+
+      it "memoizes the result" do
+        expect(driver.prepared_custom_data).to equal(driver.prepared_custom_data)
+      end
+    end
+
+    context "with a path to a file" do
+      let(:path) { File.join(ENV.fetch("HOME"), "cloud-init.yml") }
+      let(:config) { { custom_data: path } }
+
+      before { File.write(path, "#cloud-config\npackages:\n  - htop\n") }
+
+      it "base64 encodes the file's contents" do
+        expect(Base64.decode64(driver.prepared_custom_data)).to eq("#cloud-config\npackages:\n  - htop\n")
+      end
+    end
+
+    context "with a multi-line document that resembles nothing on disk" do
+      let(:config) { { custom_data: "#cloud-config\n#{"x" * 5000}\n" } }
+
+      it "encodes it inline without touching the filesystem" do
+        expect(File).not_to receive(:file?)
+        expect(Base64.decode64(driver.prepared_custom_data)).to start_with("#cloud-config")
+      end
+    end
+  end
+
   # `custom_data:` or `image_id:` written with no value is nil in YAML, not "".
   # The templates guard with .empty? while the rest of the driver uses
   # .to_s.empty?, so a nil arrived as `undefined method 'empty?' for nil` -
@@ -621,44 +659,6 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
       driver = build_driver
       parameters = driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a")
       expect(parameters[:userAssignedIdentities]).to eq({})
-    end
-  end
-
-  describe "#prepared_custom_data" do
-    it "is nil when custom_data is not configured" do
-      expect(build_driver(custom_data: nil).prepared_custom_data).to be_nil
-    end
-
-    context "with inline content" do
-      let(:config) { { custom_data: "#!/bin/sh\necho hello\n" } }
-
-      it "base64 encodes it" do
-        expect(Base64.decode64(driver.prepared_custom_data)).to eq("#!/bin/sh\necho hello\n")
-      end
-
-      it "memoizes the result" do
-        expect(driver.prepared_custom_data).to equal(driver.prepared_custom_data)
-      end
-    end
-
-    context "with a path to a file" do
-      let(:path) { File.join(ENV.fetch("HOME"), "cloud-init.yml") }
-      let(:config) { { custom_data: path } }
-
-      before { File.write(path, "#cloud-config\npackages:\n  - htop\n") }
-
-      it "base64 encodes the file's contents" do
-        expect(Base64.decode64(driver.prepared_custom_data)).to eq("#cloud-config\npackages:\n  - htop\n")
-      end
-    end
-
-    context "with a multi-line document that resembles nothing on disk" do
-      let(:config) { { custom_data: "#cloud-config\n#{"x" * 5000}\n" } }
-
-      it "encodes it inline without touching the filesystem" do
-        expect(File).not_to receive(:file?)
-        expect(Base64.decode64(driver.prepared_custom_data)).to start_with("#cloud-config")
-      end
     end
   end
 


### PR DESCRIPTION
## The problem

Two config shapes a reasonable `kitchen.yml` produces crashed with a Ruby error that named neither the setting nor the file it came from.

### A setting written with no value

```yaml
driver:
  custom_data:
  image_id:
```

That is `nil` in YAML, not `""`. The ERB templates guard these two with `.empty?`:

```erb
<%- unless custom_data.empty? -%>
<%- if image_id.empty? -%>
```

while everything else in the driver uses `.to_s.empty?` (`nsg_id`, `os_disk_size_gb`, `secret_url`, `vault_name`, `vnet_id`…). So a `nil` produced:

```
undefined method 'empty?' for nil
```

### A single identity written as a string

`user_assigned_identities` takes a list, but writing one identity as a plain string is an easy mistake:

```yaml
driver:
  user_assigned_identities: /subscriptions/.../userAssignedIdentities/my-identity
```

```ruby
config[:user_assigned_identities].to_h { |identity| [identity, {}] }
# => undefined method 'to_h' for an instance of String
```

Neither message mentions `custom_data`, `image_id`, `user_assigned_identities`, or `kitchen.yml`. The user is left with a backtrace into the driver.

## The fix

Both now behave the way the surrounding code already does:

- `image_id` and `custom_data` are passed to the templates through `.to_s`, so a value written with no value counts as unset — consistent with every other optional setting.
- `user_assigned_identities` is wrapped in `Array()`, so a lone identity counts as a list of one.

## Testing

- `bundle exec rspec` — **607 examples, 0 failures**, line coverage still 100%
- `bundle exec rake style` — 33 files, no offenses
- New specs cover: nil `custom_data`, nil `image_id` (falling back to `image_urn`), nil `vm_tags`, nil `open_ports`, and `user_assigned_identities` given as a string, as a list, and not at all.

Confirmed against a **real subscription** with exactly the `kitchen.yml` above, pointed at a real user-assigned identity:

**Before**
```
>>>>>> Failed to complete #create action: [undefined method 'to_h' for an instance of String] on nilconfig-ubuntu2204
```

**After**
```
Resource Template deployment reached end state of 'Succeeded'.
login_user=azure
OK: baseline
Finished converging <nilconfig-ubuntu2204> (0m12.57s).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)