### PR TITLE
fix: stop concurrent creates from overwriting each other's SSH key

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -561,26 +561,47 @@ module Kitchen
         template["resources"].select { |resource| resource["type"] == "Microsoft.Compute/virtualMachines" }
       end
 
+      # Serializes the generate-and-write below.
+      #
+      # Test Kitchen runs instances as threads inside one process, so
+      # +kitchen create -c+ had every thread reach the "does the key exist?"
+      # check before any of them had written one. Each generated its own pair
+      # and wrote it over the last, so only the instance whose key happened to
+      # land on disk last was reachable - the rest were deployed with a public
+      # key nobody held the private half of, and failed at converge with
+      # +Permission denied (publickey)+.
+      #
+      # @return [Mutex]
+      KEY_GENERATION_MUTEX = Mutex.new
+
       # Returns the public key to inject into the deployment, generating a new
       # key pair on disk when the configured private key does not yet exist.
       #
       # @param private_key_filename [String] path to the transport's private key.
       # @return [String] the OpenSSH-format public key, stripped of whitespace.
       def public_key_for_deployment(private_key_filename)
-        unless File.file?(private_key_filename)
-          key = SSHKey.generate
+        KEY_GENERATION_MUTEX.synchronize do
+          generate_key_pair(private_key_filename) unless File.file?(private_key_filename)
 
-          ::FileUtils.mkdir_p(File.dirname(private_key_filename))
-          File.write(private_key_filename, key.private_key)
-          File.chmod(0600, private_key_filename)
-          File.write("#{private_key_filename}.pub", key.ssh_public_key)
-          File.chmod(0600, "#{private_key_filename}.pub")
-
-          return key.ssh_public_key.strip
+          public_key_filename = instance.transport[:ssh_public_key] || "#{private_key_filename}.pub"
+          File.read(public_key_filename).strip
         end
+      end
 
-        public_key_filename = instance.transport[:ssh_public_key] || "#{private_key_filename}.pub"
-        File.read(public_key_filename).strip
+      # Writes a fresh SSH key pair to disk.
+      #
+      # Always called with {KEY_GENERATION_MUTEX} held.
+      #
+      # @param private_key_filename [String] path to write the private key to.
+      # @return [void]
+      def generate_key_pair(private_key_filename)
+        key = SSHKey.generate
+
+        ::FileUtils.mkdir_p(File.dirname(private_key_filename))
+        File.write(private_key_filename, key.private_key)
+        File.chmod(0600, private_key_filename)
+        File.write("#{private_key_filename}.pub", key.ssh_public_key)
+        File.chmod(0600, "#{private_key_filename}.pub")
       end
 
       # Builds the pre-deployment from a caller-supplied ARM template file.

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -531,6 +531,16 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
         expect(File.stat(ssh_key_path).mode & 0777).to eq(0600)
       end
 
+      # `kitchen create -c` runs instances as threads in one process, so every
+      # thread used to find the key missing at the same moment and generate its
+      # own. Only the last one written survived, and every other instance was
+      # deployed with a public key nobody held the private half of.
+      it "hands every concurrent caller the key that ends up on disk" do
+        keys = Array.new(8) { Thread.new { driver.public_key_for_deployment(ssh_key_path) } }.map(&:value)
+
+        expect(keys.uniq).to contain_exactly(File.read("#{ssh_key_path}.pub").strip)
+      end
+
       it "injects the public key into the linux configuration" do
         template = JSON.parse(driver.template_for_transport_name)
         linux = vm_resource(template)["properties"]["osProfile"]["linuxConfiguration"]


### PR DESCRIPTION
Found while bug-hunting the driver against a real subscription.

## The bug

`public_key_for_deployment` does check-then-act:

```ruby
unless File.file?(private_key_filename)
  key = SSHKey.generate
  ...write...
end
```

Test Kitchen runs instances as **threads inside one process**, so `kitchen create -c` had every thread reach that check before any of them had written a key. Each generated its own pair and wrote it over the last. Only the instance whose key landed on disk last was reachable.

The failure is silent at create time — `kitchen create` reports success for every instance — and only surfaces later at converge as `Permission denied (publickey)`.

## Confirmed against Azure

Five concurrent instances, **three different key pairs** deployed:

| suite | key deployed | reachable |
|---|---|---|
| vnet-private | `…DeZcSr1pI8…` | ✅ |
| vnet-public | `…DeZcSr1pI8…` | ✅ |
| byo-nsg | `…DJzKQ6gSxx…` | ❌ `Permission denied (publickey)` |
| open-ports | `…DJzKQ6gSxx…` | ❌ |
| subnet-fullid | `…C3iWrOMySrw…` | ❌ |

`byo-nsg` and `open-ports` sharing a key is the interleaving fingerprint of a genuine race: one thread generated it, the other read it off disk before a third clobbered the file.

This hits `kitchen test -c`, the documented way to run a platform matrix.

## The fix

Generation happens under a mutex, and the public key is read back **inside the same lock**, so every caller gets the pair that is actually on disk.

## Test

The new spec runs eight threads through `public_key_for_deployment` against a nonexistent key path and asserts they all get the key that ends up on disk. It fails 5/5 runs before the change and passes after.

`bundle exec rake` is green: 652 examples, 100% line coverage, no RuboCop offenses.