### PR TITLE
fix: let destroy finish when the resource group is already gone

### DIFF
--- a/lib/kitchen/driver/azure/arm_client.rb
+++ b/lib/kitchen/driver/azure/arm_client.rb
@@ -67,10 +67,18 @@ module Kitchen
         # Requests deletion of a resource group, returning as soon as ARM
         # accepts the request rather than waiting for it to finish.
         #
+        # A group that is already gone counts as deleted: that is the outcome
+        # the caller asked for, and ARM answers 404. Treating that as an error
+        # wedged +kitchen destroy+ permanently for any instance whose resource
+        # group had been removed out of band - deleted in the portal to save
+        # money, or never created because +kitchen create+ failed early. Every
+        # subsequent destroy failed the same way, so the instance could only be
+        # cleared by hand-deleting its state file.
+        #
         # @param name [String] resource group name.
         # @return [void]
         def delete_resource_group(name)
-          call(:delete, resource_group_path(name), api_version: RESOURCES_API_VERSION)
+          call(:delete, resource_group_path(name), api_version: RESOURCES_API_VERSION, allow: [404])
           nil
         end
 

--- a/spec/unit/kitchen/driver/azure/arm_client_spec.rb
+++ b/spec/unit/kitchen/driver/azure/arm_client_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Kitchen::Driver::Azure::ArmClient do
       expect(client.delete_resource_group("rg")).to be_nil
       expect(stub).to have_been_requested
     end
+
+    # Deleting a group that is already gone is the outcome the caller wanted.
+    # Raising here wedged `kitchen destroy` permanently for any instance whose
+    # resource group had been removed out of band.
+    it "treats a group that is already gone as deleted" do
+      stub_request(:delete, "#{base}/resourcegroups/rg").with(query: hash_including({}))
+        .to_return(status: 404, body: '{"error":{"code":"ResourceGroupNotFound","message":"could not be found."}}')
+
+      expect(client.delete_resource_group("rg")).to be_nil
+    end
   end
 
   describe "#create_deployment" do


### PR DESCRIPTION
Found while bug-hunting the driver against a real subscription.

## The bug

`ArmClient#delete_resource_group` sends its `DELETE` with no `allow:` list, so ARM's 404 for a group that is not there becomes a raised `OperationError` and fails the whole destroy action.

Test Kitchen keeps the state file when destroy fails, so every retry hits the same 404. The instance is **permanently wedged** — the only way out is to hand-delete `.kitchen/<instance>.yml`.

## Confirmed against Azure

```
$ az group exists -n kitchen-...-20260823T164522
false

$ kitchen destroy nil-image-urn
>>>>>> Failed to complete #destroy action:
       [Azure returned HTTP 404 for DELETE /subscriptions/.../resourcegroups/kitchen-...]

$ kitchen destroy nil-image-urn      # again, and again, and again
>>>>>> Failed to complete #destroy action: [Azure returned HTTP 404 ...]
```

Both ways in are mundane:

- somebody deletes the resource group in the portal to save money — routine cost cleanup;
- `kitchen create` fails before the group is created (e.g. a bad `image_urn`) and leaves state behind naming a group that never existed.

## The fix

`allow: [404]`. Deleting something that is already gone is the outcome the caller asked for — the standard idempotent-delete convention, and the same allowance `resource_group_exists?` already makes one method away.

## Test

New spec stubs a 404 `ResourceGroupNotFound` and asserts `delete_resource_group` returns rather than raising. Fails with the exact live error before the change.

`bundle exec rake` is green: 652 examples, 100% line coverage, no RuboCop offenses.