### PR TITLE
fix: keep the resource group tags destroy promises to keep

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -796,7 +796,15 @@ module Kitchen
       end
 
       # Empties a resource group by deploying an empty template in Complete
-      # mode, then restores or clears the group's tags per configuration.
+      # mode, then clears the group's tags unless asked to keep them.
+      #
+      # An empty Complete-mode deployment removes the resources in the group
+      # and leaves the group's own tags alone, so keeping them means leaving
+      # the group be. Rewriting it is what used to remove them: ARM's PUT on a
+      # resource group replaces its tags rather than merging them, so putting
+      # the *configured* tags back overwrote whatever the group actually
+      # carried - which, with +resource_group_tags+ unset, meant erasing them
+      # while announcing they would be kept.
       #
       # @param state [Hash] the instance state.
       # @return [void]
@@ -807,11 +815,11 @@ module Kitchen
 
         if config[:destroy_explicit_resource_group_tags] == false
           warn 'The "destroy_explicit_resource_group_tags" setting value is set to "false". The tags on the resource group will NOT be removed.'
-          create_resource_group(state[:azure_resource_group_name], get_resource_group)
-        else
-          warn 'The "destroy_explicit_resource_group_tags" setting value is set to "true". The tags on the resource group will be removed.'
-          create_resource_group(state[:azure_resource_group_name], get_resource_group.merge(tags: {}))
+          return
         end
+
+        warn 'The "destroy_explicit_resource_group_tags" setting value is set to "true". The tags on the resource group will be removed.'
+        create_resource_group(state[:azure_resource_group_name], get_resource_group.merge(tags: {}))
       rescue Azure::OperationError => operation_error
         error operation_error.body
         raise operation_error

--- a/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
@@ -174,21 +174,19 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
       context "with destroy_explicit_resource_group_tags disabled" do
         let(:config) { super().merge(destroy_explicit_resource_group_tags: false) }
 
-        it "restores the configured tags instead" do
+        # ARM's PUT on a resource group replaces its tags rather than merging
+        # them, so rewriting the group at all is what destroyed the tags this
+        # setting promises to keep. An empty Complete-mode deployment leaves
+        # them alone, so the way to preserve them is to leave the group be.
+        it "leaves the resource group alone so its tags survive" do
           driver.destroy(state)
-          expect(arm_client).to have_received(:create_or_update_resource_group)
-            .with(anything, hash_including(tags: { owner: "platform" }))
+          expect(arm_client).not_to have_received(:create_or_update_resource_group)
         end
 
         it "says so" do
           allow(Kitchen.logger).to receive(:warn)
           driver.destroy(state)
           expect(Kitchen.logger).to have_received(:warn).with(/tags on the resource group will NOT be removed/)
-        end
-
-        it "does not also clear them" do
-          driver.destroy(state)
-          expect(arm_client).to have_received(:create_or_update_resource_group).once
         end
       end
     end


### PR DESCRIPTION
Found while bug-hunting the driver against a real subscription.

## The bug

`destroy_explicit_resource_group_tags: false` announces that the tags on the resource group will **not** be removed — and then removes them.

Both branches rewrite the group with `create_or_update_resource_group`, supplying `tags: config[:resource_group_tags]` (empty unless the user set it). **ARM's `PUT` on a resource group replaces its tags rather than merging them**, so that call overwrites whatever the group actually carried. The branches differ only by `.merge(tags: {})` — a no-op when `resource_group_tags` is already empty — so "preserve" and "clear" did the same thing. Neither ever read the group's current tags, so preserve was never implemented; it just looked like it was.

Silent data loss on a shared resource group, with a log line stating the opposite.

## Confirmed against Azure — before

```
before: {"costcenter": "eng", "owner": "alice"}
log:    The "destroy_explicit_resource_group_tags" setting value is set to "false".
        The tags on the resource group will NOT be removed.
after:  {}
```

## The fix

I checked separately against ARM whether the empty Complete-mode deployment itself touches the tags — it does not:

```
before:      {"costcenter":"eng","owner":"alice"}
az deployment group create --mode Complete --template-file empty.json
after empty: {"costcenter":"eng","owner":"alice"}
```

So keeping the tags means leaving the group be. The clearing branch is unchanged.

## Confirmed against Azure — after

Same steps, same subscription:

```
before: {"costcenter": "eng", "owner": "alice"}
after:  {"costcenter": "eng", "owner": "alice"}
```

and the group's contents were still emptied.

## A note on the tests

The two existing specs asserted the PUT was made with the configured tags — which is exactly what the driver did. They described the bug rather than the intent, so they are replaced by one asserting the group is left alone. This is the class of defect mocked tests structurally cannot catch: the call looks correct, and only ARM's replace semantics turn it into data loss.

`bundle exec rake` is green: 651 examples, 100% line coverage, no RuboCop offenses.