### PR TITLE
fix: accept image_urn and the deployment templates written with no value

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -66,8 +66,12 @@ module Kitchen
 
       # Ubuntu 22.04 LTS, generation 2. Canonical renamed their offers after
       # 18.04, so the old "UbuntuServer" offer no longer resolves at all.
+      #
+      # @return [String]
+      DEFAULT_IMAGE_URN = "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest".freeze
+
       default_config(:image_urn) do |_config|
-        "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest"
+        DEFAULT_IMAGE_URN
       end
 
       default_config(:image_id) do |_config|
@@ -273,12 +277,12 @@ module Kitchen
         end
 
         begin
-          run_deployment(state, "pre-deploy", pre_deployment(config[:pre_deployment_template], config[:pre_deployment_parameters])) if File.file?(config[:pre_deployment_template])
+          run_deployment(state, "pre-deploy", pre_deployment(config[:pre_deployment_template], config[:pre_deployment_parameters])) if File.file?(config[:pre_deployment_template].to_s)
 
           run_deployment(state, "deploy", deployment(deployment_parameters))
           store_deployment_credentials(state, deployment_parameters)
 
-          run_deployment(state, "post-deploy", post_deployment(config[:post_deployment_template], config[:post_deployment_parameters])) if File.file?(config[:post_deployment_template])
+          run_deployment(state, "post-deploy", post_deployment(config[:post_deployment_template], config[:post_deployment_parameters])) if File.file?(config[:post_deployment_template].to_s)
         rescue Azure::OperationError => operation_error
           info operation_error.body["error"]
           raise operation_error
@@ -329,8 +333,21 @@ module Kitchen
       def image_parameters
         return { "imageId" => config[:image_id] } if config[:image_id].to_s != ""
 
-        publisher, offer, sku, version = config[:image_urn].split(":", 4)
+        publisher, offer, sku, version = image_urn.split(":", 4)
         { "imagePublisher" => publisher, "imageOffer" => offer, "imageSku" => sku, "imageVersion" => version }
+      end
+
+      # The Marketplace image URN to deploy from.
+      #
+      # An +image_urn:+ written with no value is nil rather than "", which
+      # counts as unset here the way it does everywhere else in the driver -
+      # so it falls back to {DEFAULT_IMAGE_URN} rather than failing with a
+      # Ruby error naming neither the setting nor the file it came from.
+      #
+      # @return [String]
+      def image_urn
+        urn = config[:image_urn].to_s
+        urn.empty? ? DEFAULT_IMAGE_URN : urn
       end
 
       # The OS disk size, as a number ARM will accept.

--- a/spec/unit/kitchen/driver/azurerm/create_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/create_spec.rb
@@ -316,6 +316,17 @@ RSpec.describe Kitchen::Driver::Azurerm, "#create" do
         )
       end
     end
+
+    # Written with no value these are nil, not "", and File.file? raises
+    # TypeError on nil rather than answering false.
+    context "when either is written with no value" do
+      let(:config) { { pre_deployment_template: nil, post_deployment_template: nil } }
+
+      it "treats them as unset" do
+        driver.create(state)
+        expect(deployment_names_submitted).to eq(["deploy-#{state[:uuid]}"])
+      end
+    end
   end
 
   describe "credentials in state" do

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -789,6 +789,12 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
     it "treats a nil open_ports as unset" do
       expect(build_driver(open_ports: nil).send(:nsg_ports)).to eq([22])
     end
+
+    it "treats a nil image_urn as unset, falling back to the default image" do
+      parameters = build_driver(image_urn: nil).image_parameters
+      expect(parameters["imagePublisher"]).to eq("Canonical")
+      expect(parameters["imageOffer"]).to eq("0001-com-ubuntu-server-jammy")
+    end
   end
 
   # `user_assigned_identities` takes a list, but a single identity written as


### PR DESCRIPTION
Found while bug-hunting the driver against a real subscription. Follows #340, which fixed the same class of problem for `custom_data` and `image_id`.

## The bug

A setting written with no value is `nil` in YAML, not `""`. Three more of them crash:

```yaml
driver:
  image_urn:
  pre_deployment_template:
  post_deployment_template:
```

- `image_urn:` → `undefined method 'split' for nil`
- `pre_deployment_template:` / `post_deployment_template:` → `no implicit conversion of nil into String` (`File.file?` raises `TypeError` on nil rather than answering false)

Same complaint as #340's commit message: a Ruby error naming neither the setting nor the file it came from.

The **post**-deployment case is the worst of the three — it fails *after* the main deployment has succeeded, so the VM is already built and billing when the run dies.

## Confirmed against Azure

```
$ kitchen create nil-image-urn
>>>>>> Failed to complete #create action: [undefined method 'split' for nil]

$ kitchen create nil-predeploy
>>>>>> Failed to complete #create action: [no implicit conversion of nil into String]
```

Both deploy after the change.

## The fix

All three now behave the way the surrounding code already does: a value written with no value counts as unset. An unset `image_urn` is the documented default image, so that is what it falls back to — promoted to a named constant (`DEFAULT_IMAGE_URN`) rather than a literal buried in `default_config`, so the default and the fallback cannot drift apart.

`bundle exec rake` is green: 653 examples, 100% line coverage, no RuboCop offenses.