### PR TITLE
fix: explain a missing public key instead of failing on its path

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -614,7 +614,12 @@ module Kitchen
         KEY_GENERATION_MUTEX.synchronize do
           generate_key_pair(private_key_filename) unless File.file?(private_key_filename)
 
-          public_key_filename = instance.transport[:ssh_public_key] || "#{private_key_filename}.pub"
+          explicit = instance.transport[:ssh_public_key]
+          public_key_filename = explicit || "#{private_key_filename}.pub"
+          unless File.file?(public_key_filename)
+            raise Kitchen::UserError, missing_public_key_message(private_key_filename, public_key_filename, explicit)
+          end
+
           File.read(public_key_filename).strip
         end
       end
@@ -633,6 +638,33 @@ module Kitchen
         File.chmod(0600, private_key_filename)
         File.write("#{private_key_filename}.pub", key.ssh_public_key)
         File.chmod(0600, "#{private_key_filename}.pub")
+      end
+
+      # Explains that the public half of the transport's key could not be found.
+      #
+      # +ssh_key+ names the *private* key, so a user who keeps only that has
+      # nothing wrong with their kitchen.yml. They used to get a raw
+      # Errno::ENOENT for a ".pub" path they never wrote, with nothing to say
+      # where it came from or what to do about it.
+      #
+      # The key cannot simply be derived: sshkey only reads PEM-encoded RSA,
+      # while ssh-keygen has emitted the OpenSSH format by default since 7.8
+      # and ed25519 keys are never PEM. +ssh-keygen -y+ handles every format,
+      # so point at that instead.
+      #
+      # @param private_key_filename [String] the configured private key.
+      # @param public_key_filename [String] where the public key was looked for.
+      # @param explicit [String, nil] +ssh_public_key+, when the user set it.
+      # @return [String]
+      def missing_public_key_message(private_key_filename, public_key_filename, explicit)
+        if explicit
+          "The transport's ssh_public_key setting points at #{public_key_filename}, which does not exist. " \
+            "Correct the path, or remove the setting to use #{private_key_filename}.pub."
+        else
+          "No public key was found at #{public_key_filename}. The transport's ssh_key setting names the " \
+            "private key, and the public half of it has to go on the virtual machine. Create it with: " \
+            "ssh-keygen -y -f #{private_key_filename} > #{public_key_filename}"
+        end
       end
 
       # Builds the pre-deployment from a caller-supplied ARM template file.

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -575,6 +575,36 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
         expect(driver.template_for_transport_name).not_to include("adminPassword")
       end
 
+      # Generation and the public-key lookup run in sequence, so a user with no
+      # private key *and* an ssh_public_key setting walks both halves in one
+      # pass. Neither half's own tests reach that combination.
+      context "when ssh_public_key is set and the private key does not exist" do
+        let(:transport) { transport_double(name: "Ssh", ssh_key: ssh_key_path, ssh_public_key: explicit_public_key) }
+        let(:explicit_public_key) { File.join(ENV.fetch("HOME"), "elsewhere.pub") }
+
+        context "and names an existing file" do
+          before { File.write(explicit_public_key, "ssh-rsa AAAAEXPLICIT explicit@key\n") }
+
+          it "still generates the missing private key" do
+            driver.template_for_transport_name
+            expect(File).to exist(ssh_key_path)
+          end
+
+          it "deploys the configured key rather than the one it just generated" do
+            template = JSON.parse(driver.template_for_transport_name)
+            key_data = vm_resource(template)["properties"]["osProfile"]["linuxConfiguration"]["ssh"]["publicKeys"].first["keyData"]
+            expect(key_data).to eq("ssh-rsa AAAAEXPLICIT explicit@key")
+          end
+        end
+
+        context "and names a file that does not exist" do
+          it "reports the configured path, not the .pub it just generated" do
+            expect { driver.template_for_transport_name }
+              .to raise_error(Kitchen::UserError, /ssh_public_key.*elsewhere\.pub/m)
+          end
+        end
+      end
+
       context "when the private key already exists" do
         before do
           File.write(ssh_key_path, "an existing private key")
@@ -592,6 +622,27 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
           expect(File.read(ssh_key_path)).to eq("an existing private key")
         end
 
+        # ssh_key names the *private* key, so a user who keeps only that has
+        # nothing wrong with their kitchen.yml - but got a raw Errno::ENOENT
+        # for a .pub path they never wrote.
+        context "but has no .pub beside it" do
+          before { File.delete("#{ssh_key_path}.pub") }
+
+          it "explains that ssh_key names the private half" do
+            expect { driver.template_for_transport_name }
+              .to raise_error(Kitchen::UserError, /ssh_key setting names the private key/)
+          end
+
+          # The operands are the whole point: reversed, the suggested command
+          # truncates the private key it was meant to read.
+          it "gives the exact command that derives the missing key" do
+            expect { driver.template_for_transport_name }.to raise_error(
+              Kitchen::UserError,
+              /ssh-keygen -y -f #{Regexp.escape(ssh_key_path)} > #{Regexp.escape(ssh_key_path)}\.pub/
+            )
+          end
+        end
+
         context "and ssh_public_key names a different file" do
           let(:transport) { transport_double(name: "Ssh", ssh_key: ssh_key_path, ssh_public_key: explicit_public_key) }
           let(:explicit_public_key) { File.join(ENV.fetch("HOME"), "elsewhere.pub") }
@@ -602,6 +653,20 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
             template = JSON.parse(driver.template_for_transport_name)
             key_data = vm_resource(template)["properties"]["osProfile"]["linuxConfiguration"]["ssh"]["publicKeys"].first["keyData"]
             expect(key_data).to eq("ssh-rsa AAAAEXPLICIT explicit@key")
+          end
+
+          context "that does not exist" do
+            before { File.delete(explicit_public_key) }
+
+            it "names the setting that pointed at it" do
+              expect { driver.template_for_transport_name }
+                .to raise_error(Kitchen::UserError, /ssh_public_key.*elsewhere\.pub/m)
+            end
+
+            it "offers the adjacent .pub as the way out" do
+              expect { driver.template_for_transport_name }
+                .to raise_error(Kitchen::UserError, /remove the setting to use #{Regexp.escape(ssh_key_path)}\.pub/)
+            end
           end
         end
       end


### PR DESCRIPTION
Found while bug-hunting the driver against a real subscription.

## The bug

`ssh_key` names the **private** key. A user who keeps only that — no `.pub` beside it — has nothing wrong with their `kitchen.yml`, but gets:

```
>>>>>> Failed to complete #create action:
       [No such file or directory @ rb_sysopen - /path/to/lonely.pub]
```

A raw `Errno::ENOENT` for a path they never wrote, with nothing to say where it came from or what to do about it.

## Why not just derive the key?

That was my first instinct, but I checked what `sshkey` can actually parse:

| key | result |
|---|---|
| `ssh-keygen -t rsa` (OpenSSH format, the default since OpenSSH 7.8) | ❌ `OpenSSL::PKey::PKeyError: invalid curve name` |
| `ssh-keygen -t rsa -m PEM` | ✅ |
| `ssh-keygen -t ed25519` | ❌ `OpenSSL::PKey::PKeyError: invalid curve name` |

Deriving would work for a shrinking minority of keys and mislead everyone else. `ssh-keygen -y` handles every format, so the message points at that instead.

## The fix

```
No public key was found at /path/to/lonely.pub. The transport's ssh_key setting
names the private key, and the public half of it has to go on the virtual machine.
Create it with: ssh-keygen -y -f /path/to/lonely > /path/to/lonely.pub
```

An `ssh_public_key` that names a file which does not exist gets its own message, since that is a wrong path rather than a missing key.

## Confirmed against Azure

An OpenSSH-format key with no `.pub` produces the message above; running the command it suggests derives the key, and the same instance then deploys and is reachable.

## Note on overlap

Touches the same method as #343 (the concurrent key-generation race). They are independent bugs, but whichever merges second will want a one-line rebase — happy to do that.

`bundle exec rake` is green: 653 examples, 100% line coverage, no RuboCop offenses.