### PR TITLE
fix: accept an os_disk_size_gb that YAML made a string

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -315,7 +315,7 @@ module Kitchen
 
         parameters["nicName"] = nic_name(state)
         parameters["customData"] = prepared_custom_data unless config[:custom_data].to_s.empty?
-        parameters["osDiskSizeGb"] = config[:os_disk_size_gb] unless config[:os_disk_size_gb].to_s.empty?
+        parameters["osDiskSizeGb"] = os_disk_size_gb unless config[:os_disk_size_gb].to_s.empty?
         parameters["nsgId"] = config[:nsg_id] unless config[:nsg_id].to_s.empty?
 
         parameters.merge(image_parameters)
@@ -331,6 +331,28 @@ module Kitchen
 
         publisher, offer, sku, version = config[:image_urn].split(":", 4)
         { "imagePublisher" => publisher, "imageOffer" => offer, "imageSku" => sku, "imageVersion" => version }
+      end
+
+      # The OS disk size, as a number ARM will accept.
+      #
+      # YAML makes +os_disk_size_gb: 64+ an Integer and +os_disk_size_gb: "64"+
+      # a String, and the ARM parameter is typed +int+ - Azure rejects the
+      # String outright rather than coercing it:
+      #
+      #   The provided value for the template parameter 'osDiskSizeGb' is not
+      #   valid. Expected a value of type 'Integer', but received a value of
+      #   type 'String'.
+      #
+      # Quoting a number in kitchen.yml is an easy thing to do, and the driver
+      # already tolerates the same ambiguity for +boot_diagnostics_enabled+.
+      #
+      # @return [Integer]
+      # @raise [Kitchen::UserError] if the value is not a whole number.
+      def os_disk_size_gb
+        Integer(config[:os_disk_size_gb])
+      rescue ArgumentError, TypeError
+        raise Kitchen::UserError,
+          "os_disk_size_gb must be a whole number of gigabytes, but was #{config[:os_disk_size_gb].inspect}."
       end
 
       # Whether managed boot diagnostics should be switched on.

--- a/spec/unit/kitchen/driver/azurerm/template_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/template_spec.rb
@@ -263,6 +263,29 @@ RSpec.describe Kitchen::Driver::Azurerm, "deployment template rendering" do
         end
       end
 
+      # YAML makes `os_disk_size_gb: 64` an Integer and `os_disk_size_gb: "64"`
+      # a String. The ARM parameter is typed `int`, and Azure rejects the
+      # String outright rather than coercing it.
+      describe "os_disk_size_gb as a deployment parameter" do
+        it "sends a quoted size as a number" do
+          driver = build_driver(os_disk_size_gb: "64")
+          parameters = driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a")
+          expect(parameters["osDiskSizeGb"]).to eq(64)
+        end
+
+        it "still sends an unquoted size as a number" do
+          driver = build_driver(os_disk_size_gb: 64)
+          parameters = driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a")
+          expect(parameters["osDiskSizeGb"]).to eq(64)
+        end
+
+        it "says so when the size is not a number at all" do
+          driver = build_driver(os_disk_size_gb: "sixty four")
+          expect { driver.build_deployment_parameters(uuid: "a" * 16, vm_name: "tk-a") }
+            .to raise_error(Kitchen::UserError, /os_disk_size_gb/)
+        end
+      end
+
       context "with no os_disk_size_gb" do
         it "omits the disk size" do
           os_disk = vm_resource(rendered_template(driver))["properties"]["storageProfile"]["osDisk"]


### PR DESCRIPTION
Found while bug-hunting the driver against a real subscription.

## The bug

YAML makes `os_disk_size_gb: 64` an Integer and `os_disk_size_gb: "64"` a String. The ARM parameter is typed `int`, and Azure rejects the String outright rather than coercing it:

```
InvalidTemplate: The provided value for the template parameter 'osDiskSizeGb' is not
valid. Expected a value of type 'Integer', but received a value of type 'String'.
```

## Why this is the driver's problem

Quoting a number in `kitchen.yml` is an easy thing to do, and the driver already tolerates exactly this ambiguity elsewhere — `boot_diagnostics_enabled?` honours the string spellings of `true`/`false`, and its comment says why:

> Historically this setting defaulted to the *string* `"true"`, and plenty of kitchen.yml files still say `"false"`, so both spellings are honoured.

The ERB templates already treat this setting as stringy too, guarding it with `os_disk_size_gb.to_s.empty?`.

## The fix

Coerce with `Integer()` when building the parameter. A value that is not a number at all now says so and names the setting, rather than raising a bare `ArgumentError`.

## Confirmed against Azure

`os_disk_size_gb: "64"` failed the deployment before. After the change the same config deploys, and the OS disk really is 64 GB:

```json
{"diskSizeBytes": 68719476736, "diskSizeGB": 64}
```

(so the parameter is genuinely applied, not silently dropped.)

`bundle exec rake` is green: 654 examples, 100% line coverage, no RuboCop offenses.