### PR TITLE
chore: require Test Kitchen 3.0 or newer

### DIFF
--- a/kitchen-azurerm.gemspec
+++ b/kitchen-azurerm.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "inifile", "~> 3.0", ">= 3.0.0"
   spec.add_dependency "sshkey", ">= 1.0.0", "< 4"
-  spec.add_dependency "test-kitchen", ">= 1.20", "< 5.0"
+  spec.add_dependency "test-kitchen", ">= 3.0", "< 5.0"
 end


### PR DESCRIPTION
The dependency floor was `>= 1.20`, which the driver has not supported for a long time.

## Test Kitchen 1.x cannot load the documented configuration

TK 1.x reads `.kitchen.yml`, not `kitchen.yml`. Every example in this repo's README uses the undotted name that arrived in TK 2.0, so a 1.20 install fails before it reaches the driver at all:

```
$ kitchen list
>>>>>> Class: Kitchen::UserError
>>>>>> Message: Kitchen YAML file /path/.kitchen.yml does not exist.
```

So `>= 1.20` was already a claim the project could not honour.

## Ruby floors do not line up either

| test-kitchen | required_ruby_version |
|---|---|
| 1.20.0 | `>= 2.3` |
| 2.12.0 | `>= 2.5` |
| 3.0.0 | `>= 2.5` |
| 3.7.0 | `>= 3.1` |
| 4.1.1 | `>= 3.1` |

This gem requires Ruby `>= 3.1`. TK 1.x and 2.x are long past end of life, receive no fixes, and nothing in CI tests them.

## What is actually verified

I ran the unit suite against each version. It passes on 3.0.0, 3.7.0 and 4.1.1:

```
TK 3.0.0  -> 651 examples, 0 failures
TK 3.7.0  -> 651 examples, 0 failures
TK 4.1.1  -> 651 examples, 0 failures
```

and `kitchen list` drives the real plugin successfully on 3.0.0 and up.

3.0 is therefore the oldest release the driver is genuinely exercised against. The `< 5.0` ceiling is unchanged.

*(Note for anyone reading the numbers: the unit suite also passes under 1.20/2.12, because it doubles the Kitchen instance and so barely exercises Test Kitchen itself. The `.kitchen.yml` failure above is what a real run hits.)*