### PR TITLE
feat: report whether the instance is running to `kitchen list --live`

### DIFF
--- a/lib/kitchen/driver/azure/arm_client.rb
+++ b/lib/kitchen/driver/azure/arm_client.rb
@@ -25,6 +25,13 @@ module Kitchen
         # @return [String]
         NETWORK_API_VERSION = "2025-07-01".freeze
 
+        # ARM API version used for compute resource requests. Matches the
+        # version the bundled deployment templates declare for virtual
+        # machines.
+        #
+        # @return [String]
+        COMPUTE_API_VERSION = "2025-04-01".freeze
+
         # @param subscription_id [String]
         # @param environment [Environments::Environment]
         # @param token_provider [TokenProvider]
@@ -107,6 +114,17 @@ module Kitchen
           payload.is_a?(Hash) ? Array(payload["value"]) : []
         end
 
+        # Reads a virtual machine's instance view, which carries its current
+        # power state.
+        #
+        # @param resource_group [String]
+        # @param name [String] virtual machine name.
+        # @return [Hash]
+        def virtual_machine_instance_view(resource_group, name)
+          call(:get, "#{compute_path(resource_group, "virtualMachines", name)}/instanceView",
+            api_version: COMPUTE_API_VERSION).json
+        end
+
         # Reads a public IP address resource.
         #
         # @param resource_group [String]
@@ -148,6 +166,14 @@ module Kitchen
         # @return [String]
         def network_path(resource_group, type, name)
           "#{resource_group_path(resource_group)}/providers/Microsoft.Network/#{type}/#{escape(name)}"
+        end
+
+        # @param resource_group [String]
+        # @param type [String] e.g. +"virtualMachines"+.
+        # @param name [String]
+        # @return [String]
+        def compute_path(resource_group, type, name)
+          "#{resource_group_path(resource_group)}/providers/Microsoft.Compute/#{type}/#{escape(name)}"
         end
 
         # @param value [String]

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -729,6 +729,50 @@ module Kitchen
         end
       end
 
+      # How Azure's power states map onto Test Kitchen's liveness question.
+      #
+      # Anything absent from this table is passed through as-is with +live+
+      # left nil: reporting a state we have not seen before is more use than
+      # guessing whether it counts as running.
+      #
+      # @return [Hash{String => Boolean}]
+      POWER_STATES = {
+        "running" => true,
+        "starting" => true,
+        "stopping" => true,
+        "stopped" => false,
+        "deallocating" => false,
+        "deallocated" => false,
+      }.freeze
+
+      # Reports whether the virtual machine backing this instance is running.
+      #
+      # Drives +kitchen list --live+ (and its +kitchen status+ alias). Test
+      # Kitchen rescues anything raised here and reports "unknown", but a
+      # listing should not be where an Azure outage first shows up, so the
+      # failure modes are handled explicitly and reported as data.
+      #
+      # No retries: this is a status probe behind an interactive command, and
+      # waiting out the retry budget on every unreachable instance would be
+      # worse than saying so promptly.
+      #
+      # @param state [Hash] the instance state.
+      # @return [Hash] +:live+, +:state+, +:resource_id+ and +:message+.
+      def status(state)
+        resource_group = state[:azure_resource_group_name]
+        vm_name = state[:vm_name]
+        return { live: false, state: "not_created", message: "No Azure virtual machine has been created yet." } unless
+          state[:server_id] && resource_group && vm_name
+
+        power_state_status(state, resource_group, vm_name)
+      rescue Azure::OperationError => operation_error
+        return { live: false, state: "not_created", message: "The virtual machine no longer exists in Azure." } if operation_error.status == 404
+
+        { live: nil, state: "unknown", message: "#{operation_error.code}: #{operation_error.message}" }
+      rescue Azure::TransientError => transient_error
+        { live: nil, state: "unknown", message: "Could not reach Azure (#{transient_error.message})." }
+      end
+
       # Tears down whatever {#create} built.
       #
       # @param state [Hash] the instance state, mutated in place.
@@ -771,6 +815,53 @@ module Kitchen
         state.delete(:hostname)
         state.delete(:username)
         state.delete(:password)
+      end
+
+      # Asks Azure for the virtual machine's power state.
+      #
+      # @param state [Hash] the instance state.
+      # @param resource_group [String]
+      # @param vm_name [String]
+      # @return [Hash] as {#status} returns.
+      def power_state_status(state, resource_group, vm_name)
+        view = status_arm_client(state).virtual_machine_instance_view(resource_group, vm_name)
+        status = Array(view["statuses"]).find { |entry| entry["code"].to_s.start_with?("PowerState/") }
+        power = status && status["code"].to_s.split("/", 2).last
+
+        {
+          live: power ? POWER_STATES[power] : nil,
+          state: power || "unknown",
+          resource_id: virtual_machine_id(status_subscription_id(state), resource_group, vm_name),
+          message: status && status["displayStatus"],
+        }
+      end
+
+      # An ARM client for a status probe, built from state the way {#destroy}
+      # builds one, so that an instance created against another subscription
+      # or cloud is still asked about in the right place.
+      #
+      # @param state [Hash] the instance state.
+      # @return [Azure::ArmClient]
+      def status_arm_client(state)
+        @arm_client ||= Kitchen::Driver::AzureCredentials.new(
+          subscription_id: status_subscription_id(state),
+          environment: state[:azure_environment] || config[:azure_environment]
+        ).arm_client
+      end
+
+      # @param state [Hash] the instance state.
+      # @return [String, nil] the subscription the instance was created in.
+      def status_subscription_id(state)
+        state[:subscription_id] || config[:subscription_id]
+      end
+
+      # @param subscription_id [String]
+      # @param resource_group [String]
+      # @param vm_name [String]
+      # @return [String] the virtual machine's ARM resource id.
+      def virtual_machine_id(subscription_id, resource_group, vm_name)
+        "/subscriptions/#{subscription_id}/resourceGroups/#{resource_group}" \
+          "/providers/Microsoft.Compute/virtualMachines/#{vm_name}"
       end
 
       # Deletes an explicitly-named resource group when the instance itself was

--- a/spec/support/azure_doubles.rb
+++ b/spec/support/azure_doubles.rb
@@ -19,6 +19,7 @@ module AzureDoubles
       deployment_operations: [],
       public_ip: public_ip_response,
       network_interface: network_interface_response,
+      virtual_machine_instance_view: instance_view_response,
     }
     instance_double(Kitchen::Driver::Azure::ArmClient, **defaults.merge(overrides))
   end
@@ -66,6 +67,20 @@ module AzureDoubles
         "ipAddress" => ip_address,
         "dnsSettings" => { "fqdn" => fqdn },
       },
+    }
+  end
+
+  # A virtual machine instance view.
+  #
+  # @param code [String] a status code, e.g. +"PowerState/running"+.
+  # @param display_status [String] Azure's human-readable wording.
+  # @return [Hash]
+  def instance_view_response(code = "PowerState/running", display_status = "VM running")
+    {
+      "statuses" => [
+        { "code" => "ProvisioningState/succeeded", "displayStatus" => "Provisioning succeeded" },
+        { "code" => code, "displayStatus" => display_status },
+      ],
     }
   end
 

--- a/spec/unit/kitchen/driver/azure/arm_client_spec.rb
+++ b/spec/unit/kitchen/driver/azure/arm_client_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Kitchen::Driver::Azure::ArmClient do
   let(:base) { "https://management.azure.com/subscriptions/#{subscription_id}" }
   let(:resources_version) { described_class::RESOURCES_API_VERSION }
   let(:network_version) { described_class::NETWORK_API_VERSION }
+  let(:compute_version) { described_class::COMPUTE_API_VERSION }
 
   def token_provider_double
     instance_double(Kitchen::Driver::Azure::TokenProvider, authorization_header: "Bearer a-token")
@@ -120,6 +121,17 @@ RSpec.describe Kitchen::Driver::Azure::ArmClient do
     it "is an empty array when ARM returns something that is not an object" do
       stub_request(:get, %r{/operations}).to_return(status: 200, body: "[]")
       expect(client.deployment_operations("rg", "d")).to eq([])
+    end
+  end
+
+  describe "#virtual_machine_instance_view" do
+    it "GETs the instance view with the compute API version" do
+      stub = stub_request(:get, "#{base}/resourcegroups/rg/providers/Microsoft.Compute/virtualMachines/vm/instanceView")
+        .with(query: { "api-version" => compute_version })
+        .to_return(status: 200, body: '{"statuses":[{"code":"PowerState/running"}]}')
+
+      expect(client.virtual_machine_instance_view("rg", "vm")).to eq("statuses" => [{ "code" => "PowerState/running" }])
+      expect(stub).to have_been_requested
     end
   end
 

--- a/spec/unit/kitchen/driver/azurerm/status_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/status_spec.rb
@@ -1,0 +1,123 @@
+RSpec.describe Kitchen::Driver::Azurerm, "#status" do
+  subject(:driver) { build_driver }
+
+  let(:arm_client) { arm_client_double }
+  let(:state) do
+    {
+      uuid: "abc123",
+      server_id: "vmabc123",
+      vm_name: "tk-abc123",
+      azure_resource_group_name: "kitchen-default-20260822T134505",
+      subscription_id: "115b12cb-b0d3-4ed9-94db-f73733be6f3c",
+      azure_environment: "Azure",
+    }
+  end
+
+  before { stub_arm_client(driver, arm_client:) }
+
+  describe "before the instance has been created" do
+    it "reports it as not created" do
+      expect(driver.status({})).to include(live: false, state: "not_created")
+    end
+
+    it "does not ask Azure about a machine that cannot exist" do
+      driver.status({})
+      expect(arm_client).not_to have_received(:virtual_machine_instance_view)
+    end
+  end
+
+  describe "when the virtual machine is running" do
+    before do
+      allow(arm_client).to receive(:virtual_machine_instance_view)
+        .and_return(instance_view_response("PowerState/running", "VM running"))
+    end
+
+    it "reports it live" do
+      expect(driver.status(state)).to include(live: true, state: "running")
+    end
+
+    it "passes Azure's own wording along" do
+      expect(driver.status(state)[:message]).to eq("VM running")
+    end
+
+    it "names the machine it asked about" do
+      expect(driver.status(state)[:resource_id]).to eq(
+        "/subscriptions/115b12cb-b0d3-4ed9-94db-f73733be6f3c/resourceGroups/" \
+        "kitchen-default-20260822T134505/providers/Microsoft.Compute/virtualMachines/tk-abc123"
+      )
+    end
+  end
+
+  describe "when the virtual machine is deallocated" do
+    before do
+      allow(arm_client).to receive(:virtual_machine_instance_view)
+        .and_return(instance_view_response("PowerState/deallocated", "VM deallocated"))
+    end
+
+    it "reports it not live" do
+      expect(driver.status(state)).to include(live: false, state: "deallocated")
+    end
+  end
+
+  describe "when Azure reports a power state we do not recognise" do
+    before do
+      allow(arm_client).to receive(:virtual_machine_instance_view)
+        .and_return(instance_view_response("PowerState/hibernated", "VM hibernated"))
+    end
+
+    it "passes the state through rather than guessing whether it is live" do
+      expect(driver.status(state)).to include(live: nil, state: "hibernated")
+    end
+  end
+
+  describe "when the instance view carries no power state" do
+    before { allow(arm_client).to receive(:virtual_machine_instance_view).and_return({ "statuses" => [] }) }
+
+    it "reports unknown" do
+      expect(driver.status(state)).to include(state: "unknown")
+    end
+  end
+
+  describe "when the virtual machine is gone" do
+    before do
+      allow(arm_client).to receive(:virtual_machine_instance_view)
+        .and_raise(azure_operation_error(code: "ResourceNotFound", status: 404))
+    end
+
+    it "reports it as not created rather than as an error" do
+      expect(driver.status(state)).to include(live: false, state: "not_created")
+    end
+  end
+
+  describe "when Azure cannot be reached" do
+    before do
+      allow(arm_client).to receive(:virtual_machine_instance_view)
+        .and_raise(Kitchen::Driver::Azure::TransientError, "Net::OpenTimeout: timed out")
+    end
+
+    it "reports unknown rather than failing the listing" do
+      expect(driver.status(state)).to include(live: nil, state: "unknown")
+    end
+
+    it "says why" do
+      expect(driver.status(state)[:message]).to include("timed out")
+    end
+  end
+
+  describe "when Azure refuses the request" do
+    before do
+      allow(arm_client).to receive(:virtual_machine_instance_view)
+        .and_raise(azure_operation_error(code: "AuthorizationFailed", status: 403))
+    end
+
+    it "reports unknown and says why" do
+      expect(driver.status(state)).to include(live: nil, state: "unknown")
+      expect(driver.status(state)[:message]).to include("AuthorizationFailed")
+    end
+  end
+
+  # Test Kitchen skips a driver whose #status takes no arguments.
+  it "accepts the instance state" do
+    expect(described_class.instance_method(:status).arity).to eq(1)
+  end
+end


### PR DESCRIPTION
Test Kitchen 4 added a driver hook behind `kitchen list --live` (and its `kitchen status` alias). This driver did not implement it, so it inherited `Driver::Base`'s placeholder and a running VM reported `unknown` forever:

```
Instance        ...  Last Action  Live Status
st-ubuntu-2204  ...  Created      unknown
```

even though ARM knows exactly what is going on.

## Confirmed against Azure, across every transition

| what I did | reported |
|---|---|
| (before create) | `not_created` |
| `kitchen create` | `running` |
| `az vm deallocate` | `deallocated` |
| `az vm delete` (RG left behind) | `not_created` |

## Design notes

- **Unknown power states pass through** with `live` left nil, rather than guessing whether something like `hibernated` counts as running.
- **Failures are reported as data, not raised.** Test Kitchen wraps the call in `rescue Exception` and degrades to "unknown", but a listing is a poor place for an Azure outage to first surface — so a 404 reports "the machine is gone", and an unreachable or refusing Azure says so in the message.
- **No retries.** This is a status probe behind an interactive command; waiting out the retry budget on every unreachable instance would be worse than answering promptly.
- **The client is built from state, not config**, the way `#destroy` builds one, so an instance created against another subscription or cloud is still asked about in the right place.
- `#status` takes the state argument — Test Kitchen skips any driver whose `status` has arity 0, and there is a spec pinning that.

## Also added

`ArmClient#virtual_machine_instance_view` plus a `COMPUTE_API_VERSION` constant, matching the version the bundled templates already declare for virtual machines.

`bundle exec rake` is green: 664 examples, 100% line coverage, no RuboCop offenses.