### PR TITLE
fix: stop a blank value in state shadowing the configured one

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -429,11 +429,20 @@ module Kitchen
 
       # Whether a state property is already populated.
       #
+      # A blank value does not count. A run that fails early still writes its
+      # state, so an empty +subscription_id+ - which is what a quoted ERB
+      # interpolation of an unset variable produces - used to be taken as
+      # authoritative from then on, shadowing the real value in config for the
+      # rest of the instance's life.
+      #
+      # +false+ is a value, so this asks whether the value is blank rather
+      # than whether it is truthy.
+      #
       # @param state [Hash] Hash of existing state values.
       # @param property [Symbol, String] the property to check.
-      # @return [Boolean] true when the key exists and its value is not nil.
+      # @return [Boolean] true when the key exists and its value is not blank.
       def existing_state_value?(state, property)
-        state.key?(property) && !state[property].nil?
+        state.key?(property) && !state[property].to_s.empty?
       end
 
       # Fills in any state values that are not already present.
@@ -736,8 +745,8 @@ module Kitchen
       # @raise [Azure::OperationError] if an Azure API call fails.
       def destroy(state)
         # TODO: We have some not so fun state issues we need to clean up
-        state[:azure_environment] = config[:azure_environment] unless state[:azure_environment]
-        state[:subscription_id] = config[:subscription_id] unless state[:subscription_id]
+        state[:azure_environment] = config[:azure_environment] unless existing_state_value?(state, :azure_environment)
+        state[:subscription_id] = config[:subscription_id] unless existing_state_value?(state, :subscription_id)
 
         @arm_client = Kitchen::Driver::AzureCredentials.new(subscription_id: state[:subscription_id],
           environment: state[:azure_environment]).arm_client

--- a/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/destroy_spec.rb
@@ -19,6 +19,39 @@ RSpec.describe Kitchen::Driver::Azurerm, "#destroy" do
 
   before { stub_arm_client(driver, arm_client:) }
 
+  # An empty subscription_id in state used to be taken as authoritative, so
+  # destroy built a client with no subscription at all and Azure was asked to
+  # DELETE /subscriptions//resourcegroups/... - a 400 that left the resource
+  # group behind, still billing.
+  describe "with a blank subscription_id left in state" do
+    let(:config) { { subscription_id: "sub-from-config" } }
+
+    before { state[:subscription_id] = "" }
+
+    it "falls back to the configured subscription" do
+      driver.destroy(state)
+      expect(Kitchen::Driver::AzureCredentials).to have_received(:new)
+        .with(hash_including(subscription_id: "sub-from-config"))
+    end
+
+    it "repairs the value in state" do
+      driver.destroy(state)
+      expect(state[:subscription_id]).to eq("sub-from-config")
+    end
+  end
+
+  describe "with a blank azure_environment left in state" do
+    let(:config) { { azure_environment: "AzureUSGovernment" } }
+
+    before { state[:azure_environment] = "" }
+
+    it "falls back to the configured cloud" do
+      driver.destroy(state)
+      expect(Kitchen::Driver::AzureCredentials).to have_received(:new)
+        .with(hash_including(environment: "AzureUSGovernment"))
+    end
+  end
+
   describe "the ordinary case" do
     it "deletes the resource group" do
       driver.destroy(state)

--- a/spec/unit/kitchen/driver/azurerm/state_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/state_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Kitchen::Driver::Azurerm, "state management" do
     it "is true for a falsey but non-nil value" do
       expect(driver.existing_state_value?({ use_managed_disks: false }, :use_managed_disks)).to be true
     end
+
+    # A blank value is not a value. Left standing, one written into state by a
+    # failed run shadows the real one in config for the rest of the instance's
+    # life.
+    it "is false when the value is blank" do
+      expect(driver.existing_state_value?({ subscription_id: "" }, :subscription_id)).to be false
+    end
   end
 
   describe "#validate_state" do
@@ -194,6 +201,11 @@ RSpec.describe Kitchen::Driver::Azurerm, "state management" do
       it "does not overwrite values already in state" do
         driver.validate_state(state.merge!(subscription_id: "sub-from-state"))
         expect(state[:subscription_id]).to eq("sub-from-state")
+      end
+
+      it "replaces a blank value left in state by an earlier run" do
+        driver.validate_state(state.merge!(subscription_id: ""))
+        expect(state[:subscription_id]).to eq("sub-123")
       end
     end
 


### PR DESCRIPTION
Found while auditing the driver against Test Kitchen 4.

## The bug

A run that fails early still writes its state. When `subscription_id` resolves to an empty string, that empty string is written to state and then treated as authoritative for the rest of the instance's life:

- `existing_state_value?` only rejected `nil`
- `#destroy` guarded with `unless state[:subscription_id]`, which `""` passes

`#create` reads config rather than state, so the instance still builds once the real value is supplied. **Only teardown breaks** — and it breaks like this:

```
Failed to complete #destroy action:
[Azure returned HTTP 400 for DELETE /subscriptions//resourcegroups/kitchen-...]
                                                 ^^ empty subscription
```

The resource group is left behind, **still billing**, and every retry fails identically.

## How you get a blank subscription_id

```yaml
subscription_id: "<%= ENV['AZURE_SUBSCRIPTION_ID'] %>"   # -> ""   breaks
subscription_id: <%= ENV['AZURE_SUBSCRIPTION_ID'] %>     # -> nil  fine
```

I checked both forms through `kitchen diagnose`. The unquoted form the README uses yields `nil`, which was already handled. Quoting it — a common defensive habit — yields the empty string that was not.

## The fix

A blank value is not a value, so it no longer counts as one. `false` still does, which is why the check asks whether the value is *blank* rather than whether it is truthy — there is an existing spec pinning `use_managed_disks: false` as present, and it still passes.

`#destroy`'s two hand-rolled guards now go through the same helper instead of duplicating the rule.

## Confirmed against Azure

The whole sequence, end to end:

```
1. create with the variable unset  -> fails, writes  subscription_id: 
2. export the variable, create     -> Finished creating
3. destroy                         -> Destroying Resource Group: kitchen-blank-...
                                      Finished destroying
```

Step 3 is the one that used to 400. The resource group is now actually deleted (`az group exists` -> false).

## Out of scope

If *neither* state nor config has a subscription, `#destroy` can still build a client with an empty one. `#create` raises a clear error for that case and `#destroy` does not — worth a follow-up, but it is a different defect and I kept this focused.

`bundle exec rake` is green: 656 examples, 100% line coverage, no RuboCop offenses.