### PR TITLE
feat: check configuration and credentials in `kitchen doctor`

### DIFF
--- a/lib/kitchen/driver/azure/arm_client.rb
+++ b/lib/kitchen/driver/azure/arm_client.rb
@@ -32,6 +32,11 @@ module Kitchen
         # @return [String]
         COMPUTE_API_VERSION = "2025-04-01".freeze
 
+        # ARM API version used to read the subscription itself.
+        #
+        # @return [String]
+        SUBSCRIPTION_API_VERSION = "2022-12-01".freeze
+
         # @param subscription_id [String]
         # @param environment [Environments::Environment]
         # @param token_provider [TokenProvider]
@@ -49,6 +54,19 @@ module Kitchen
 
         # @return [TokenProvider]
         attr_reader :token_provider
+
+        # Reads the subscription itself.
+        #
+        # Unlike a resource group HEAD - which answers 404 both for a
+        # subscription that does not exist and for one that merely has no such
+        # group - this distinguishes a reachable subscription from a wrong
+        # one, so it is what {Azurerm#doctor} probes with.
+        #
+        # @return [Hash]
+        def subscription
+          call(:get, "/subscriptions/#{escape(subscription_id)}",
+            api_version: SUBSCRIPTION_API_VERSION).json
+        end
 
         # Whether a resource group exists.
         #

--- a/lib/kitchen/driver/azure/errors.rb
+++ b/lib/kitchen/driver/azure/errors.rb
@@ -40,6 +40,17 @@ module Kitchen
         def code
           body.is_a?(Hash) ? body.dig("error", "code") : nil
         end
+
+        # Azure's own explanation, when ARM supplied one.
+        #
+        # +message+ is this class's summary of the request that failed; this
+        # is what Azure said about it, which is usually the part worth showing
+        # somebody.
+        #
+        # @return [String, nil]
+        def detail
+          body.is_a?(Hash) ? body.dig("error", "message") : nil
+        end
       end
 
       # Raised when a request could not be completed and is worth retrying:

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -287,6 +287,78 @@ module Kitchen
         state[:hostname] = resolve_hostname(state, deployment_parameters["nicName"])
       end
 
+      # Settings the driver cannot supply a default for, and what they are.
+      #
+      # @return [Hash{Symbol => String}]
+      REQUIRED_CONFIG = {
+        subscription_id: "the Azure subscription to deploy into",
+        location: "the Azure region to deploy into, e.g. eastus",
+        machine_size: "the VM size to deploy, e.g. Standard_D2s_v3",
+      }.freeze
+
+      # Checks configuration and credentials, for +kitchen doctor+.
+      #
+      # Deployment failures are usually one of two things: a required setting
+      # nobody filled in, or credentials that do not work. Both otherwise
+      # surface as an Azure error partway through a create, once the resource
+      # group already exists, so this looks for them up front.
+      #
+      # @param state [Hash] the instance state, unused - the checks are about
+      #   configuration and credentials, which exist before any instance does.
+      # @return [Boolean] true when a problem was found, as +kitchen doctor+
+      #   expects.
+      def doctor(_state)
+        problems = missing_required_config
+        problems += unreachable_azure if problems.empty?
+        problems.each { |problem| error("kitchen-azurerm: #{problem}") }
+        problems.any?
+      end
+
+      # Required settings that were left unset.
+      #
+      # @return [Array<String>]
+      def missing_required_config
+        REQUIRED_CONFIG.select { |option, _| config[option].to_s.empty? }
+          .map { |option, purpose| "#{option} is not set. It has no default: give it #{purpose}." }
+      end
+
+      # Whether Azure answers, accepts the credentials, and knows the
+      # subscription.
+      #
+      # Reads the subscription rather than probing a resource group: ARM
+      # answers a resource group HEAD with 404 both for a subscription that
+      # does not exist and for one that merely has no such group, so it cannot
+      # tell a wrong subscription from a healthy one. Reading the subscription
+      # gives back either its details or +SubscriptionNotFound+.
+      #
+      # @return [Array<String>]
+      def unreachable_azure
+        Kitchen::Driver::AzureCredentials.new(subscription_id: config[:subscription_id],
+          environment: config[:azure_environment]).arm_client.subscription
+        []
+      rescue Azure::OperationError => operation_error
+        [azure_problem(operation_error)]
+      rescue Azure::TransientError => transient_error
+        ["Could not reach Azure (#{transient_error.message})."]
+      end
+
+      # Describes an OperationError raised while checking Azure.
+      #
+      # An error carrying no Azure error code never reached ARM - it comes
+      # from acquiring the token, and already explains itself. Announcing that
+      # Azure rejected a request that was never made only sends the reader
+      # looking in the wrong place.
+      #
+      # @param operation_error [Azure::OperationError]
+      # @return [String]
+      def azure_problem(operation_error)
+        return operation_error.message unless operation_error.code
+
+        "Azure rejected the request (#{operation_error.code}: " \
+          "#{operation_error.detail || operation_error.message}). " \
+          "Check the credentials, and that they can reach subscription #{config[:subscription_id]}."
+      end
+
       # Builds the ARM parameter values for the virtual machine deployment.
       #
       # @param state [Hash] instance state, already through {#validate_state}.

--- a/spec/support/azure_doubles.rb
+++ b/spec/support/azure_doubles.rb
@@ -12,6 +12,7 @@ module AzureDoubles
   def arm_client_double(**overrides)
     defaults = {
       resource_group_exists?: true,
+      subscription: { "subscriptionId" => "115b12cb-b0d3-4ed9-94db-f73733be6f3c" },
       create_or_update_resource_group: { "id" => "/subscriptions/s/resourcegroups/rg" },
       delete_resource_group: nil,
       create_deployment: { "id" => "/deployments/d" },

--- a/spec/unit/kitchen/driver/azure/arm_client_spec.rb
+++ b/spec/unit/kitchen/driver/azure/arm_client_spec.rb
@@ -145,6 +145,17 @@ RSpec.describe Kitchen::Driver::Azure::ArmClient do
     end
   end
 
+  describe "#subscription" do
+    it "GETs the subscription itself" do
+      stub = stub_request(:get, "https://management.azure.com/subscriptions/#{subscription_id}")
+        .with(query: { "api-version" => described_class::SUBSCRIPTION_API_VERSION })
+        .to_return(status: 200, body: %({"subscriptionId":"#{subscription_id}","displayName":"Testing"}))
+
+      expect(client.subscription["displayName"]).to eq("Testing")
+      expect(stub).to have_been_requested
+    end
+  end
+
   describe "network resources" do
     it "reads a public IP with the network API version" do
       stub = stub_request(:get, "#{base}/resourcegroups/rg/providers/Microsoft.Network/publicIPAddresses/publicip")

--- a/spec/unit/kitchen/driver/azure/errors_spec.rb
+++ b/spec/unit/kitchen/driver/azure/errors_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe Kitchen::Driver::Azure::OperationError do
     expect(error.body.dig("error", "message")).to eq("busy")
   end
 
+  it "exposes Azure's own explanation separately from its own message" do
+    expect(error.detail).to eq("busy")
+    expect(error.message).to eq("boom")
+  end
+
+  it "has no detail when Azure sent no error object" do
+    expect(described_class.new("boom").detail).to be_nil
+  end
+
+  it "has no detail when the body is not a Hash" do
+    expect(described_class.new("boom", body: "plain text").detail).to be_nil
+  end
+
   it "has no code when Azure sent no error object" do
     expect(described_class.new("boom").code).to be_nil
   end

--- a/spec/unit/kitchen/driver/azurerm/doctor_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm/doctor_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe Kitchen::Driver::Azurerm, "#doctor" do
+  subject(:driver) { build_driver(**config) }
+
+  let(:config) { {} }
+  let(:arm_client) { arm_client_double }
+  let(:state) { {} }
+  let(:reported) { [] }
+
+  before do
+    stub_arm_client(driver, arm_client:)
+    allow(Kitchen.logger).to receive(:error) { |message| reported << message }
+  end
+
+  describe "a healthy configuration" do
+    it "finds no problems" do
+      expect(driver.doctor(state)).to be false
+    end
+
+    it "reports nothing" do
+      driver.doctor(state)
+      expect(reported).to be_empty
+    end
+
+    # A HEAD on a resource group answers 404 for a subscription that does not
+    # exist and for one that merely has no such group, so it cannot tell a
+    # wrong subscription from a healthy one. Reading the subscription can.
+    it "proves the credentials reach the subscription by reading it" do
+      driver.doctor(state)
+      expect(arm_client).to have_received(:subscription)
+    end
+  end
+
+  describe "when required settings are missing" do
+    let(:config) { { subscription_id: nil, location: nil, machine_size: nil } }
+
+    it "finds problems" do
+      expect(driver.doctor(state)).to be true
+    end
+
+    it "names every missing setting" do
+      driver.doctor(state)
+      expect(reported.join("\n")).to include("subscription_id").and include("location").and include("machine_size")
+    end
+
+    it "does not bother Azure when there is no subscription to ask about" do
+      driver.doctor(state)
+      expect(arm_client).not_to have_received(:subscription)
+    end
+  end
+
+  describe "when a required setting is blank rather than absent" do
+    let(:config) { { location: "" } }
+
+    it "counts as missing" do
+      expect(driver.doctor(state)).to be true
+      expect(reported.join("\n")).to include("location")
+    end
+  end
+
+  describe "when Azure rejects the credentials" do
+    before do
+      allow(arm_client).to receive(:subscription)
+        .and_raise(azure_operation_error(code: "AuthorizationFailed", message: "does not have authorization", status: 403))
+    end
+
+    it "finds a problem" do
+      expect(driver.doctor(state)).to be true
+    end
+
+    it "passes Azure's own reason along" do
+      driver.doctor(state)
+      expect(reported.join("\n")).to include("AuthorizationFailed").and include("does not have authorization")
+    end
+  end
+
+  describe "when the subscription does not exist" do
+    before do
+      allow(arm_client).to receive(:subscription)
+        .and_raise(azure_operation_error(code: "SubscriptionNotFound",
+          message: "The subscription '00000000-0000-0000-0000-000000000000' could not be found.", status: 404))
+    end
+
+    it "finds a problem and names the subscription" do
+      expect(driver.doctor(state)).to be true
+      expect(reported.join("\n")).to include("SubscriptionNotFound").and include("could not be found")
+    end
+  end
+
+  describe "when Azure cannot be reached" do
+    before do
+      allow(arm_client).to receive(:subscription)
+        .and_raise(Kitchen::Driver::Azure::TransientError, "Net::OpenTimeout: timed out")
+    end
+
+    it "finds a problem and says why" do
+      expect(driver.doctor(state)).to be true
+      expect(reported.join("\n")).to include("timed out")
+    end
+  end
+
+  describe "when credentials cannot be resolved at all" do
+    before do
+      allow(Kitchen::Driver::AzureCredentials).to receive(:new)
+        .and_raise(Kitchen::Driver::Azure::OperationError.new("The Azure CLI (`az`) was not found on PATH"))
+    end
+
+    it "finds a problem and says why" do
+      expect(driver.doctor(state)).to be true
+      expect(reported.join("\n")).to include("was not found on PATH")
+    end
+
+    # Nothing reached Azure, so saying Azure rejected it sends the reader
+    # looking in the wrong place.
+    it "does not blame Azure for a request that was never made" do
+      driver.doctor(state)
+      expect(reported.join("\n")).not_to include("Azure rejected")
+    end
+  end
+end


### PR DESCRIPTION
`kitchen doctor` inherited `Driver::Base`'s answer, so it found nothing however broken the setup was:

```
$ kitchen doctor d
-----> The doctor is in
```

It now looks for the two things that account for most failed deployments.

## 1. Required settings left unset

`location` and `machine_size` have no defaults. An empty one otherwise surfaces as an Azure error partway through create — after the resource group already exists.

```
>>>>>> kitchen-azurerm: location is not set. It has no default: give it the Azure region to deploy into, e.g. eastus.
>>>>>> kitchen-azurerm: machine_size is not set. It has no default: give it the VM size to deploy, e.g. Standard_D2s_v3.
```

## 2. Credentials that do not work, or a subscription they cannot reach

My first attempt probed with `resource_group_exists?`, and a live test caught that it silently passes a completely wrong subscription. ARM answers a resource-group `HEAD` with 404 both for a subscription that does not exist and for one that merely has no such group:

```
HEAD rg  sub=fba9781d (real) -> 404
HEAD rg  sub=00000000 (bogus) -> 404          <- indistinguishable

GET  sub fba9781d -> 200 {"id": "/subscriptions/fba9781d-...", ...}
GET  sub 00000000 -> 404 {"error":{"code":"SubscriptionNotFound", ...}}
```

So it reads the subscription instead.

An error carrying no Azure error code never reached ARM — it comes from acquiring the token and already explains itself — so it is reported as-is rather than dressed up as Azure rejecting a request that was never made.

## Confirmed against Azure

| setup | result |
|---|---|
| healthy | no problems, exit 0 |
| no `location`/`machine_size` | names each missing setting, exit 1 |
| wrong subscription | `SubscriptionNotFound: The subscription ... could not be found.`, exit 1 |
| `az` off PATH, no credentials file | `The Azure CLI (\`az\`) was not found on PATH, and no other Azure credentials were configured.`, exit 1 |

## Also included

- `ArmClient#subscription` and a `SUBSCRIPTION_API_VERSION` constant.
- `OperationError#detail` — Azure's own explanation, as a sibling of the existing `#code`, so callers stop reaching into the error body.

## Possible follow-up

A regional core-quota check would catch the confusing `InvalidTemplateDeployment` / `QuotaExceeded` failure, but it needs a new usages endpoint — happy to add it separately rather than widen this.

`bundle exec rake` is green: 668 examples, 100% line coverage, no RuboCop offenses.