### PR TITLE
feat: report the plugin version to kitchen diagnose

### DIFF
--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -2,6 +2,7 @@ require "kitchen"
 
 require_relative "azure_credentials"
 require_relative "azure/errors"
+require_relative "azurerm_version"
 require "securerandom" unless defined?(SecureRandom)
 require "base64" unless defined?(Base64)
 autoload :SSHKey, "sshkey"
@@ -30,6 +31,8 @@ module Kitchen
       attr_accessor :arm_client
 
       kitchen_driver_api_version 2
+
+      plugin_version Kitchen::Driver::AZURERM_VERSION
 
       # Settings that Azure retirements have made inoperable. They are still
       # accepted so that an existing kitchen.yml keeps loading, but they no

--- a/spec/unit/kitchen/driver/azurerm_spec.rb
+++ b/spec/unit/kitchen/driver/azurerm_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe Kitchen::Driver::Azurerm do
       expect(driver.diagnose_plugin[:api_version]).to eq(2)
     end
 
+    it "reports its own gem version to kitchen diagnose" do
+      expect(driver.diagnose_plugin[:version])
+        .to eq(Kitchen::Driver::AZURERM_VERSION)
+    end
+
     it "is named Azurerm" do
       expect(driver.name).to eq("Azurerm")
     end


### PR DESCRIPTION
The driver declared its API version but never its own gem version:

```ruby
kitchen_driver_api_version 2
```

so `kitchen diagnose` reported

```yaml
driver:
  name: azurerm
  api_version: 2
  version: ~
```

`version: ~` is the field you go looking for first when triaging a bug report against a driver that talks to a moving cloud API, and it was empty.

```ruby
kitchen_driver_api_version 2

plugin_version Kitchen::Driver::AZURERM_VERSION
```

The constant already existed in `azurerm_version.rb` and is what release-please bumps; it just was not wired to `plugin_version`. `diagnose` now reports `version: 2.3.0`.

## Verification

- `rake test` — **701 examples, 0 failures** (700 before; 1 new)
- line coverage 100.0% (807/807), so the repo's coverage floor is satisfied
- `cookstyle --chefstyle` — 35 files, no offenses
