### PR TITLE
docs: correct the contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,22 +26,39 @@ bundle install
 ## Running the tests
 
 ```sh
-bundle exec rake          # unit tests and linting
-bundle exec rake spec     # unit tests only
-bundle exec rake style    # Cookstyle / RuboCop only
+bundle exec rake          # unit tests and linting, the same as CI
+bundle exec rake test     # unit tests only
+bundle exec rake style    # Cookstyle / Chefstyle only
 ```
 
 To run a single spec file:
 
 ```sh
-bundle exec rspec spec/kitchen/driver/azurerm_spec.rb
+bundle exec rspec spec/unit/kitchen/driver/azurerm_spec.rb
 ```
 
 Many style offenses can be corrected automatically:
 
 ```sh
-bundle exec cookstyle -a
+bundle exec rake style:autocorrect
 ```
+
+**Do not run `cookstyle` on its own here.** This project is linted with the
+Chefstyle rule set, which Cookstyle only applies when it is asked for — either
+by the `--chefstyle` flag, or by requiring `cookstyle/chefstyle` before
+Cookstyle loads, which is what the Rakefile does. A bare `bundle exec cookstyle`
+instead lints against the cookbook rule set and reports thousands of offenses
+that are not real, every one of them marked autocorrectable:
+
+```text
+35 files inspected, 2480 offenses detected, 2480 offenses autocorrectable
+```
+
+so `cookstyle -a` will happily rewrite the whole repository against rules it is
+not held to. Use the Rake tasks above, or `bundle exec cookstyle --chefstyle`,
+which is exactly what CI runs. The `require: - cookstyle/chefstyle` line in
+`.rubocop.yml` cannot help: RuboCop reads it only after Cookstyle has already
+decided which rule set it is using.
 
 The unit tests stub HTTP at the wire with WebMock, so they neither deploy
 resources nor require a subscription or a service principal. WebMock also blocks
@@ -56,8 +73,8 @@ Ruby standard library. The pieces live under `lib/kitchen/driver/azure/`:
 | File | Responsibility |
 | --- | --- |
 | `environments.rb` | Endpoints for each Azure cloud (public, US Government, China, Germany). |
-| `token_provider.rb` | Acquires and caches access tokens: service principal, managed identity, or `az login`. |
-| `arm_client.rb` | The eight ARM requests the driver makes. |
+| `token_provider.rb` | Acquires and caches access tokens: workload identity federation, service principal, managed identity, or `az login`. |
+| `arm_client.rb` | The ten ARM requests the driver makes. |
 | `http.rb` | A small `Net::HTTP` wrapper that separates transient network failures from real API errors. |
 
 One trap worth knowing about: Test Kitchen defines `Kitchen::StandardError`, and
@@ -91,17 +108,47 @@ a run that fails partway through can leave a VM, disks, and a public IP behind.
 2. Create a feature branch off `main`.
 3. Make your change, adding or updating tests to cover it.
 4. Make sure `bundle exec rake` passes.
-5. Push the branch to your fork and open a pull request.
+5. Write the commit subject as a [Conventional Commit](https://www.conventionalcommits.org/).
+6. Push the branch to your fork and open a pull request.
 
 Please keep pull requests focused on a single change — it makes review much
 faster. Update the driver properties tables in `README.md` when you add or
 change a configuration option.
 
+### Commit messages
+
+Commit subjects are not just for readers here: releases are automated, and the
+subject line is what decides whether a release happens at all and what version
+it gets. Use one of these types:
+
+| Type | Effect on the next release |
+| --- | --- |
+| `fix:` | Patch version bump, listed under Bug Fixes. |
+| `feat:` | Minor version bump, listed under Features. |
+| `docs:`, `test:`, `refactor:`, `chore:`, `ci:` | No version bump, and not listed in the changelog. |
+
+Append `!` (`feat!:`) or add a `BREAKING CHANGE:` footer for a major bump.
+
+Because a squashed pull request lands as a single commit, the **pull request
+title** is what ends up in the changelog. A `fix:` PR that quietly adds a
+feature, or a `chore:` PR that fixes a bug, produces a release with the wrong
+version and a changelog that does not mention the change at all — which is
+also why pull requests here are kept to a single concern.
+
 ## Release process
 
-Releases are handled by the maintainers.
+Releases are automated with
+[release-please](https://github.com/googleapis/release-please); there is nothing
+to do by hand, and `lib/kitchen/driver/azurerm_version.rb` and `CHANGELOG.md`
+should not be edited in a pull request.
 
-1. Update `lib/kitchen/driver/azurerm_version.rb` with the new version.
-2. Update `CHANGELOG.md`.
-3. Merge to `main`; the publish workflow builds the gem and pushes it to
-   RubyGems.
+1. A merge to `main` runs release-please, which reads the Conventional Commit
+   subjects since the last release.
+2. If any of them warrant one, it opens or updates a release pull request that
+   bumps the version file and writes the changelog entries.
+3. Merging that release pull request tags the release and publishes the gem to
+   RubyGems and GitHub Packages.
+
+The release pull request belongs to the bot and does not resolve conflicts on
+its own. If it picks one up, rebase it by hand, keeping `main`'s content and the
+bot's version — never force the branch back to an older version.


### PR DESCRIPTION
## Why

Several instructions in `CONTRIBUTING.md` no longer match the repository, and two of them actively mislead a new contributor.

### `cookstyle -a` rewrites the repository against the wrong rules

The guide says "Many style offenses can be corrected automatically: `bundle exec cookstyle -a`".

This project is linted with the **Chefstyle** rule set, which Cookstyle applies only when it is asked for — via `--chefstyle`, or by requiring `cookstyle/chefstyle` before Cookstyle loads, which is what the Rakefile does. A bare `cookstyle` run lints against the *cookbook* rule set instead:

```
$ bundle exec cookstyle
35 files inspected, 2480 offenses detected, 2480 offenses autocorrectable

$ bundle exec cookstyle --chefstyle
35 files inspected, no offenses detected
```

So following the guide as written rewrites all 35 files against rules the project is not held to, and CI — which runs `cookstyle --chefstyle` — then disagrees with the working tree.

Worth being explicit that the `require: - cookstyle/chefstyle` line in `.rubocop.yml` does not prevent this. It cannot: RuboCop reads that file only after Cookstyle has already decided which rule set it is using. I confirmed by deleting the line, and `rake style` behaves identically with and without it.

Replaced with `bundle exec rake style:autocorrect`, and documented the trap.

### The release process describes something that no longer happens

The guide told maintainers to hand-edit `azurerm_version.rb` and `CHANGELOG.md`. release-please owns both of those, so doing it in a pull request now fights the automation.

Rewrote it to describe what actually happens, and — more importantly — wrote down that **Conventional Commit subjects are required**, since that is what decides whether a release happens at all and what version it gets. That was not stated anywhere, despite being load-bearing: a squashed PR lands as one commit, so a `fix:` PR that quietly adds a feature ships the wrong version and a changelog that never mentions the change.

Added a short table of the types and what each one does to the next release.

## Smaller corrections

- The single-spec example pointed at `spec/kitchen/driver/azurerm_spec.rb`, a path that has not existed since the specs moved under `spec/unit/`. Running it as documented just fails.
- `bundle exec rake spec` works but is an undocumented alias; the task is `rake test`, which is also what CI runs.
- `arm_client.rb` is described as "the eight ARM requests the driver makes". It is ten.
- `token_provider.rb`'s description omitted workload identity federation, which is the method CI should be using.

## Testing

Docs only. Every command the guide now recommends was run against this branch:

```
$ bundle exec rake test
701 examples, 0 failures
Line Coverage: 100.0% (807 / 807)

$ bundle exec cookstyle --chefstyle
35 files inspected, no offenses detected

$ bundle exec rspec spec/unit/kitchen/driver/azurerm_spec.rb
58 examples, 0 failures

$ bundle exec rake style:autocorrect
35 files inspected, no offenses detected     # and left the tree clean
```

markdownlint-cli2 reports no issues.

Kept clear of the `### Integration tests` section #334 adds, so the two should merge cleanly in either order.