### PR TITLE
chore: remove SimpleCov code-coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 Gemfile.lock
 *.gem
 /docs/examples
-coverage
 *.log
 *kitchen.local.yml
 .kitchen/

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec development_group: :test
 group :test do
   gem "rake", ">= 11.0"
   gem "rspec", "~> 3.13"
-  gem "simplecov", "~> 0.22"
   gem "webmock", "~> 3.19"
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,13 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-
-SimpleCov.start do
-  add_filter "/spec/"
-  enable_coverage :branch
-end
-
 require "stringio"
 require "tmpdir"
 require "json"


### PR DESCRIPTION
## What this removes

- `gem "simplecov", "~> 0.22"` from the `:test` group in `Gemfile`
- `require "simplecov"` and the `SimpleCov.start` block from `spec/spec_helper.rb`
- the `coverage` artifact path from `.gitignore`

That is the whole of it. There was no `minimum_coverage` / `minimum_coverage_by_file` enforcement, no `COVERAGE` env-var branching in the specs, `Rakefile`, or workflows, no coverage-driving Rake task, and no CI step that uploaded or reported coverage — so nothing else needed touching. The suite never gated on the numbers; SimpleCov only wrote an unread report at the end of every local run.

## YARD documentation coverage is deliberately untouched

`rake yard:stats` ("Report YARD documentation coverage without failing") is *documentation* coverage, not code coverage, and it stays exactly as it was. So do `rake yard`, `rake doc`, and `rake yard:server`.

```
$ bundle exec rake -T | grep -i yard
rake doc                    # Generate YARD documentation into doc/
rake yard                   # Generate YARD Documentation
rake yard:server            # Serve YARD documentation at http://localhost:8808
rake yard:stats             # Report YARD documentation coverage without failing

$ bundle exec rake yard:stats
yard stats --list-undoc
Files:           8
Modules:         5 (    0 undocumented)
Classes:        12 (    0 undocumented)
Constants:      22 (    0 undocumented)
Attributes:     11 (    0 undocumented)
Methods:       106 (    0 undocumented)
 100.00% documented
```

## Verification

No SimpleCov references remain outside the historical changelog (those entries are release-please's record of past releases and must not be rewritten):

```
$ grep -rin 'simplecov' . --exclude-dir=.git
CHANGELOG.md:383:* Remove `simplecov` development dependency (@tas50)
CHANGELOG.md:395:* Remove Simplecov dev dep ([e416832](https://github.com/test-kitchen/kitchen-azurerm/commit/e416832))

$ grep -rn 'COVERAGE' . --exclude-dir=.git
(no matches)

$ grep -rin 'coverage' . --exclude-dir=.git --exclude=CHANGELOG.md
Rakefile:26:  desc "Report YARD documentation coverage without failing"
```

Tests — example count unchanged at **701**, before and after:

```
# before (origin/main)
701 examples, 0 failures
Coverage report generated for RSpec to .../coverage.
Line Coverage: 100.0% (807 / 807)

# after (this branch)
$ bundle exec rake test
Finished in 1.49 seconds (files took 0.37676 seconds to load)
701 examples, 0 failures
```

Lint, under **Cookstyle 9.0.0 / RuboCop 1.90.0** (the version CI resolves, matching the `~> 9.0` pin from #360):

```
$ bundle exec cookstyle --chefstyle
Inspecting 35 files
...................................

35 files inspected, no offenses detected
```

## Open PRs and merge order

Checked all four open PRs. Only one overlaps:

- **#334 (`feat: add integration suites that deploy against real Azure`)** also modifies `Gemfile`. Its hunk *appends* an `:integration` group after the `:cookstyle` group, while this PR deletes a line from the `:test` group, so the two edits are far apart and should merge cleanly. Note that #334 is already stale against `main` on this file for an unrelated reason — its context still shows `gem "cookstyle", "~> 8.4"` and `main` is now on `~> 9.0` after #360 — so it needs a rebase regardless of this PR. **Recommended order: merge this PR first, then rebase #334 once** and pick up both changes together. #334 also touches `Rakefile`, which this PR does not.
- **#299**, **#233** — no overlap (driver, templates, spec, ERB only).
- **#358** is the release-please branch and is left alone; it only touches the manifest, changelog, and version file.

No open PR modifies `spec/spec_helper.rb`.

## CI

Watched to completion on this branch — all 8 jobs green:

```
lint-unit / markdown-lint                       completed  success
lint-unit / Cookstyle/Chefstyle on Ruby (3.2)   completed  success
lint-unit / yamllint                            completed  success
lint-unit / Unit Test with Ruby (3.1)           completed  success
lint-unit / Unit Test with Ruby (3.2)           completed  success
lint-unit / Unit Test with Ruby (3.3)           completed  success
lint-unit / Unit Test with Ruby (3.4)           completed  success
lint-unit / Unit Test with Ruby (4.0)           completed  success
```

