### PR TITLE
docs: complete the YARD tags and correct doc/code mismatches

### DIFF
--- a/lib/kitchen/driver/azure/environments.rb
+++ b/lib/kitchen/driver/azure/environments.rb
@@ -63,6 +63,10 @@ module Kitchen
         # Every supported cloud, keyed by its downcased name so that lookups are
         # case-insensitive.
         #
+        # +AzureGermanCloud+ is kept only so that an existing kitchen.yml naming
+        # it still loads: Microsoft closed that cloud in 2021, and its endpoints
+        # no longer answer.
+        #
         # @return [Hash{String => Environment}]
         ALL = [
           Environment.new("Azure",

--- a/lib/kitchen/driver/azure/errors.rb
+++ b/lib/kitchen/driver/azure/errors.rb
@@ -22,11 +22,12 @@ module Kitchen
 
         # The HTTP status code of the failing response.
         #
-        # @return [Integer]
+        # @return [Integer, nil] nil when the error was raised before a
+        #   response arrived, as the token providers do.
         attr_reader :status
 
         # @param message [String] human-readable summary.
-        # @param status [Integer] HTTP status code.
+        # @param status [Integer, nil] HTTP status code, when there was one.
         # @param body [Hash] parsed ARM error body.
         def initialize(message, status: nil, body: {})
           super(message)

--- a/lib/kitchen/driver/azurerm.rb
+++ b/lib/kitchen/driver/azurerm.rb
@@ -30,6 +30,17 @@ module Kitchen
       # @return [Azure::ArmClient, nil]
       attr_accessor :arm_client
 
+      # The writer needs a docstring of its own: one comment above an
+      # attr_accessor is copied to both methods, so the argument the writer
+      # takes can only be described here. The directive has to come after the
+      # accessor - placed before it, the accessor overwrites it.
+
+      # @!method arm_client=(client)
+      #   Replaces the ARM client.
+      #
+      #   @param client [Azure::ArmClient, nil] the client to use.
+      #   @return [Azure::ArmClient, nil] the client that was set.
+
       kitchen_driver_api_version 2
 
       plugin_version Kitchen::Driver::AZURERM_VERSION
@@ -256,6 +267,8 @@ module Kitchen
       # @param state [Hash] the instance state, mutated in place.
       # @return [void]
       # @raise [RuntimeError] if no +subscription_id+ can be resolved.
+      # @raise [Kitchen::UserError] if +os_disk_size_gb+ is not a whole number,
+      #   or the public half of the transport's SSH key cannot be found.
       # @raise [Azure::OperationError] if an Azure API call fails
       #   for any reason other than an already-running deployment.
       def create(state)
@@ -310,8 +323,9 @@ module Kitchen
       # surface as an Azure error partway through a create, once the resource
       # group already exists, so this looks for them up front.
       #
-      # @param state [Hash] the instance state, unused - the checks are about
-      #   configuration and credentials, which exist before any instance does.
+      # @param _state [Hash] the instance state. Test Kitchen passes it, but
+      #   the checks are about configuration and credentials, which exist
+      #   before any instance does, so it is ignored.
       # @return [Boolean] true when a problem was found, as +kitchen doctor+
       #   expects.
       def doctor(_state)
@@ -559,7 +573,13 @@ module Kitchen
         state.key?(property) && !state[property].to_s.empty?
       end
 
-      # Fills in any state values that are not already present.
+      # Fills in any state values that are not already present, and drops the
+      # generated password when the transport authenticates with an SSH key.
+      #
+      # +use_managed_disks+ is copied across with the settings that are still
+      # read, even though Azure's retirement of unmanaged disks left nothing
+      # reading it - see {DEPRECATED_CONFIG}. It is written as nil, since the
+      # setting has no default.
       #
       # @param state [Hash] existing Hash of state values.
       # @return [Hash] the same Hash, with defaults applied.
@@ -933,7 +953,9 @@ module Kitchen
       # worse than saying so promptly.
       #
       # @param state [Hash] the instance state.
-      # @return [Hash] +:live+, +:state+, +:resource_id+ and +:message+.
+      # @return [Hash] always +:live+, +:state+ and +:message+; +:resource_id+
+      #   only when the virtual machine was found, since nothing else knows
+      #   which resource to name.
       def status(state)
         resource_group = state[:azure_resource_group_name]
         vm_name = state[:vm_name]
@@ -1394,7 +1416,11 @@ module Kitchen
 
       # Base64-encoded custom data for the VM.
       #
-      # @return [String, nil] nil when no +custom_data+ is configured.
+      # An unset +custom_data+ is "" rather than nil, which encodes to "" - so
+      # callers guard on the setting being empty rather than on this returning
+      # nil.
+      #
+      # @return [String, nil] nil only when +custom_data+ is explicitly nil.
       def prepared_custom_data
         return nil if config[:custom_data].nil?
 
@@ -1543,7 +1569,7 @@ module Kitchen
       # Requests deletion of a resource group without waiting for it to finish.
       #
       # @param resource_group_name [String] the resource group name.
-      # @return [Object] the operation response.
+      # @return [void] ARM answers a delete with no body worth returning.
       def delete_resource_group_async(resource_group_name)
         with_azure_retries("while sending resource group deletion request for '#{resource_group_name}'.") do
           arm_client.delete_resource_group(resource_group_name)


### PR DESCRIPTION
## What

`yard stats` already reports **100.00% documented** (106 methods, 0 undocumented) — but it counts any docstring at all, so it says nothing about whether the *tags* are complete or correct. Measuring the tags instead turns up a different picture.

Measured over the `.yardopts` scope, before and after:

| | before | after |
|---|---|---|
| methods | 160 | 160 |
| missing `@param` | 2 | **0** |
| missing `@return` | 0 | 0 |
| `yard` warnings | 1 | **0** |

```
$ bundle exec yard 2>&1 | grep -i warn
[warn]: @param tag has unknown parameter name: state
    in file `lib/kitchen/driver/azurerm.rb' near line 317
```

is now silent.

## The two missing `@param`s

**`Azurerm#doctor`** carried `@param state`, and YARD reported it as an unknown parameter name because the method's signature is `doctor(_state)`. The tag documented a parameter that does not exist. Fixed to match the real signature: Test Kitchen does pass the instance state, `doctor` just ignores it, so the tag now names `_state` and says why it goes unread — rather than being deleted, which would have left the argument undocumented.

**`Azurerm#arm_client=`** had no `@param` at all. One comment above an `attr_accessor` is copied verbatim to *both* generated methods, so the writer's argument can only be described separately. A bare `@param` on the accessor comment would have swapped the missing tag for an `unknown parameter name` warning on the *reader*, so the writer gets a `@!method arm_client=(client)` directive instead — placed **after** the accessor, since a directive before it is overwritten by the accessor.

## Doc/code contradictions fixed

Reading each docstring against its code turned up six more:

- **`delete_resource_group_async`** — `@return [Object] the operation response.` It has none: `ArmClient#delete_resource_group` ends in an explicit `nil`, which is exactly what it documents (`@return [void]`), and `destroy` discards the result. Now `@return [void]`.
- **`status`** — `@return` listed `:resource_id` alongside `:live`, `:state` and `:message` as if always present. Only the `power_state_status` branch sets it; the `not_created` early return and both `rescue` branches never do. Now distinguishes the keys that are always there from the one that is not.
- **`OperationError#status`** — typed `@return [Integer]`, but the keyword defaults to `nil` and every `OperationError` raised while *acquiring a token* (`TokenProvider#assertion`, `AzureCliToken#fetch_token`) is built without one. `[Integer, nil]` on both the reader and the `initialize` param.
- **`prepared_custom_data`** — `nil when no custom_data is configured`. `custom_data` defaults to `""`, not `nil`, so the common case returns `""`, not `nil`. The doc now says nil happens only for an explicit `nil`, and points at the emptiness check callers actually guard on.
- **`validate_state`** — "Fills in any state values that are not already present." It also *deletes* `:password` for SSH-key transports, and it copies the retired `use_managed_disks` setting into state alongside the ones still read. Both now documented.
- **`create`** — the `@raise` list named `RuntimeError` and `Azure::OperationError` but not the `Kitchen::UserError` reachable through `os_disk_size_gb` and `public_key_for_deployment`.

## Type-name sweep

`lib/` was swept for the three failure modes that have bitten sibling drivers: constant casing that does not match the real class, `Array[T]`/`Hash[K,V]` where YARD spells them `Array<T>`/`Hash{K => V}`, and `@return` types naming a class the method never returns.

- No `Array[...]` or `Hash[...]` anywhere — every collection tag already uses `Array<...>` or `Hash{... => ...}`.
- Every named constant resolves: `Azure::ArmClient`, `Azure::TokenProvider`, `Environments::Environment`, `Http::Response`, `Azure::OperationError`, `Azure::TransientError`, `Kitchen::UserError`, `Kitchen::Logger`, `IniFile`, `Net::HTTPRequest`, `Net::HTTPResponse`, `IPAddr`, `Mutex`. The `Struct.new` classes (`Http::Response`, `Environments::Environment`) are registered by YARD as classes, so tags naming them link.
- `@param uri [URI]` / `@return [URI, nil]` in `Http` were checked rather than assumed: `URI` is in the ancestors of `URI::HTTP`, so `is_a?(URI)` holds and the tag is accurate.
- The one wrong return type found is `delete_resource_group_async`, above.

## Also noted

`AzureGermanCloud` is still in the `Environments::ALL` table, but Microsoft closed that cloud in 2021 and its endpoints no longer answer. It is kept so an existing kitchen.yml naming it still loads; the constant now says so.

## Not changed

Comments only. Verified mechanically — filtering `git diff -U0 -- lib/` down to non-comment, non-blank lines yields **zero lines**. Nothing in the ARM template construction, the token providers, or the long-running-operation polling was touched.

The YARD rake tasks (`yard`, `doc`, `yard:stats`, `yard:server`) and `.yardopts` already existed and are unchanged; `rake -T` still lists all four and `rake doc` still renders.

## Verification

```
$ bundle exec rake test
701 examples, 0 failures          # 701 before, 701 after

$ bundle exec cookstyle --chefstyle
35 files inspected, no offenses detected     # Cookstyle 9.0.0, RuboCop 1.90.0

$ bundle exec yard 2>&1 | grep -i warn
                                  # silent

$ bundle exec rake yard:stats
Methods:       106 (    0 undocumented)
 100.00% documented
```